### PR TITLE
[MNT] Fix pytest by setting upper bound on `dash`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "pytest-randomly",
     "pytest-timeout",
     "pytest-xdist",
+    "dash<=2.8.1", #https://github.com/plotly/dash/issues/2463 remove when fixed
     "wheel",
     "boto3",  # mlflow related
     "botocore",  # mlflow related


### PR DESCRIPTION
The issue is fixed in https://github.com/plotly/dash/pull/2461, but a new release is required to fix our CI.