### PR TITLE
[ENH] Removes nested dataframes from shape dtw

### DIFF
--- a/aeon/classification/_dummy.py
+++ b/aeon/classification/_dummy.py
@@ -81,8 +81,7 @@ class DummyClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-format pandas dataframe with shape(n,d),
-        or numpy ndarray with shape(n,d,m)
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
         y : array-like, shape = [n_instances] - the class labels
 
         Returns
@@ -110,7 +109,7 @@ class DummyClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-format pandas dataframe or array-like, shape (n, d)
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
 
         Returns
         -------

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -198,12 +198,8 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array (any number of channels, equal length series)
-                of shape [n_instances, n_channels, series_length]
-            or 2D np.array (univariate, equal length series)
-                of shape [n_instances, series_length]
-            or pd.DataFrame with each column a dimension, each cell a pd.Series
-                (any number of channels, equal or unequal length series)
+        X : 3D np.array of shape (n_instances, n_channels, series_length)
+            or 2D np.array of shape (n_instances, series_length)
 
         Returns
         -------
@@ -227,14 +223,12 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array (any number of channels, equal length series)
-                of shape [n_cases, n_channels, series_length]
-            or 2D np.array (univariate, equal length series)
-                of shape [n_cases, series_length]
+        X : 3D np.array of shape (n_cases, n_channels, series_length)
+            or 2D np.array of shape (n_cases, series_length)
 
         Returns
         -------
-        y : 2D array of shape [n_cases, n_classes] - predicted class probabilities
+        y : 2D array of shape (n_cases, n_classes) - predicted class probabilities
             First dimension indices correspond to instance indices in X,
             second dimension indices correspond to class labels, (i, j)-th entry is
             estimated probability that i-th instance is of class j

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -443,7 +443,7 @@ class BaseClassifier(BaseEstimator, ABC):
                 raise ValueError(msg)
 
     def _convert_X(self, X):
-        """Convert equal length series from DataFrame to numpy array or vice versa.
+        """Convert to inner type.
 
         Parameters
         ----------

--- a/aeon/classification/compose/_channel_ensemble.py
+++ b/aeon/classification/compose/_channel_ensemble.py
@@ -330,8 +330,6 @@ def _get_channel(X, key):
             "strings, or boolean mask is allowed"
         )
 
-    # ensure that pd.DataFrame is returned rather than
-    # pd.Series
     if isinstance(key, (int, str)):
         key = [key]
 

--- a/aeon/classification/compose/_channel_ensemble.py
+++ b/aeon/classification/compose/_channel_ensemble.py
@@ -126,18 +126,14 @@ class _BaseChannelEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier)
             yield name, estimator, channel
 
     def _fit(self, X, y):
-        # the data passed in could be an array of dataframes?
         """Fit all estimators, fit the data.
 
         Parameters
         ----------
-        X : array-like or DataFrame of shape [n_samples, n_channels,
-        n_length]
-            Input data, of which specified subsets are used to fit the
-            transformations.
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
 
-        y : array-like, shape (n_samples, ...), optional
-            Targets for supervised learning.
+        y : array-like, shape = [n_instances]
+            The class labels.
 
         """
         if self.estimators is None or len(self.estimators) == 0:

--- a/aeon/classification/deep_learning/inception_time.py
+++ b/aeon/classification/deep_learning/inception_time.py
@@ -541,17 +541,6 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
             n_channels is assumed to be 1.
         y : array-like, shape = (n_instances)
             The training data class labels.
-        input_checks : boolean
-            whether to check the X and y parameters
-        validation_X : array-like of shape = (n_instances, series_length, n_channels)
-            The validation samples. If a 2D array-like is passed,
-            n_channels is assumed to be 1.
-            Unless strictly defined by the user via callbacks (such as
-            EarlyStopping), the presence or state of the validation
-            data does not alter training in any way. Predictions at each epoch
-            are stored in the model's fit history.
-        validation_y : array-like, shape = (n_instances)
-            The validation class labels.
 
         Returns
         -------

--- a/aeon/classification/deep_learning/inception_time.py
+++ b/aeon/classification/deep_learning/inception_time.py
@@ -539,19 +539,18 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
         X : array-like of shape = (n_instances, n_channels, series_length)
             The training input samples. If a 2D array-like is passed,
             n_channels is assumed to be 1.
-        y : array-like, shape = [n_instances]
+        y : array-like, shape = (n_instances)
             The training data class labels.
         input_checks : boolean
             whether to check the X and y parameters
-        validation_X : a nested pd.Dataframe, or array-like of shape =
-        (n_instances, series_length, n_channels)
+        validation_X : array-like of shape = (n_instances, series_length, n_channels)
             The validation samples. If a 2D array-like is passed,
             n_channels is assumed to be 1.
             Unless strictly defined by the user via callbacks (such as
             EarlyStopping), the presence or state of the validation
             data does not alter training in any way. Predictions at each epoch
             are stored in the model's fit history.
