### PR TITLE
[ENH] remove incorrect iloc calls

### DIFF
--- a/aeon/classification/early_classification/tests/test_all_early_classifiers.py
+++ b/aeon/classification/early_classification/tests/test_all_early_classifiers.py
@@ -137,7 +137,7 @@ class TestAllEarlyClassifiers(EarlyClassifierFixtureGenerator, QuickTester):
         indices = np.random.RandomState(4).choice(len(y_train), 10, replace=False)
 
         # train classifier and predict probas
-        estimator_instance.fit(X_train.iloc[indices], y_train[indices])
+        estimator_instance.fit(X_train[indices], y_train[indices])
         y_proba, _ = estimator_instance.predict_proba(X_test[indices])
 
         # assert probabilities are the same

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,6 @@ addopts =
     --ignore docs
     --doctest-modules
     --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,13 @@ addopts =
     --ignore docs
     --doctest-modules
     --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
this removes a couple of calls to iloc for returned data that is no longer a data frame. It also removes a test that is skipped and listed as being deprecated some time ago. 