### PR TITLE
[ENH] combine test_returns_self with test_fit_updates_state

### DIFF
--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -142,7 +142,6 @@ EXCLUDED_TESTS = {
         "test_inheritance",
         "test_create_test_instance",
     ],
-    "SAX": "test_fit_transform_output",  # SAX returns strange output format
     # this needs to be fixed, was not tested previously due to legacy exception
     "Prophet": ":test_hierarchical_with_exogeneous",
     # Prophet does not support datetime indices, see #2475 for the known issue
@@ -166,10 +165,6 @@ NON_STATE_CHANGING_METHODS_ARRAYLIKE = (
     "predict_proba",
     "decision_function",
     "transform",
-    # todo: add this back
-    # escaping this, since for some estimators
-    #   the input format of inverse_transform assumes special col names
-    # "inverse_transform",
 )
 
 NON_STATE_CHANGING_METHODS = NON_STATE_CHANGING_METHODS_ARRAYLIKE + (

--- a/aeon/tests/test_all_estimators.py
+++ b/aeon/tests/test_all_estimators.py
@@ -1085,19 +1085,16 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
             ), f"Estimator: {estimator} does not initiate attribute: {attr} to False"
 
         fitted_estimator = scenario.run(estimator_instance, method_sequence=["fit"])
+        # Check fit returns self
+        assert (
+            fitted_estimator is estimator_instance
+        ), f"Estimator: {estimator_instance} does not return self when calling fit"
 
         # Check 0s_fitted attribute is updated correctly to False after calling fit
         for attr in attrs:
             assert getattr(
                 fitted_estimator, attr
             ), f"Estimator: {estimator} does not update attribute: {attr} during fit"
-
-    def test_fit_returns_self(self, estimator_instance, scenario):
-        """Check that fit returns self."""
-        fit_return = scenario.run(estimator_instance, method_sequence=["fit"])
-        assert (
-            fit_return is estimator_instance
-        ), f"Estimator: {estimator_instance} does not return self when calling fit"
 
     def test_raises_not_fitted_error(self, estimator_instance, scenario, method_nsc):
         """Check exception raised for non-fit method calls to unfitted estimators.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,14 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
+    --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,6 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
test_all_estimators calls fit a very large number of times. Whislt I appreciate having clear tests that do things independently, the state of testing is so slow, I think its worth combining some of them to reduce the calls to fit. 

test_returns_self takes about a minute and calls fit on everything, testing if self is returned. I have rolled this into test_fit_updates_state, using the call to fit there to test self and to print the same error message. This takes it locally down from 13mins 6 sec to 11m 43s (not including loading). Every little helps!

there are other similar compromises we could make here to reduce the number of fit calls. Real pig is forecasting though, need to address that at some point