### PR TITLE
[ENH] Convert DWTTransformer to use numpy format internally

### DIFF
--- a/aeon/transformations/panel/dwt.py
+++ b/aeon/transformations/panel/dwt.py
@@ -16,8 +16,17 @@ class DWTTransformer(BaseTransformer):
 
     Parameters
     ----------
-    num_levels : int, number of levels to perform the Haar wavelet
+    n_levels : int, number of levels to perform the Haar wavelet
                  transformation.
+
+    Examples
+    --------
+    >>> from aeon.transformations.panel import DWTTransformer
+    >>> import numpy as np
+    >>> data = np.array([[[1,2,3,4,5,6,7,8,9,10]],[[5,5,5,5,5,5,5,5,5,5]]])
+    >>> dwt = DWTTransformer(n_levels=2)
+    >>> data2 = dwt.fit_transform(data)
+
     """
 
     _tags = {
@@ -28,8 +37,8 @@ class DWTTransformer(BaseTransformer):
         "fit_is_empty": True,
     }
 
-    def __init__(self, num_levels=3):
-        self.num_levels = num_levels
+    def __init__(self, n_levels=3):
+        self.n_levels = n_levels
         super(DWTTransformer, self).__init__()
 
     def _transform(self, X, y=None):
@@ -66,7 +75,7 @@ class DWTTransformer(BaseTransformer):
         from levels 1 to num_levels followed by the approximation
         coefficients of the highest level.
         """
-        num_levels = self.num_levels
+        num_levels = self.n_levels
         res = []
 
         for x in data:
