### PR TITLE
[ENH] Converts RocketClassifier back to being a sklearn pipeline classifier

### DIFF
--- a/aeon/classification/convolution_based/_arsenal.py
+++ b/aeon/classification/convolution_based/_arsenal.py
@@ -103,8 +103,8 @@ class Arsenal(BaseClassifier):
     --------
     >>> from aeon.classification.convolution_based import Arsenal
     >>> from aeon.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test =load_unit_test(split="test", return_X_y=True)
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test =load_unit_test(split="test")
     >>> clf = Arsenal(num_kernels=100, n_estimators=5)
     >>> clf.fit(X_train, y_train)
     Arsenal(...)
@@ -137,7 +137,6 @@ class Arsenal(BaseClassifier):
         self.rocket_transform = rocket_transform
         self.max_dilations_per_kernel = max_dilations_per_kernel
         self.n_features_per_kernel = n_features_per_kernel
-
         self.time_limit_in_minutes = time_limit_in_minutes
         self.contract_max_n_estimators = contract_max_n_estimators
         self.save_transformed_data = save_transformed_data

--- a/aeon/classification/convolution_based/_rocket_classifier.py
+++ b/aeon/classification/convolution_based/_rocket_classifier.py
@@ -134,7 +134,7 @@ class RocketClassifier(BaseClassifier):
         self.n_instances_, self.n_dims_, self.series_length_ = X.shape
 
         if self.rocket_transform == "rocket":
-            self.transformer_ = Rocket(num_kernels=self.num_kernels)
+            transformer = Rocket(num_kernels=self.num_kernels)
         elif self.rocket_transform == "minirocket":
             if self.n_dims_ > 1:
                 transformer = MiniRocketMultivariate(
@@ -154,7 +154,7 @@ class RocketClassifier(BaseClassifier):
                     n_features_per_kernel=self.n_features_per_kernel,
                 )
             else:
-                self._transformer = MultiRocket(
+                transformer = MultiRocket(
                     num_kernels=self.num_kernels,
                     max_dilations_per_kernel=self.max_dilations_per_kernel,
                     n_features_per_kernel=self.n_features_per_kernel,

--- a/aeon/classification/convolution_based/_rocket_classifier.py
+++ b/aeon/classification/convolution_based/_rocket_classifier.py
@@ -9,10 +9,9 @@ __all__ = ["RocketClassifier"]
 
 import numpy as np
 from sklearn.linear_model import RidgeClassifierCV
-from sklearn.preprocessing import StandardScaler
 
-from aeon.classification._delegate import _DelegatedClassifier
-from aeon.pipeline import make_pipeline
+from aeon.base._base import _clone_estimator
+from aeon.classification import BaseClassifier
 from aeon.transformations.panel.rocket import (
     MiniRocket,
     MiniRocketMultivariate,
@@ -22,7 +21,7 @@ from aeon.transformations.panel.rocket import (
 )
 
 
-class RocketClassifier(_DelegatedClassifier):
+class RocketClassifier(BaseClassifier):
     """Classifier wrapped for the Rocket transformer using RidgeClassifierCV.
 
     This classifier simply transforms the input data using the Rocket [1]_
@@ -97,8 +96,8 @@ class RocketClassifier(_DelegatedClassifier):
     --------
     >>> from aeon.classification.convolution_based import RocketClassifier
     >>> from aeon.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
-    >>> X_test, y_test = load_unit_test(split="test", return_X_y=True)
+    >>> X_train, y_train = load_unit_test(split="train")
+    >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = RocketClassifier(num_kernels=500)
     >>> clf.fit(X_train, y_train)
     RocketClassifier(...)
@@ -112,7 +111,6 @@ class RocketClassifier(_DelegatedClassifier):
     }
     # valid rocket strings for input validity checking
     VALID_ROCKET_STRINGS = ["rocket", "minirocket", "multirocket"]
-    VALID_MULTIVAR_VALUES = ["auto", "yes", "no"]
 
     def __init__(
         self,
@@ -123,82 +121,120 @@ class RocketClassifier(_DelegatedClassifier):
         use_multivariate="auto",
         n_jobs=1,
         random_state=None,
+        estimator=None,
     ):
         self.num_kernels = num_kernels
         self.rocket_transform = rocket_transform
         self.max_dilations_per_kernel = max_dilations_per_kernel
         self.n_features_per_kernel = n_features_per_kernel
-        self.use_multivariate = use_multivariate
-
         self.n_jobs = n_jobs
         self.random_state = random_state
-
+        self.estimator = estimator
+        self.n_instances_ = 0
+        self.n_dims_ = 0
+        self.series_length_ = 0
         super(RocketClassifier, self).__init__()
 
-        if use_multivariate not in self.VALID_MULTIVAR_VALUES:
-            raise ValueError(
-                f"Invalid use_multivariate value, must be one of "
-                f"{self.VALID_MULTIVAR_VALUES}, but found {use_multivariate}"
-            )
+    def _fit(self, X, y):
+        """Fit Arsenal to training data.
 
-        common_params = {
-            "num_kernels": self.num_kernels,
-            "random_state": self.random_state,
-            "max_dilations_per_kernel": self.max_dilations_per_kernel,
-            "n_jobs": self._threads_to_use,
-        }
+        Parameters
+        ----------
+        X : 3D np.array of shape = [n_instances, n_channels, series_length]
+            The training data.
+        y : array-like, shape = [n_instances]
+            The class labels.
 
-        if rocket_transform == "rocket":
-            del common_params["max_dilations_per_kernel"]
-            univar_rocket = Rocket(**common_params)
-            multivar_rocket = univar_rocket
+        Returns
+        -------
+        self :
+            Reference to self.
 
-        elif rocket_transform == "minirocket":
-            multivar_rocket = MiniRocketMultivariate(**common_params)
-            univar_rocket = MiniRocket(**common_params)
+        Notes
+        -----
+        Changes state by creating a fitted model that updates attributes
+        ending in "_" and sets is_fitted flag to True.
+        """
+        self.n_instances_, self.n_dims_, self.series_length_ = X.shape
 
+        if self.rocket_transform == "rocket":
+            self.transformer_ = Rocket(num_kernels=self.num_kernels)
+        elif self.rocket_transform == "minirocket":
+            if self.n_dims_ > 1:
+                self._transformer = MiniRocketMultivariate(
+                    num_kernels=self.num_kernels,
+                    max_dilations_per_kernel=self.max_dilations_per_kernel,
+                )
+            else:
+                self._transformer = MiniRocket(
+                    num_kernels=self.num_kernels,
+                    max_dilations_per_kernel=self.max_dilations_per_kernel,
+                )
         elif self.rocket_transform == "multirocket":
-            common_params["n_features_per_kernel"] = self.n_features_per_kernel
-            multivar_rocket = MultiRocketMultivariate(**common_params)
-            univar_rocket = MultiRocket(**common_params)
-
+            if self.n_dims_ > 1:
+                self._transformer = MultiRocketMultivariate(
+                    num_kernels=self.num_kernels,
+                    max_dilations_per_kernel=self.max_dilations_per_kernel,
+                    n_features_per_kernel=self.n_features_per_kernel,
+                )
+            else:
+                self._transformer = MultiRocket(
+                    num_kernels=self.num_kernels,
+                    max_dilations_per_kernel=self.max_dilations_per_kernel,
+                    n_features_per_kernel=self.n_features_per_kernel,
+                )
         else:
-            raise ValueError(
-                f"Invalid rocket_transform string, must be one of "
-                f"{self.VALID_ROCKET_STRINGS}, but found {rocket_transform}"
-            )
-
-        self.multivar_rocket_ = make_pipeline(
-            multivar_rocket,
-            StandardScaler(with_mean=False),
-            RidgeClassifierCV(alphas=np.logspace(-3, 3, 10)),
+            raise ValueError(f"Invalid Rocket transformer: {self.rocket_transform}")
+        self._estimator = _clone_estimator(
+            RidgeClassifierCV(alphas=np.logspace(-3, 3, 10))
+            if self.estimator is None
+            else self.estimator,
+            self.random_state,
         )
-        self.univar_rocket_ = make_pipeline(
-            univar_rocket,
-            StandardScaler(with_mean=False),
-            RidgeClassifierCV(alphas=np.logspace(-3, 3, 10)),
-        )
+        X_trans = self._transformer.fit_transform(X, y)
+        self._estimator.fit(X_trans, y)
+        return self
 
-        if not use_multivariate:
-            self.set_tags(**{"capability:multivariate": False})
+    def _predict(self, X) -> np.ndarray:
+        """Predicts labels for sequences in X.
 
-    @property
-    def estimator_(self):
-        """Shorthand for the internal estimator that is fitted."""
-        return self._get_delegate()
+        Parameters
+        ----------
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The data to make predictions for.
 
-    def _get_delegate(self):
-        use_multivariate = self.use_multivariate
-        if use_multivariate == "auto":
-            code_dict = {True: "yes", False: "no"}
-            use_multivariate = code_dict[not self._X_metadata["is_univariate"]]
+        Returns
+        -------
+        y : array-like, shape = [n_instances]
+            Predicted class labels.
+        """
+        X_trans = self._transformer.transform(X)
+        return self._estimator.predict(X_trans)
 
-        if use_multivariate == "yes":
-            delegate = self.multivar_rocket_
+    def _predict_proba(self, X) -> np.ndarray:
+        """Predicts labels probabilities for sequences in X.
+
+        Parameters
+        ----------
+        X : 3D np.array of shape = [n_instances, n_channels, series_length]
+            The data to make predict probabilities for.
+
+        Returns
+        -------
+        y : array-like, shape = [n_instances, n_classes_]
+            Predicted probabilities using the ordering in classes_.
+        """
+        X_trans = self._transformer.transform(X)
+
+        m = getattr(self._estimator, "predict_proba", None)
+        if callable(m):
+            return self._estimator.predict_proba(X_trans)
         else:
-            delegate = self.univar_rocket_
-
-        return delegate
+            dists = np.zeros((X.shape[0], self.n_classes_))
+            preds = self._estimator.predict(X_trans)
+            for i in range(0, X.shape[0]):
+                dists[i, np.where(self.classes_ == preds[i])] = 1
+            return dists
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/aeon/classification/convolution_based/_rocket_classifier.py
+++ b/aeon/classification/convolution_based/_rocket_classifier.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """RandOm Convolutional KErnel Transform (Rocket).
 
-Pipeline classifier using the ROCKET transformer and RidgeClassifierCV estimator.
+Pipeline classifier using the ROCKET transformer and an sklearn classifier.
 """
 
-__author__ = ["MatthewMiddlehurst", "victordremov", "fkiraly"]
+__author__ = ["MatthewMiddlehurst", "victordremov", "TonyBagnall"]
 __all__ = ["RocketClassifier"]
 
 import numpy as np
@@ -26,9 +26,9 @@ from aeon.transformations.panel.rocket import (
 class RocketClassifier(BaseClassifier):
     """Classifier wrapped for the Rocket transformer using RidgeClassifierCV.
 
-    This classifier simply transforms the input data using the Rocket [1]_
+    This classifier simply transforms the input data using a Rocket [1,2,3]_
     transformer, performs a Standard scaling and fits a sklearn classifier,
-    using the transformed data (default is a RidgeClassifierCV estimator).
+    using the transformed data (default classifier is RidgeClassifierCV).
 
     The classifier can be configured to use Rocket [1]_, MiniRocket [2] or
     MultiRocket [3].

--- a/aeon/classification/convolution_based/_rocket_classifier.py
+++ b/aeon/classification/convolution_based/_rocket_classifier.py
@@ -97,8 +97,6 @@ class RocketClassifier(BaseClassifier):
         rocket_transform="rocket",
         max_dilations_per_kernel=32,
         n_features_per_kernel=4,
-        use_multivariate="auto",
-        n_jobs=1,
         random_state=None,
         estimator=None,
     ):
@@ -106,7 +104,6 @@ class RocketClassifier(BaseClassifier):
         self.rocket_transform = rocket_transform
         self.max_dilations_per_kernel = max_dilations_per_kernel
         self.n_features_per_kernel = n_features_per_kernel
-        self.n_jobs = n_jobs
         self.random_state = random_state
         self.estimator = estimator
         self.n_instances_ = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,6 @@ addopts =
     --ignore docs
     --doctest-modules
     --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,13 @@ addopts =
     --ignore docs
     --doctest-modules
     --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
RocketClassifier had been altered to inherit from _DelegateClassifier in a completely unnecessary complication. This PR reverts it to being an sklearn pipeline classifier, and as a bonus adds the ability to set a different classifier.

Simplified  the docstring, removed the strange option of using a univariate version of MiniRocket on multivariate.


#### Reference Issues/PRs

Part of #128 

#### What does this implement/fix? Explain your changes.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/aeon/ to keep external dependencies of the core aeon package to a minimum.
-->

#### Did you add any tests for the change?
 No, already tested in test_all_classifiers, which it passexs

