### PR TITLE
[ENH] Experimental cache functionality for BaseTransformer

### DIFF
--- a/aeon/__init__.py
+++ b/aeon/__init__.py
@@ -4,6 +4,7 @@
 
 __version__ = "0.1.0rc0"
 
-__all__ = ["show_versions"]
+__all__ = ["show_versions", "get_config", "set_config", "config_context"]
 
+from aeon._config import config_context, get_config, set_config
 from aeon.utils._maint._show_versions import show_versions

--- a/aeon/_config.py
+++ b/aeon/_config.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager as contextmanager
 
 _global_config = {
     "cache": False,
-    "_cache": {},
+    "_cache": None,
 }
 _threadlocal = threading.local()
 

--- a/aeon/_config.py
+++ b/aeon/_config.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Global configuration state and functions for management."""
+import threading
+from contextlib import contextmanager as contextmanager
+
+_global_config = {
+    "cache": False,
+    "_cache": {},
+}
+_threadlocal = threading.local()
+
+
+def _get_threadlocal_config():
+    """Get a threadlocal **mutable** configuration.
+
+    If the configuration does not exist, copy the default global configuration.
+    """
+    if not hasattr(_threadlocal, "global_config"):
+        _threadlocal.global_config = _global_config.copy()
+    return _threadlocal.global_config
+
+
+def get_config():
+    """Retrieve current values for configuration set by :func:`set_config`.
+
+    Returns
+    -------
+    config : dict
+        Keys are parameter names that can be passed to :func:`set_config`.
+
+    See Also
+    --------
+    config_context : Context manager for global aeon configuration.
+    set_config : Set global aeon configuration.
+    """
+    # Return a copy of the threadlocal configuration so that users will
+    # not be able to modify the configuration with the returned dict.
+    return _get_threadlocal_config().copy()
+
+
+def set_config(
+    cache: bool = None,
+    _cache=None,
+):
+    """Set global aeon configuration.
+
+    Parameters
+    ----------
+    cache: bool, default=None
+
+    See Also
+    --------
+    config_context : Context manager for global aeon configuration.
+    get_config : Retrieve current values of the global configuration.
+    """
+    local_config = _get_threadlocal_config()
+
+    if cache is not None:
+        local_config["cache"] = cache
+    if _cache is not None:
+        local_config["_cache"] = _cache
+
+
+@contextmanager
+def config_context(
+    *,
+    cache=None,
+    _cache=None,
+):
+    """Context manager for global aeon configuration.
+
+    Parameters
+    ----------
+    cache: bool, default=None
+        If True, will make checks on X and y
+
+    Yields
+    ------
+    None.
+
+    See Also
+    --------
+    set_config : Set global aeon configuration.
+    get_config : Retrieve current values of the global configuration.
+
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited.
+    """
+    old_config = get_config()
+    set_config(
+        cache=cache,
+        _cache=_cache,
+    )
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/aeon/base/__init__.py
+++ b/aeon/base/__init__.py
@@ -10,8 +10,10 @@ __all__ = [
     "BaseEstimator",
     "_HeterogenousMetaEstimator",
     "load",
+    "cache",
 ]
 
 from aeon.base._base import BaseEstimator, BaseObject
+from aeon.base._cache import cache
 from aeon.base._meta import _HeterogenousMetaEstimator
 from aeon.base._serialize import load

--- a/aeon/base/_cache.py
+++ b/aeon/base/_cache.py
@@ -9,10 +9,10 @@ from aeon import get_config, set_config
 
 def cache(func):
     """Decorate functions to cache return."""
-    if get_config()["cache"]:
 
-        @wraps(func)
-        def cached_func(*args, **kwargs):
+    @wraps(func)
+    def cached_func(*args, **kwargs):
+        if get_config()["cache"]:
             # Convert unhashable objects to hashable ones
             key = joblib.hash((args, kwargs))
             if get_config()["_cache"] is None:
@@ -28,7 +28,7 @@ def cache(func):
                 set_config(_cache=_cache)
 
                 return result
+        else:
+            return func(*args, **kwargs)
 
-        return cached_func
-    else:
-        return func
+    return cached_func

--- a/aeon/base/_cache.py
+++ b/aeon/base/_cache.py
@@ -16,7 +16,8 @@ def cache(func):
             # Convert unhashable objects to hashable ones
             key = joblib.hash((args, kwargs))
             if get_config()["_cache"] is None:
-                _cache = LRUCache(maxsize=5)
+                _cache = LRUCache(maxsize=1)
+                # _cache = {}
             else:
                 _cache = get_config()["_cache"]
             if key in _cache:

--- a/aeon/base/_cache.py
+++ b/aeon/base/_cache.py
@@ -4,23 +4,28 @@ from functools import wraps
 import joblib
 from cachetools import LRUCache
 
-from aeon import get_config
+from aeon import get_config, set_config
 
 
 def cache(func):
     """Decorate functions to cache return."""
     if get_config()["cache"]:
-        cache = LRUCache(maxsize=1000)
 
         @wraps(func)
         def cached_func(*args, **kwargs):
             # Convert unhashable objects to hashable ones
             key = joblib.hash((args, kwargs))
-            if key in cache:
-                return cache[key]
+            if get_config()["_cache"] is None:
+                _cache = LRUCache(maxsize=5)
+            else:
+                _cache = get_config()["_cache"]
+            if key in _cache:
+                return _cache[key]
             else:
                 result = func(*args, **kwargs)
-                cache[key] = result
+                _cache[key] = result
+                set_config(_cache=_cache)
+
                 return result
 
         return cached_func

--- a/aeon/base/_cache.py
+++ b/aeon/base/_cache.py
@@ -1,25 +1,10 @@
 # -*- coding: utf-8 -*-
 from functools import wraps
 
-import numpy as np
+import joblib
 from cachetools import LRUCache
 
 from aeon import get_config
-
-
-def make_hashable(obj):
-    """Convert an unhashable object to a hashable one."""
-    # Replace unhashable types with their string representation
-    if isinstance(obj, dict):
-        return tuple((k, make_hashable(v)) for k, v in obj.items())
-    elif isinstance(obj, (list, tuple)):
-        return tuple(make_hashable(x) for x in obj)
-    elif isinstance(obj, set):
-        return frozenset(make_hashable(x) for x in obj)
-    elif isinstance(obj, np.ndarray):
-        return obj.tobytes()
-    else:
-        return str(obj)
 
 
 def cache(func):
@@ -30,7 +15,7 @@ def cache(func):
         @wraps(func)
         def cached_func(*args, **kwargs):
             # Convert unhashable objects to hashable ones
-            key = make_hashable((args, kwargs))
+            key = joblib.hash((args, kwargs))
             if key in cache:
                 return cache[key]
             else:

--- a/aeon/base/_cache.py
+++ b/aeon/base/_cache.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from functools import wraps
+
+import numpy as np
+from cachetools import LRUCache
+
+from aeon import get_config
+
+
+def make_hashable(obj):
+    """Convert an unhashable object to a hashable one."""
+    # Replace unhashable types with their string representation
+    if isinstance(obj, dict):
+        return tuple((k, make_hashable(v)) for k, v in obj.items())
+    elif isinstance(obj, (list, tuple)):
+        return tuple(make_hashable(x) for x in obj)
+    elif isinstance(obj, set):
+        return frozenset(make_hashable(x) for x in obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tobytes()
+    else:
+        return str(obj)
+
+
+def cache(func):
+    """Decorate functions to cache return."""
+    if get_config()["cache"]:
+        cache = LRUCache(maxsize=1000)
+
+        @wraps(func)
+        def cached_func(*args, **kwargs):
+            # Convert unhashable objects to hashable ones
+            key = make_hashable((args, kwargs))
+            if key in cache:
+                return cache[key]
+            else:
+                result = func(*args, **kwargs)
+                cache[key] = result
+                return result
+
+        return cached_func
+    else:
+        return func

--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -474,6 +474,7 @@ class BaseTransformer(BaseEstimator):
 
         return X_out
 
+    @cache  # noqa: B019
     def fit_transform(self, X, y=None):
         """Fit to data, then transform it.
 

