### PR TITLE
[ENH] Remove old Transformer Minxin Classes

### DIFF
--- a/sktime/registry/__init__.py
+++ b/sktime/registry/__init__.py
@@ -6,10 +6,6 @@ from sktime.registry._base_classes import (
     BASE_CLASS_LOOKUP,
     BASE_CLASS_REGISTER,
     BASE_CLASS_SCITYPE_LIST,
-    TRANSFORMER_MIXIN_LIST,
-    TRANSFORMER_MIXIN_LOOKUP,
-    TRANSFORMER_MIXIN_REGISTER,
-    TRANSFORMER_MIXIN_SCITYPE_LIST,
 )
 from sktime.registry._lookup import all_estimators, all_tags
 from sktime.registry._scitype import scitype
@@ -30,8 +26,4 @@ __all__ = [
     "BASE_CLASS_LIST",
     "BASE_CLASS_LOOKUP",
     "BASE_CLASS_SCITYPE_LIST",
-    "TRANSFORMER_MIXIN_REGISTER",
-    "TRANSFORMER_MIXIN_LIST",
-    "TRANSFORMER_MIXIN_LOOKUP",
-    "TRANSFORMER_MIXIN_SCITYPE_LIST",
 ]

--- a/sktime/registry/_base_classes.py
+++ b/sktime/registry/_base_classes.py
@@ -14,15 +14,6 @@ each tuple corresponds to a base class, elements as follows:
 
 ---
 
-TRANSFORMER_MIXIN_REGISTER - list of tuples
-
-each tuple corresponds to a transformer mixin, elements as follows:
-    0 : string - scitype shorthand
-    1 : type - the transformer mixin itself
-    2 : string - plain English description of the scitype
-
----
-
 BASE_CLASS_SCITYPE_LIST - list of string
     elements are 0-th entries of BASE_CLASS_REGISTER, in same order
 
@@ -35,22 +26,6 @@ BASE_CLASS_LIST - list of string
 
 BASE_CLASS_LOOKUP - dictionary
     keys/entries are 0/1-th entries of BASE_CLASS_REGISTER