@@ -96,14 +105,14 @@ class DWTTransformer(BaseTransformer):
         ------
         ValueError or TypeError if a parameters input is invalid.
         """
-        if isinstance(self.num_levels, int):
-            if self.num_levels <= -1:
+        if isinstance(self.n_levels, int):
+            if self.n_levels <= -1:
                 raise ValueError("num_levels must have the value" + "of at least 0")
         else:
             raise TypeError(
                 "num_levels must be an 'int'. Found"
                 + "'"
-                + type(self.num_levels).__name__
+                + type(self.n_levels).__name__
                 + "' instead."
             )
 

--- a/aeon/transformations/panel/tests/test_dwt.py
+++ b/aeon/transformations/panel/tests/test_dwt.py
@@ -16,17 +16,17 @@ def test_bad_input_args(bad_num_levels):
 
     if not isinstance(bad_num_levels, int):
         with pytest.raises(TypeError):
-            DWTTransformer(num_levels=bad_num_levels).fit_transform(X)
+            DWTTransformer(n_levels=bad_num_levels).fit_transform(X)
     else:
         with pytest.raises(ValueError):
-            DWTTransformer(num_levels=bad_num_levels).fit(X).transform(X)
+            DWTTransformer(n_levels=bad_num_levels).fit(X).transform(X)
 
 
 # Check the transformer has changed the data correctly.
 def test_output_of_transformer():
     X = np.array([[[4, 6, 10, 12, 8, 6, 5, 5]]])
 
-    d = DWTTransformer(num_levels=2).fit(X)
+    d = DWTTransformer(n_levels=2).fit(X)
     res = d.transform(X)
     orig = np.array([[[16, 12, -6, 2, -math.sqrt(2), -math.sqrt(2), math.sqrt(2), 0]]])
     np.testing.assert_array_almost_equal(res, orig)
@@ -55,7 +55,7 @@ def test_output_of_transformer():
 # This is to test that if num_levels = 0 then no change occurs.
 def test_no_levels_does_no_change():
     X = np.array([[[1, 2, 3, 4, 5, 56]]])
-    d = DWTTransformer(num_levels=0).fit(X)
+    d = DWTTransformer(n_levels=0).fit(X)
     res = d.transform(X)
     np.testing.assert_array_almost_equal(res, X)
 
@@ -63,7 +63,7 @@ def test_no_levels_does_no_change():
 @pytest.mark.parametrize("num_levels,corr_series_length", [(2, 12), (3, 11), (4, 12)])
 def test_output_dimensions(num_levels, corr_series_length):
     X = np.ones(shape=(10, 1, 13))
-    d = DWTTransformer(num_levels=num_levels).fit(X)
+    d = DWTTransformer(n_levels=num_levels).fit(X)
     res = d.transform(X)
 
     n_cases, n_channels, series_length = res.shape
@@ -76,7 +76,7 @@ def test_output_dimensions(num_levels, corr_series_length):
 # This is to check that DWT produces the same result along each dimension
 def test_dwt_performs_correcly_along_each_dim():
     X = np.array([[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]])
-    d = DWTTransformer(num_levels=3).fit(X)
+    d = DWTTransformer(n_levels=3).fit(X)
     res = d.transform(X)
     orig = np.array(
         [

--- a/aeon/transformations/panel/tests/test_dwt.py
+++ b/aeon/transformations/panel/tests/test_dwt.py
@@ -2,11 +2,9 @@
 import math
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from aeon.transformations.panel.dwt import DWTTransformer
-from aeon.utils._testing.panel import _make_nested_from_array
 
 
 # Check that exception is raised for bad num levels.
@@ -14,11 +12,11 @@ from aeon.utils._testing.panel import _make_nested_from_array
 # correct input is meant to be a positive integer of 0 or more.
 @pytest.mark.parametrize("bad_num_levels", ["str", 1.2, -1.2, -1, {}])
 def test_bad_input_args(bad_num_levels):
-    X = _make_nested_from_array(np.ones(10), n_instances=10, n_columns=1)
+    X = np.ones(shape=(10, 1, 10))
 
     if not isinstance(bad_num_levels, int):
         with pytest.raises(TypeError):
-            DWTTransformer(num_levels=bad_num_levels).fit(X).transform(X)
+            DWTTransformer(num_levels=bad_num_levels).fit_transform(X)
     else:
         with pytest.raises(ValueError):
             DWTTransformer(num_levels=bad_num_levels).fit(X).transform(X)
@@ -26,128 +24,86 @@ def test_bad_input_args(bad_num_levels):
 
 # Check the transformer has changed the data correctly.
 def test_output_of_transformer():
-    X = _make_nested_from_array(
-        np.array([4, 6, 10, 12, 8, 6, 5, 5]), n_instances=1, n_columns=1
-    )
+    X = np.array([[[4, 6, 10, 12, 8, 6, 5, 5]]])
 
     d = DWTTransformer(num_levels=2).fit(X)
     res = d.transform(X)
-    orig = convert_list_to_dataframe(
-        [[16, 12, -6, 2, -math.sqrt(2), -math.sqrt(2), math.sqrt(2), 0]]
-    )
-    orig.columns = X.columns
-    assert check_if_dataframes_are_equal(res, orig)
-
-    X = _make_nested_from_array(
-        np.array([-5, 2.5, 1, 3, 10, -1.5, 6, 12, -3]), n_instances=1, n_columns=1
-    )
+    orig = np.array([[[16, 12, -6, 2, -math.sqrt(2), -math.sqrt(2), math.sqrt(2), 0]]])
+    np.testing.assert_array_almost_equal(res, orig)
+    X = np.array([[[-5, 2.5, 1, 3, 10, -1.5, 6, 12, -3]]])
     d = d.fit(X)
     res = d.transform(X)
-    orig = convert_list_to_dataframe(
+    orig = np.array(
         [
             [
-                0.75000,
-                13.25000,
-                -3.25000,
-                -4.75000,
-                -5.303301,
-                -1.414214,
-                8.131728,
-                -4.242641,
+                [
+                    0.75000,
+                    13.25000,
+                    -3.25000,
+                    -4.75000,
+                    -5.303301,
+                    -1.414214,
+                    8.131728,
+                    -4.242641,
+                ]
             ]
         ]
     )
-    # These are equivalent but cannot exactly test if two floats are equal
-    # res.iloc[0,0]
-    # orig.iloc[0,0]
-    # assert check_if_dataframes_are_equal(res,orig)
+    np.testing.assert_array_almost_equal(res, orig)
 
 
 # This is to test that if num_levels = 0 then no change occurs.
 def test_no_levels_does_no_change():
-    X = _make_nested_from_array(
-        np.array([1, 2, 3, 4, 5, 56]), n_instances=1, n_columns=1
-    )
+    X = np.array([[[1, 2, 3, 4, 5, 56]]])
     d = DWTTransformer(num_levels=0).fit(X)
     res = d.transform(X)
-    assert check_if_dataframes_are_equal(res, X)
+    np.testing.assert_array_almost_equal(res, X)
 
 
 @pytest.mark.parametrize("num_levels,corr_series_length", [(2, 12), (3, 11), (4, 12)])
 def test_output_dimensions(num_levels, corr_series_length):
-    X = _make_nested_from_array(np.ones(13), n_instances=10, n_columns=1)
-
+    X = np.ones(shape=(10, 1, 13))
     d = DWTTransformer(num_levels=num_levels).fit(X)
     res = d.transform(X)
 
-    # get the dimension of the generated dataframe.
-    act_time_series_length = res.iloc[0, 0].shape[0]
-    num_rows = res.shape[0]
-    num_cols = res.shape[1]
+    n_cases, n_channels, series_length = res.shape
 
-    assert act_time_series_length == corr_series_length
-    assert num_rows == 10
-    assert num_cols == 1
+    assert series_length == corr_series_length
+    assert n_cases == 10
+    assert n_channels == 1
 
 
 # This is to check that DWT produces the same result along each dimension
 def test_dwt_performs_correcly_along_each_dim():
-    X = _make_nested_from_array(
-        np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), n_instances=1, n_columns=2
-    )
-
+    X = np.array([[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]])
     d = DWTTransformer(num_levels=3).fit(X)
     res = d.transform(X)
-    orig = convert_list_to_dataframe(
+    orig = np.array(
         [
             [
-                9 * math.sqrt(2),
-                -4 * math.sqrt(2),
-                -2,
-                -2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-            ],
-            [
-                9 * math.sqrt(2),
-                -4 * math.sqrt(2),
-                -2,
-                -2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-                -math.sqrt(2) / 2,
-            ],
+                [
+                    9 * math.sqrt(2),
+                    -4 * math.sqrt(2),
+                    -2,
+                    -2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                ],
+                [
+                    9 * math.sqrt(2),
+                    -4 * math.sqrt(2),
+                    -2,
+                    -2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                    -math.sqrt(2) / 2,
+                ],
+            ]
         ]
     )
-    orig.columns = X.columns
-    assert check_if_dataframes_are_equal(res, orig)
-
-
-def convert_list_to_dataframe(list_to_convert):
-    # Convert this into a panda's data frame
-    df = pd.DataFrame()
-    for i in range(len(list_to_convert)):
-        inst = list_to_convert[i]
-        data = []
-        data.append(pd.Series(inst))
-        df[i] = data
-
-    return df
-
-
-def check_if_dataframes_are_equal(df1, df2):
-    """
-    for some reason, this is how you check that two dataframes are equal.
-    """
-    from pandas.testing import assert_frame_equal
-
-    try:
-        assert_frame_equal(df1, df2)
-        return True
-    except AssertionError:
-        return False
+    np.testing.assert_array_almost_equal(res, orig)


### PR DESCRIPTION
and another one, doing them one PR at a time to avoid big PRs. This could be made faster with numba I'm sure. Like PAA, it does the weird reshape to allow for channel-wise transform, simply to conform to existing code. This could also possibly be done better. 

Reference Issues/PRs
fixws #98 
part of #197 #110  
