### PR TITLE
[MNT] Cleanup the forecasting tests

### DIFF
--- a/aeon/forecasting/compose/tests/test_reduce_global.py
+++ b/aeon/forecasting/compose/tests/test_reduce_global.py
@@ -227,7 +227,7 @@ def test_list_reduction(y, index_names):
     check_eval(y_pred.index.names, index_names)
 
 
-def test_equality_transfo_nontranso(regressor):
+def test_equality_transfo_nontranso():
     """Test that recursive reducers return same results for global / local forecasts."""
     y = load_airline()
     y_train, y_test = temporal_train_test_split(y, test_size=30)

--- a/aeon/forecasting/model_selection/tests/test_tune.py
+++ b/aeon/forecasting/model_selection/tests/test_tune.py
@@ -23,7 +23,6 @@ from aeon.forecasting.naive import NaiveForecaster
 from aeon.forecasting.tests._config import (
     TEST_N_ITERS,
     TEST_OOS_FHS,
-    TEST_RANDOM_SEEDS,
     TEST_WINDOW_LENGTHS_INT,
 )
 from aeon.forecasting.trend import PolynomialTrendForecaster
@@ -113,8 +112,7 @@ def test_gscv(forecaster, param_grid, cv, scoring, error_score):
 @pytest.mark.parametrize("error_score", ERROR_SCORES)
 @pytest.mark.parametrize("cv", CVs)
 @pytest.mark.parametrize("n_iter", TEST_N_ITERS)
-@pytest.mark.parametrize("random_state", TEST_RANDOM_SEEDS)
-def test_rscv(forecaster, param_grid, cv, scoring, error_score, n_iter, random_state):
+def test_rscv(forecaster, param_grid, cv, scoring, error_score, n_iter):
     """Test ForecastingRandomizedSearchCV.
 
     Tests that ForecastingRandomizedSearchCV successfully searches the
@@ -128,13 +126,11 @@ def test_rscv(forecaster, param_grid, cv, scoring, error_score, n_iter, random_s
         scoring=scoring,
         error_score=error_score,
         n_iter=n_iter,
-        random_state=random_state,
+        random_state=42,
     )
     rscv.fit(y, X)
 
-    param_distributions = list(
-        ParameterSampler(param_grid, n_iter, random_state=random_state)
-    )
+    param_distributions = list(ParameterSampler(param_grid, n_iter, random_state=42))
     _check_cv(forecaster, rscv, cv, param_distributions, y, X, scoring)
 
 

--- a/aeon/forecasting/tests/_config.py
+++ b/aeon/forecasting/tests/_config.py
@@ -17,7 +17,6 @@ __all__ = [
     "TEST_INITIAL_WINDOW",
     "VALID_INDEX_FH_COMBINATIONS",
     "INDEX_TYPE_LOOKUP",
-    "TEST_RANDOM_SEEDS",
     "TEST_N_ITERS",
 ]
 
@@ -91,7 +90,6 @@ TEST_FHS_TIMEDELTA = [*TEST_OOS_FHS_TIMEDELTA, *TEST_INS_FHS_TIMEDELTA]
 TEST_SPS = [3, 12]
 TEST_ALPHAS = [0.05, 0.1]
 TEST_YS = [_make_series(all_positive=True)]
-TEST_RANDOM_SEEDS = [1, 42]
 TEST_N_ITERS = [1, 4]
 
 # We currently support the following combinations of index and forecasting horizon types

--- a/aeon/forecasting/tests/test_all_forecasters.py
+++ b/aeon/forecasting/tests/test_all_forecasters.py
@@ -198,37 +198,6 @@ class TestAllForecasters(ForecasterFixtureGenerator, QuickTester):
             msg = str(e).lower()
             assert "exogenous" in msg
 
-    # todo: refactor with scenarios. Need to override fh and scenario args for this.
-    @pytest.mark.parametrize(
-        "index_fh_comb", VALID_INDEX_FH_COMBINATIONS, ids=index_fh_comb_names
-    )
-    @pytest.mark.parametrize("fh_int", TEST_FHS, ids=[f"fh={fh}" for fh in TEST_FHS])
-    def test_predict_time_index(
-        self, estimator_instance, n_columns, index_fh_comb, fh_int
-    ):
-        """Check that predicted time index matches forecasting horizon."""
-        index_type, fh_type, is_relative = index_fh_comb
-        if fh_type == "timedelta":
-            return None
-            # todo: ensure check_estimator works with pytest.skip like below
-            # pytest.skip(
-            #    "ForecastingHorizon with timedelta values "
-            #     "is currently experimental and not supported everywhere"
-            # )
-        y_train = _make_series(
-            n_columns=n_columns, index_type=index_type, n_timepoints=50
-        )
-        cutoff = get_cutoff(y_train, return_index=True)
-        fh = _make_fh(cutoff, fh_int, fh_type, is_relative)
-
-        try:
-            estimator_instance.fit(y_train, fh=fh)
-            y_pred = estimator_instance.predict()
-            _assert_correct_pred_time_index(y_pred.index, cutoff, fh=fh_int)
-            _assert_correct_columns(y_pred, y_train)
-        except NotImplementedError:
-            pass
-
     @pytest.mark.parametrize(
         "index_fh_comb", VALID_INDEX_FH_COMBINATIONS, ids=index_fh_comb_names
     )

--- a/aeon/utils/_testing/series.py
+++ b/aeon/utils/_testing/series.py
@@ -23,7 +23,7 @@ def _make_series(
     data = rng.normal(size=(n_timepoints, n_columns))
     if add_nan:
         # add some nan values
-        data[int(len(data) / 2)] = np.nan
+        data[len(data) // 2] = np.nan
         data[0] = np.nan
         data[-1] = np.nan
     if all_positive:


### PR DESCRIPTION
- drop parametrization over random seeds
- update
- drop the redundant test_predict_time_index
- unparametrize test_equality_transfo_nontranso test

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

- related #154 

#### What does this implement/fix? Explain your changes.

Dropping `test_predict_time_index` is based on the observation that is essentially tests the `ForecastingHorizon` scenarios since all forecasters should inherit from `BaseForecaster` and therefore the use `check_fh` in `fit` which converts whatever input into a `ForecastingHorizon` instance. Tests for different inputs to `ForecastingHorizon` are already covered by `test_fh` so `test_predict_time_index` is redundant here.

Some timings from my local env:
- with `test_predict_time_index`: 12844 passed, 351 skipped, 117 warnings in 2019.45s (0:33:39)
- wthout`test_predict_time_index`: - 10900 passed, 351 skipped, 117 warnings in 1232.48s (0:20:32) 

while test coverage - measured by `pytest-cov` stays exactly at the same level of 67% for the forecasting module. 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