--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -346,6 +346,7 @@ class BaseTransformer(BaseEstimator):
         else:
             return ColumnSelect(key) * self
 
+    @cache  # noqa: B019
     def fit(self, X, y=None):
         """Fit transformer to X, optionally to y.
 

--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -51,7 +51,7 @@ from typing import Union
 import numpy as np
 import pandas as pd
 
-from aeon.base import BaseEstimator
+from aeon.base import BaseEstimator, cache
 from aeon.datatypes import (
     VectorizedDF,
     check_is_mtype,
@@ -399,6 +399,7 @@ class BaseTransformer(BaseEstimator):
 
         return self
 
+    @cache  # noqa: B019
     def transform(self, X, y=None):
         """Transform X and return a transformed version.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
General idea: speed up grid search.

Experimental implementation of a cache functionality to cache output of `transform`, `fit` and `fit_transform`. This can be especially useful in grid search and pipelining. Idea is e.g. in below grid search to reduce the number of `transform()` calls per transformer by `66%`


Example:
```python
from aeon import set_config
from aeon.utils._testing.hierarchical import _make_hierarchical
from aeon.forecasting.compose import TransformedTargetForecaster
from aeon.forecasting.model_selection import ForecastingGridSearchCV
from aeon.forecasting.model_selection import ExpandingWindowSplitter
from aeon.forecasting.naive import NaiveForecaster
from aeon.transformations.series.adapt import TabularToSeriesAdaptor
from aeon.transformations.compose import OptionalPassthrough
from aeon.transformations.series.impute import Imputer
from aeon.transformations.series.exponent import ExponentTransformer
from aeon.transformations.series.detrend import Detrender, Deseasonalizer
from aeon.transformations.compose import TransformerPipeline

from sklearn.preprocessing import PowerTransformer
from sklearn.preprocessing import MinMaxScaler

y = _make_hierarchical(min_timepoints=60, max_timepoints=60, index_type="datetime")

set_config(cache=True)

pipe = TransformedTargetForecaster(steps=[
    ("imputer1", Imputer(method="constant", value=1)),
    ("minmax", TabularToSeriesAdaptor(MinMaxScaler((1, 10)))),
    ("detrender", OptionalPassthrough(Detrender())),
    ("exponent", ExponentTransformer()),
    ("deseasonalizer", Deseasonalizer(sp=2)),
    ("power", TabularToSeriesAdaptor(PowerTransformer())),
    ("imputer2", Imputer()),
    ("forecaster", NaiveForecaster(sp=3)),
])
cv = ExpandingWindowSplitter(
    initial_window=12,
    step_length=1,
    fh=[1,2,3],
)
gscv = ForecastingGridSearchCV(
    forecaster=pipe,
    param_grid={
        "forecaster__sp": [3, 4, 5],
        # "detrender__passthrough": [True, False],
    },
    cv=cv,
    n_jobs=-1,
    verbose=1,
    error_score='raise',
)
gscv.fit(y)
```

#### What should a reviewer concentrate their feedback on?
Performance is not yet as expected. The custom `@cache` decorator was required due to unhashable `aeon` objects. Seems to be slow still, was experimenting also with `joblib.hash`. There might be a better place for the cache functionality than the `transform`, it could already be done in the `TransfomedTargetForecaster` and possibly before the "vetorization" or somewhere in it.