-
----
-
-TRANSFORMER_MIXIN_SCITYPE_LIST - list of string
-    elements are 0-th entries of TRANSFORMER_MIXIN_REGISTER, in same order
-
----
-
-TRANSFORMER_MIXIN_LIST - list of string
-    elements are 1-st entries of TRANSFORMER_MIXIN_REGISTER, in same order
-
----
-
-TRANSFORMER_MIXIN_LOOKUP - dictionary
-    keys/entries are 0/1-th entries of TRANSFORMER_MIXIN_REGISTER
-
 
 """
 
@@ -73,13 +48,7 @@ from sktime.networks.base import BaseDeepNetwork
 from sktime.param_est.base import BaseParamFitter
 from sktime.performance_metrics.base import BaseMetric
 from sktime.regression.base import BaseRegressor
-from sktime.transformations.base import (
-    BaseTransformer,
-    _PanelToPanelTransformer,
-    _PanelToTabularTransformer,
-    _SeriesToPrimitivesTransformer,
-    _SeriesToSeriesTransformer,
-)
+from sktime.transformations.base import BaseTransformer
 
 BASE_CLASS_REGISTER = [
     ("object", BaseObject, "object"),
@@ -113,31 +82,3 @@ BASE_CLASS_SCITYPE_LIST = pd.DataFrame(BASE_CLASS_REGISTER)[0].tolist()
 BASE_CLASS_LIST = pd.DataFrame(BASE_CLASS_REGISTER)[1].tolist()
 
 BASE_CLASS_LOOKUP = dict(zip(BASE_CLASS_SCITYPE_LIST, BASE_CLASS_LIST))
-
-
-TRANSFORMER_MIXIN_REGISTER = [
-    (
-        "series-to-primitive-trafo",
-        _SeriesToPrimitivesTransformer,
-        "time-series-to-primitives transformer",
-    ),
-    (
-        "series-to-series-trafo",
-        _SeriesToSeriesTransformer,
-        "time-series-to-time-series transformer",
-    ),
-    (
-        "panel-to-tabular-trafo",
-        _PanelToTabularTransformer,
-        "panel-to-tabular transformer",
-    ),
-    ("panel-to-panel-trafo", _PanelToPanelTransformer, "panel-to-panel transformer"),
-]
-
-TRANSFORMER_MIXIN_SCITYPE_LIST = pd.DataFrame(TRANSFORMER_MIXIN_REGISTER)[0].tolist()
-
-TRANSFORMER_MIXIN_LIST = pd.DataFrame(TRANSFORMER_MIXIN_REGISTER)[1].tolist()
-
-TRANSFORMER_MIXIN_LOOKUP = dict(
-    zip(TRANSFORMER_MIXIN_SCITYPE_LIST, TRANSFORMER_MIXIN_LIST)
-)

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -26,20 +26,14 @@ from pathlib import Path
 import pandas as pd
 
 from sktime.base import BaseEstimator
-from sktime.registry._base_classes import (
-    BASE_CLASS_LIST,
-    BASE_CLASS_LOOKUP,
-    TRANSFORMER_MIXIN_LIST,
-)
+from sktime.registry._base_classes import BASE_CLASS_LIST, BASE_CLASS_LOOKUP
 from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
 
-VALID_TRANSFORMER_TYPES = tuple(TRANSFORMER_MIXIN_LIST)
 VALID_ESTIMATOR_BASE_TYPES = tuple(BASE_CLASS_LIST)
 
 VALID_ESTIMATOR_TYPES = (
     BaseEstimator,
     *VALID_ESTIMATOR_BASE_TYPES,
-    *VALID_TRANSFORMER_TYPES,
 )
 
 
@@ -219,7 +213,6 @@ def all_estimators(
         for module_name in _walk(
             root=ROOT, exclude=MODULES_TO_IGNORE, prefix="sktime."
         ):
-
             # Filter modules
             if _is_private_module(module_name):
                 continue
@@ -396,7 +389,7 @@ def _check_tag_cond(estimator, filter_tags=None, as_dataframe=True):
 
     cond_sat = True
 
-    for (key, value) in filter_tags.items():
+    for key, value in filter_tags.items():
         if not isinstance(value, list):
             value = [value]
         cond_sat = cond_sat and estimator.get_class_tag(key) in set(value)

--- a/sktime/registry/_lookup.py
+++ b/sktime/registry/_lookup.py
@@ -238,7 +238,7 @@ def all_estimators(
                 # Skip missing soft dependencies
                 if "soft dependency" not in str(e):
                     raise e
-                warnings.warn(str(e), ImportWarning)
+                warnings.warn(str(e), ImportWarning, stacklevel=2)
 
     # Drop duplicates
     all_estimators = set(all_estimators)

--- a/sktime/registry/tests/test_lookup.py
+++ b/sktime/registry/tests/test_lookup.py
@@ -8,16 +8,10 @@ import pytest
 
 from sktime.base import BaseObject
 from sktime.registry import all_estimators, all_tags, scitype
-from sktime.registry._base_classes import (
-    BASE_CLASS_LOOKUP,
-    BASE_CLASS_SCITYPE_LIST,
-    TRANSFORMER_MIXIN_SCITYPE_LIST,
-)
+from sktime.registry._base_classes import BASE_CLASS_LOOKUP, BASE_CLASS_SCITYPE_LIST
 from sktime.registry._lookup import _check_estimator_types
 
-VALID_SCITYPES_SET = set(
-    BASE_CLASS_SCITYPE_LIST + TRANSFORMER_MIXIN_SCITYPE_LIST + ["estimator"]
-)
+VALID_SCITYPES_SET = set(BASE_CLASS_SCITYPE_LIST + ["estimator"])
 
 # some scitypes have no associated tags yet
 SCITYPES_WITHOUT_TAGS = [

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -9,6 +9,8 @@ from sktime.registry import BASE_CLASS_LIST, BASE_CLASS_LOOKUP, ESTIMATOR_TAG_LI
 EXCLUDE_ESTIMATORS = [
     # SFA is non-compliant with any transformer interfaces, #2064
     "SFA",
+    # Interface is outdated, needs a rework.
+    "ColumnTransformer",
     # PlateauFinder seems to be broken, see #2259
     "PlateauFinder",
     # below are removed due to mac failures we don't fully understand, see #3103

--- a/sktime/tests/_config.py
+++ b/sktime/tests/_config.py
@@ -4,13 +4,7 @@ __author__ = ["mloning"]
 __all__ = ["EXCLUDE_ESTIMATORS", "EXCLUDED_TESTS"]
 
 from sktime.base import BaseEstimator, BaseObject
-from sktime.registry import (
-    BASE_CLASS_LIST,
-    BASE_CLASS_LOOKUP,
-    ESTIMATOR_TAG_LIST,
-    TRANSFORMER_MIXIN_LIST,
-)
-from sktime.transformations.base import BaseTransformer
+from sktime.registry import BASE_CLASS_LIST, BASE_CLASS_LOOKUP, ESTIMATOR_TAG_LIST
 
 EXCLUDE_ESTIMATORS = [
     # SFA is non-compliant with any transformer interfaces, #2064
@@ -147,15 +141,12 @@ NON_STATE_CHANGING_METHODS = NON_STATE_CHANGING_METHODS_ARRAYLIKE + (
 )
 
 # The following gives a list of valid estimator base classes.
-VALID_TRANSFORMER_TYPES = tuple(TRANSFORMER_MIXIN_LIST) + (BaseTransformer,)
-
 BASE_BASE_TYPES = (BaseEstimator, BaseObject)
 VALID_ESTIMATOR_BASE_TYPES = tuple(set(BASE_CLASS_LIST).difference(BASE_BASE_TYPES))
 
 VALID_ESTIMATOR_TYPES = (
     BaseEstimator,
     *VALID_ESTIMATOR_BASE_TYPES,
-    *VALID_TRANSFORMER_TYPES,
 )
 
 VALID_ESTIMATOR_BASE_TYPE_LOOKUP = BASE_CLASS_LOOKUP

--- a/sktime/tests/test_all_estimators.py
+++ b/sktime/tests/test_all_estimators.py
@@ -41,8 +41,8 @@ from sktime.tests._config import (
     VALID_ESTIMATOR_BASE_TYPES,
     VALID_ESTIMATOR_TAGS,
     VALID_ESTIMATOR_TYPES,
-    VALID_TRANSFORMER_TYPES,
 )
+from sktime.transformations.base import BaseTransformer
 from sktime.utils._testing._conditional_fixtures import (
     create_conditional_fixtures_and_names,
 )
@@ -855,7 +855,7 @@ class TestAllObjects(BaseFixtureGenerator, QuickTester):
         # If the estimator inherits from more than one base estimator type, we check if
         # one of them is a transformer base type
         if n_base_types > 1:
-            assert issubclass(estimator_class, VALID_TRANSFORMER_TYPES)
+            assert issubclass(estimator_class, BaseTransformer)
 
     def test_has_common_interface(self, estimator_class):
         """Check estimator implements the common interface."""

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -43,10 +43,6 @@ State:
 __author__ = ["mloning", "fkiraly", "miraep8"]
 __all__ = [
     "BaseTransformer",
-    "_SeriesToPrimitivesTransformer",
-    "_SeriesToSeriesTransformer",
-    "_PanelToTabularTransformer",
-    "_PanelToPanelTransformer",
 ]
 
 from itertools import product
@@ -1308,57 +1304,6 @@ class BaseTransformer(BaseEstimator):
             return X_inner, y_inner, metadata
         else:
             return X_inner, y_inner
-
-
-class _SeriesToPrimitivesTransformer(BaseTransformer):
-    """Transformer base class for series to primitive(s) transforms."""
-
-    # class is temporary for downwards compatibility
-
-    # default tag values for "Series-to-Primitives"
-    _tags = {
-        "scitype:transform-input": "Series",
-        # what is the scitype of X: Series, or Panel
-        "scitype:transform-output": "Primitives",
-        # what scitype is returned: Primitives, Series, Panel
-        "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-    }
-
-
-class _SeriesToSeriesTransformer(BaseTransformer):
-    """Transformer base class for series to series transforms."""
-
-    # class is temporary for downwards compatibility
-
-    # default tag values for "Series-to-Series"
-    _tags = {
-        "scitype:transform-input": "Series",
-        # what is the scitype of X: Series, or Panel
-        "scitype:transform-output": "Series",
-        # what scitype is returned: Primitives, Series, Panel
-        "scitype:instancewise": True,  # is this an instance-wise transform?
-        "X_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-    }
-
-
-class _PanelToTabularTransformer(BaseTransformer):
-    """Transformer base class for panel to tabular transforms."""
-
-    # class is temporary for downwards compatibility
-
-    # default tag values for "Panel-to-Tabular"
-    _tags = {
-        "scitype:transform-input": "Series",
-        # what is the scitype of X: Series, or Panel
-        "scitype:transform-output": "Primitives",
-        # what is the scitype of y: None (not needed), Primitives, Series, Panel
-        "scitype:instancewise": False,  # is this an instance-wise transform?
-        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
-        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-    }
 
 
 class _PanelToPanelTransformer(BaseTransformer):

--- a/sktime/transformations/base.py
+++ b/sktime/transformations/base.py
@@ -1304,20 +1304,3 @@ class BaseTransformer(BaseEstimator):
             return X_inner, y_inner, metadata
         else:
             return X_inner, y_inner
-
-
-class _PanelToPanelTransformer(BaseTransformer):
-    """Transformer base class for panel to panel transforms."""
-
-    # class is temporary for downwards compatibility
-
-    # default tag values for "Panel-to-Panel"
-    _tags = {
-        "scitype:transform-input": "Series",
-        # what is the scitype of X: Series, or Panel
-        "scitype:transform-output": "Series",
-        # what scitype is returned: Primitives, Series, Panel
-        "scitype:instancewise": False,  # is this an instance-wise transform?
-        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
-        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
-    }

--- a/sktime/transformations/panel/compose.py
+++ b/sktime/transformations/panel/compose.py
@@ -9,7 +9,7 @@ import pandas as pd
 from scipy import sparse
 from sklearn.compose import ColumnTransformer as _ColumnTransformer
 
-from sktime.transformations.base import BaseTransformer, _PanelToPanelTransformer
+from sktime.transformations.base import BaseTransformer
 from sktime.utils.multiindex import flatten_multiindex
 from sktime.utils.validation.panel import check_X
 
@@ -17,7 +17,7 @@ __author__ = ["mloning", "sajaysurya", "fkiraly"]
 __all__ = ["ColumnTransformer", "ColumnConcatenator"]
 
 
-class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
+class ColumnTransformer(_ColumnTransformer, BaseTransformer):
     """Column-wise application of transformers.
 
     Applies transformations to columns of an array or pandas DataFrame. Simply
