### PR TITLE
[BUG] Include `packaging` as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=1.0.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",
-    "packaging",
+    "packaging>=20.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pandas>=1.1.0,<1.6.0",
     "scikit-learn>=1.0.0,<1.3.0",
     "scipy<2.0.0,>=1.2.0",
+    "packaging",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We use `packaging` for soft dependencies, but it is not included as a dependency itself. There have been some people missing it when they install `aeon`.

Fixes #55 
Fixes #256