### PR TITLE
[ENH] change Imputer to allow for 0 to be the missing value to replace

### DIFF
--- a/aeon/transformations/series/impute.py
+++ b/aeon/transformations/series/impute.py
@@ -174,7 +174,7 @@ class Imputer(BaseTransformer):
         X = X.copy()
 
         # replace missing_values with np.nan
-        if self.missing_values:
+        if self.missing_values is not None:
             X = X.replace(to_replace=self.missing_values, value=np.nan)
 
         # in case a column only contains missing values, fill with value


### PR DESCRIPTION
The Imputer transform begins by allowing the user to specify what value represents missing. 

        # replace missing_values with np.nan
        if self.missing_values:
            X = X.replace(to_replace=self.missing_values, value=np.nan)

python interprets 0 as False in a C style. This corrects that to 

        if self.missing_values is not None:
            X = X.replace(to_replace=self.missing_values, value=np.nan)

#### Reference Issues/PRs
Fixes #266 