@@ -105,6 +105,16 @@ class ColumnTransformer(_ColumnTransformer, _PanelToPanelTransformer):
         sparse matrix or a dense numpy array, which depends on the output
         of the individual transformations and the `sparse_threshold` keyword.
     """
+
+    _tags = {
+        "scitype:transform-input": "Series",
+        # what is the scitype of X: Series, or Panel
+        "scitype:transform-output": "Series",
+        # what scitype is returned: Primitives, Series, Panel
+        "scitype:instancewise": False,  # is this an instance-wise transform?
+        "X_inner_mtype": "nested_univ",  # which mtypes do _fit/_predict support for X?
+        "y_inner_mtype": "pd.Series",  # which mtypes do _fit/_predict support for X?
+    }
 
     def __init__(
         self,

--- a/sktime/utils/_testing/scenarios_transformers.py
+++ b/sktime/utils/_testing/scenarios_transformers.py
@@ -16,17 +16,11 @@ import pandas as pd
 
 from sktime.base import BaseObject
 from sktime.datatypes import mtype_to_scitype
-from sktime.transformations.base import _PanelToPanelTransformer
 from sktime.utils._testing.estimator_checks import _make_primitives, _make_tabular_X
 from sktime.utils._testing.forecasting import _make_series
 from sktime.utils._testing.hierarchical import _make_hierarchical
 from sktime.utils._testing.panel import _make_classification_y, _make_panel_X
 from sktime.utils._testing.scenarios import TestScenario
-
-OLD_MIXINS = (_PanelToPanelTransformer,)
-
-OLD_PANEL_MIXINS = (_PanelToPanelTransformer,)
-
 
 # random seed for generating data to keep scenarios exactly reproducible
 RAND_SEED = 42
@@ -70,9 +64,6 @@ class TransformerTestScenario(TestScenario, BaseObject):
         # pre-refactor classes can't deal with Series *and* Panel both
         X_scitype = self.get_tag("X_scitype")
         y_scitype = self.get_tag("y_scitype", None, raise_error=False)
-
-        if _is_child_of(obj, OLD_PANEL_MIXINS) and X_scitype != "Panel":
-            return False
 
         # if transformer requires y, the scenario also must pass y
         has_y = self.get_tag("has_y")
@@ -143,14 +134,10 @@ class TransformerTestScenario(TestScenario, BaseObject):
             X_out_prim = X_out_scitype == "Primitives"
 
             # determine output by X_out_scitype
-            #   until transformer refactor is complete, use the old classes, too
-            if _is_child_of(obj, OLD_MIXINS):
-                p2p = _is_child_of(obj, _PanelToPanelTransformer)
-            else:
-                s2s = X_scitype == "Series" and X_out_series
-                s2p = X_scitype == "Series" and X_out_prim
-                p2t = X_scitype == "Panel" and X_out_prim
-                p2p = X_scitype == "Panel" and X_out_series
+            s2s = X_scitype == "Series" and X_out_series
+            s2p = X_scitype == "Series" and X_out_prim
+            p2t = X_scitype == "Panel" and X_out_prim
+            p2p = X_scitype == "Panel" and X_out_series
 
             # expected input type of inverse_transform is expected output of transform
             if s2p:


### PR DESCRIPTION
A bit of clean-up in preparation for #149.

The only usage is `ColumnTransformer` which is very outdated and requires a rework. I have added it to the text exclude list.