-        validation_y : array-like, shape = [n_instances]
+        validation_y : array-like, shape = (n_instances)
             The validation class labels.
 
         Returns

--- a/aeon/classification/dictionary_based/_muse.py
+++ b/aeon/classification/dictionary_based/_muse.py
@@ -168,8 +168,8 @@ class MUSE(BaseClassifier):
 
         Parameters
         ----------
-        X : nested pandas DataFrame of shape [n_instances, 1]
-            Nested dataframe with univariate time-series in cells.
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
         y : array-like, shape = [n_instances]
             The class labels.
 
@@ -262,8 +262,7 @@ class MUSE(BaseClassifier):
 
         Parameters
         ----------
-        X : nested pandas DataFrame of shape [n_instances, 1]
-            Nested dataframe with univariate time-series in cells.
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
 
         Returns
         -------
@@ -278,8 +277,7 @@ class MUSE(BaseClassifier):
 
         Parameters
         ----------
-        X : nested pandas DataFrame of shape [n_instances, 1]
-            Nested dataframe with univariate time-series in cells.
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
 
         Returns
         -------

--- a/aeon/classification/distance_based/_shape_dtw.py
+++ b/aeon/classification/distance_based/_shape_dtw.py
@@ -135,7 +135,7 @@ class ShapeDTW(BaseClassifier):
 
         Parameters
         ----------
-        X - pandas dataframe of training data of shape [n_instances,1].
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
         y - list of class labels of shape [n_instances].
 
         Returns
@@ -182,7 +182,7 @@ class ShapeDTW(BaseClassifier):
 
         Parameters
         ----------
-        X - training data in a dataframe of shape [n_instances,1]
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
         y - training data classes of shape [n_instances].
         """
         self._metric_params = {k.lower(): v for k, v in self._metric_params.items()}
@@ -257,7 +257,7 @@ class ShapeDTW(BaseClassifier):
 
         Parameters
         ----------
-        X - pandas dataframe of testing data of shape [n_instances,1].
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
 
         Returns
         -------

--- a/aeon/classification/distance_based/_shape_dtw.py
+++ b/aeon/classification/distance_based/_shape_dtw.py
@@ -243,8 +243,6 @@ class ShapeDTW(BaseClassifier):
         # and then performs the shape descriptor function on
         # each subsequence.
         _X = self.sw.transform(X)
-        # Temporary until conversion complete
-        # X = from_3d_numpy_to_nested(X)
         # Feed X into the appropriate shape descriptor function
         _X = self._generate_shape_descriptors(_X)
 

--- a/aeon/classification/distance_based/_shape_dtw.py
+++ b/aeon/classification/distance_based/_shape_dtw.py
@@ -16,7 +16,6 @@ from aeon.classification.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesClassifier,
 )
 from aeon.datatypes import convert
-from aeon.datatypes._panel._convert import from_3d_numpy_to_nested
 from aeon.transformations.panel.dictionary_based._paa import PAA
 from aeon.transformations.panel.dwt import DWTTransformer
 
@@ -248,13 +247,13 @@ class ShapeDTW(BaseClassifier):
         # the test/training data. It extracts the subsequences
         # and then performs the shape descriptor function on
         # each subsequence.
-        X = self.sw.transform(X)
+        _X = self.sw.transform(X)
         # Temporary until conversion complete
-        X = from_3d_numpy_to_nested(X)
+        # X = from_3d_numpy_to_nested(X)
         # Feed X into the appropriate shape descriptor function
-        X = self._generate_shape_descriptors(X)
+        _X = self._generate_shape_descriptors(_X)
 
-        return X
+        return _X
 
     def _predict_proba(self, X) -> np.ndarray:
         """Perform predictions on the testing data X.
@@ -316,28 +315,27 @@ class ShapeDTW(BaseClassifier):
                 )
 
         # To hold the result of each transformer
-        dataFrames = []
-        col_names = list(range(len(data.columns)))
+        trans_data = []
 
         # Apply each transformer on the set of subsequences
         for t in self.transformer:
             if t is None:
                 # Do no transformations
-                dataFrames.append(data)
+                trans_data.append(data)
             else:
                 # Do the transformation and extract the resulting data frame.
                 t.fit(data)
                 newData = t.transform(data)
-                dataFrames.append(newData)
+                trans_data.append(newData)
 
-        # Combine the arrays into one dataframe
+        # Combine the arrays into one numpy array
         if self.shape_descriptor_function == "compound":
-            result = self._combine_data_frames(
-                dataFrames, self.weighting_factor, col_names
-            )
+            result = np.array(trans_data)
+        #            result = self._combine_data_frames(
+        #                trans_data, self.weighting_factor, col_names
+        #            )
         else:
