### PR TITLE
[BUG] fix class values for SFA tests

### DIFF
--- a/aeon/transformations/panel/dictionary_based/tests/test_sfa.py
+++ b/aeon/transformations/panel/dictionary_based/tests/test_sfa.py
@@ -96,7 +96,7 @@ test_dft_mft(True, True)
 def test_sfa_anova(binning_method):
     # load training data
     X = np.random.rand(10, 1, 150)
-    y = np.random.randint(0, 2, 10)
+    y = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
 
     word_length = 6
     alphabet_size = 4
@@ -140,7 +140,7 @@ def test_word_lengths(
 ):
     # training data
     X = np.random.rand(10, 1, 150)
-    y = np.random.randint(0, 2, 10)
+    y = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
 
     p = SFA(
         word_length=word_length,
@@ -158,7 +158,7 @@ def test_word_lengths(
 def test_bit_size():
     # load training data
     X = np.random.rand(10, 1, 150)
-    y = np.random.randint(0, 2, 10)
+    y = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
 
     word_length = 40
     alphabet_size = 12
@@ -182,7 +182,7 @@ def test_bit_size():
 def test_typed_dict():
     # load training data
     X = np.random.rand(10, 1, 150)
-    y = np.random.randint(0, 2, 10)
+    y = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
 
     word_length = 6
     alphabet_size = 4


### PR DESCRIPTION
Sporadic failure of test_sfa (tests a private method of sfa) caused by random class values occasionally being all the same value fixed by hard coding the testing class values to be evenly balanced

#### Reference Issues/PRs
Fixes #223 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/aeon/ to keep external dependencies of the core aeon package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

##### For new estimators
- [ ] I've added the estimator to the online documentation.
- [ ] I've updated the existing example notebooks or provided a new one to showcase how my estimator works.


<!--
Thanks for contributing!
-->