-            result = dataFrames[0]
-            result.columns = col_names
+            result = trans_data[0]
 
         return result
 

--- a/aeon/classification/early_classification/base.py
+++ b/aeon/classification/early_classification/base.py
@@ -571,7 +571,7 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         Returns
         -------
         X : input X converted to type in "X_inner_mtype" tag
-                usually a pd.DataFrame (nested) or 3D np.ndarray
+                usually a 3D np.ndarray
             Checked and possibly converted input data
         """
         _convert_X = BaseClassifier._convert_X

--- a/aeon/classification/feature_based/_signature_classifier.py
+++ b/aeon/classification/feature_based/_signature_classifier.py
@@ -153,9 +153,8 @@ class SignatureClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : nested pandas DataFrame of shape [n_instances, n_dims]
-            Nested dataframe with univariate time-series in cells.
-        y : array-like, shape = [n_instances] The class labels.
+        X : np.ndarray of shape (n_cases, n_channels, series_length)
+        y : array-like, shape = (n_instances) The class labels.
 
         Returns
         -------
@@ -176,7 +175,7 @@ class SignatureClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : pd.DataFrame of shape (n_instances, n_dims)
+        X : np.ndarray of shape (n_cases, n_channels, series_length)
 
         Returns
         -------
@@ -192,7 +191,7 @@ class SignatureClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : pd.DataFrame of shape (n_instances, n_dims)
+        X : np.ndarray of shape (n_cases, n_channels, series_length)
 
         Returns
         -------

--- a/aeon/classification/sklearn/_rotation_forest.py
+++ b/aeon/classification/sklearn/_rotation_forest.py
@@ -103,7 +103,6 @@ class RotationForest(BaseEstimator):
     --------
     >>> from aeon.classification.sklearn import RotationForest
     >>> from aeon.datasets import load_unit_test
-    >>> from aeon.datatypes._panel._convert import from_nested_to_3d_numpy
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = RotationForest(n_estimators=10)

--- a/aeon/classification/tests/_classification_test_reproduction.py
+++ b/aeon/classification/tests/_classification_test_reproduction.py
@@ -34,7 +34,6 @@ from aeon.classification.interval_based import (
 )
 from aeon.classification.shapelet_based import ShapeletTransformClassifier
 from aeon.datasets import load_basic_motions, load_unit_test
-from aeon.datatypes._panel._convert import from_nested_to_3d_numpy
 from aeon.transformations.panel.catch22 import Catch22
 from aeon.transformations.panel.catch22wrapper import Catch22Wrapper
 from aeon.transformations.panel.random_intervals import RandomIntervals

--- a/aeon/classification/tests/test_base.py
+++ b/aeon/classification/tests/test_base.py
@@ -206,14 +206,14 @@ def _create_unequal_length_nested_dataframe(cases=5, dimensions=1, length=10):
     return testy
 
 
-MTYPES = ["numpy3D", "pd-multiindex", "df-list", "numpyflat"]
+INPUT_TYPES = ["numpy3D", "pd-multiindex", "df-list", "numpyflat"]
 
 
-@pytest.mark.parametrize("mtype", MTYPES)
-def test_input_conversion_fit_predict(mtype):
+@pytest.mark.parametrize("input_type", INPUT_TYPES)
+def test_input_conversion_fit_predict(input_type):
     """Test that base class lets all valid input types through."""
     y = _make_classification_y()
-    X = _make_panel(return_mtype=mtype)
+    X = _make_panel(return_mtype=input_type)
 
     clf = DummyClassifier()
     clf.fit(X, y)

--- a/aeon/regression/deep_learning/inception_time.py
+++ b/aeon/regression/deep_learning/inception_time.py
@@ -514,18 +514,6 @@ class IndividualInceptionRegressor(BaseDeepRegressor):
             n_channels is assumed to be 1.
         y : np.ndarray of shape (n_instances)
             The training data target values.
-        input_checks : boolean
-            whether to check the X and y parameters
-        validation_X : a nested pd.Dataframe, or array-like of shape =
-        (n_instances, series_length, n_channels)
-            The validation samples. If a 2D array-like is passed,
-            n_channels is assumed to be 1.
-            Unless strictly defined by the user via callbacks (such as
-            EarlyStopping), the presence or state of the validation
-            data does not alter training in any way. Predictions at each epoch
-            are stored in the model's fit history.
-        validation_y : array-like, shape = [n_instances]
-            The validation target values.
 
         Returns
         -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,14 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
+    --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,6 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
This removes the nested_univ from ShapeDTW (also fixes a couple of bugs I found there with "compound" option) and also removes doc string mentions to using nested Pandas dataframes. There is no usage of the nested_univ input type in classification, regression or clustering. There are still some transformations to do, and some testing to revise

#### Reference Issues/PRs
Part of #110 

