### PR TITLE
[ENH] purge mentions of Panel in classification

### DIFF
--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -382,11 +382,11 @@ class BaseClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : any object (to check/convert)
-            should be of a supported Panel mtype or 2D numpy.ndarray
+            should be of a supported Collection type or 2D numpy.ndarray
 
         Returns
         -------
-        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        X: an object of a supported Collection type, numpy3D if X was a 2D numpy.ndarray
 
         Raises
         ------

--- a/aeon/classification/dictionary_based/_weasel_v2.py
+++ b/aeon/classification/dictionary_based/_weasel_v2.py
@@ -311,18 +311,6 @@ class WEASELTransformerV2:
         Seed for random, integer
     """
 
-    # _tags = {
-    #     "univariate-only": True,
-    #     "scitype:transform-input": "Series",
-    #     # what is the scitype of X: Series, or Panel
-    #     "scitype:transform-output": "Series",
-    #     # what scitype is returned: Primitives, Series, Panel
-    #     "scitype:instancewise": False,  # is this an instance-wise transform?
-    #     "X_inner_mtype": "numpy3D",  # which mtypes do _fit/_predict support for X?
-    #     "y_inner_mtype": "pd_Series_Table",  # which mtypes does y require?
-    #     "requires_y": True,  # does y need to be passed in fit?
-    # }
-
     def __init__(
         self,
         min_window=4,

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -95,9 +95,10 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-compatible Panel data format, with n_samples series
-        y : {array-like, sparse matrix}
-            Class labels of shape = [n_samples]
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
+        y : array-like, shape = [n_instances]
+            The class labels.
         """
         if isinstance(self.distance, str):
             if self.distance_params is None:
@@ -116,11 +117,12 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-compatible Panel data format, with n_samples series
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
 
         Returns
         -------
-        p : array of shape = [n_samples, n_classes]
+        p : array of shape = [n_instances, n_classes]
             The class probabilities of the input samples. Classes are ordered
             by lexicographic order.
         """
@@ -142,11 +144,12 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-compatible Panel data format, with n_samples series
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
 
         Returns
         -------
-        y : array of shape [n_samples] or [n_samples, n_outputs]
+        y : array of shape [n_instances]
             Class labels for each data sample.
         """
         self.check_is_fitted()
@@ -170,7 +173,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : aeon-compatible data format, Panel or Series, with n_samples series
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
 
         Returns
         -------

--- a/aeon/classification/early_classification/base.py
+++ b/aeon/classification/early_classification/base.py
@@ -530,11 +530,11 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : any object (to check/convert)
-            should be of a supported Panel mtype or 2D numpy.ndarray
+            should be of a supported input type or 2D numpy.ndarray
 
         Returns
         -------
-        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        X: an object of a supported input type, numpy3D if X was a 2D numpy.ndarray
 
         Raises
         ------
@@ -584,7 +584,7 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : check whether conformant with any aeon Panel mtype specification
+        X : check whether conformant with any aeon input type specification
         y : check whether a pd.Series or np.array
         enforce_min_cases : int, optional (default=1)
             check there are a minimum number of instances.
@@ -609,12 +609,12 @@ class BaseEarlyClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : an object of a supported Panel mtype, or 2D numpy.ndarray
+        X : an object of a supported input type including 2D numpy.ndarray
         y : np.ndarray or pd.Series
 
         Returns
         -------
-        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        X: an object of a supported input type, numpy3D if X was a 2D numpy.ndarray
         y: np.ndarray
         """
         _internal_convert = BaseClassifier._internal_convert

--- a/aeon/classification/sklearn/_rotation_forest.py
+++ b/aeon/classification/sklearn/_rotation_forest.py
@@ -103,7 +103,6 @@ class RotationForest(BaseEstimator):
     --------
     >>> from aeon.classification.sklearn import RotationForest
     >>> from aeon.datasets import load_unit_test
-    >>> from aeon.datatypes._panel._convert import from_nested_to_3d_numpy
     >>> X_train, y_train = load_unit_test(split="train")
     >>> X_test, y_test = load_unit_test(split="test")
     >>> clf = RotationForest(n_estimators=10)

--- a/aeon/classification/tests/test_sklearn_compatability.py
+++ b/aeon/classification/tests/test_sklearn_compatability.py
@@ -86,7 +86,8 @@ COMPOSITE_ESTIMATORS = [
 
 @pytest.mark.parametrize("data_args", DATA_ARGS)
 def test_sklearn_cross_validation(data_args):
-    """Test sklearn cross-validation works with aeon panel data and classifiers."""
+    """Test sklearn cross-validation works with aeon time series data and
+    classifiers."""
     clf = CanonicalIntervalForest.create_test_instance()
     fit_args = make_classification_problem(**data_args)
 
@@ -97,7 +98,7 @@ def test_sklearn_cross_validation(data_args):
 @pytest.mark.parametrize("data_args", DATA_ARGS)
 @pytest.mark.parametrize("cross_validation_method", CROSS_VALIDATION_METHODS)
 def test_sklearn_cross_validation_iterators(data_args, cross_validation_method):
-    """Test if sklearn cross-validation iterators can handle aeon panel data."""
+    """Test if sklearn cross-validation iterators can handle aeon time series data."""
     fit_args = make_classification_problem(**data_args)
     groups = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10]
 
@@ -108,7 +109,7 @@ def test_sklearn_cross_validation_iterators(data_args, cross_validation_method):
 @pytest.mark.parametrize("data_args", DATA_ARGS)
 @pytest.mark.parametrize("parameter_tuning_method", PARAMETER_TUNING_METHODS)
 def test_sklearn_parameter_tuning(data_args, parameter_tuning_method):
-    """Test if sklearn parameter tuners can handle aeon panel data and classifiers."""
+    """Test if sklearn parameter tuners can handle aeon data and classifiers."""
     clf = CanonicalIntervalForest.create_test_instance()
     param_grid = {"n_intervals": [2, 3], "att_subsample_size": [2, 3]}
     fit_args = make_classification_problem(**data_args)

--- a/aeon/regression/base.py
+++ b/aeon/regression/base.py
@@ -116,11 +116,11 @@ class BaseRegressor(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array (any number of dimensions, equal length series)
-                of shape [n_instances, n_dimensions, series_length]
+        X : 3D np.array (any number of channels, equal length series)
+                of shape [n_instances, n_channels, series_length]
             or 2D np.array (univariate, equal length series)
                 of shape [n_instances, series_length]
-            or of any other supported Panel mtype
+            or of any other supported input type
                 for list of mtypes, see datatypes.SCITYPE_REGISTER
         y : 1D np.array of float, of shape [n_instances] - regression labels for fitting
             indices correspond to instance indices in X
@@ -167,11 +167,11 @@ class BaseRegressor(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array (any number of dimensions, equal length series)
-                of shape [n_instances, n_dimensions, series_length]
+        X : 3D np.array (any number of channels, equal length series)
+                of shape [n_instances, n_channels, series_length]
             or 2D np.array (univariate, equal length series)
                 of shape [n_instances, series_length]
-            or of any other supported Panel mtype
+            or of any other supported input type
                 for list of mtypes, see datatypes.SCITYPE_REGISTER
 
         Returns
@@ -191,8 +191,8 @@ class BaseRegressor(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array (any number of dimensions, equal length series)
-                of shape [n_instances, n_dimensions, series_length]
+        X : 3D np.array (any number of channels, equal length series)
+                of shape [n_instances, n_channels, series_length]
             or 2D np.array (univariate, equal length series)
                 of shape [n_instances, series_length]
             or of any other supported type
@@ -220,7 +220,7 @@ class BaseRegressor(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+                3D np.ndarray of shape = [n_instances, n_channels, series_length]
             for list of other mtypes, see datatypes.SCITYPE_REGISTER
         y : 1D np.array of float, of shape [n_instances] - regression labels for fitting
             indices correspond to instance indices in X
@@ -245,7 +245,7 @@ class BaseRegressor(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+                3D np.ndarray of shape = [n_instances, n_channels, series_length]
             for list of other mtypes, see datatypes.SCITYPE_REGISTER
 
         Returns
@@ -261,11 +261,11 @@ class BaseRegressor(BaseEstimator, ABC):
         Parameters
         ----------
         X : any object (to check/convert)
-            should be of a supported Panel mtype or 2D numpy.ndarray
+            should be of a supported input type including 2D numpy.ndarray
 
         Returns
         -------
-        X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+        X: an object of a supported input type, numpy3D if X was a 2D numpy.ndarray
 
         Raises
         ------
@@ -364,7 +364,7 @@ def _check_regressor_input(
 
     Parameters
     ----------
-    X : check whether conformant with any aeon Panel mtype specification
+    X : check whether X is a valid input type
     y : check whether a pd.Series or np.array
     enforce_min_instances : int, optional (default=1)
         check there are a minimum number of instances.
@@ -383,7 +383,7 @@ def _check_regressor_input(
     if not X_valid:
         raise TypeError(
             f"X is not of a supported input data type."
-            f"X must be in a supported mtype format for Panel, found {type(X)}"
+            f"X must be in a supported type format for Regression, found {type(X)}"
             f"Use datatypes.check_is_mtype to check conformance with specifications."
         )
     n_cases = X_metadata["n_instances"]
@@ -411,7 +411,7 @@ def _check_regressor_input(
             if y.ndim > 1:
                 raise ValueError(
                     f"np.ndarray y must be 1-dimensional, "
-                    f"but found {y.ndim} dimensions"
+                    f"but found {y.ndim} channels"
                 )
     return X_metadata
 
@@ -424,12 +424,12 @@ def _internal_convert(X, y=None):
 
     Parameters
     ----------
-    X : an object of a supported Panel mtype, or 2D numpy.ndarray
+    X : an object of a supported input type including 2D numpy.ndarray
     y : np.ndarray or pd.Series
 
     Returns
     -------
-    X: an object of a supported Panel mtype, numpy3D if X was a 2D numpy.ndarray
+    X: an object of a supported input type, numpy3D if X was a 2D numpy.ndarray
     y: np.ndarray
     """
     if isinstance(X, np.ndarray):

--- a/aeon/regression/distance_based/_time_series_neighbors.py
+++ b/aeon/regression/distance_based/_time_series_neighbors.py
@@ -43,7 +43,6 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
                                 metric='mpdist', metric_params={'m':30})
         if callable, must be of signature (X: np.ndarray, X2: np.ndarray) -> np.ndarray
             output must be mxn array if X is array of m Series, X2 of n Series
-        can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
         dictionary for metric parameters , in case that distance is a str
 
@@ -89,9 +88,10 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
 
         Parameters
         ----------
-        X : aeon-compatible Panel data format, with n_samples series
-        y : {array-like, sparse matrix}
-            Target values of shape = [n_samples]
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
+        y : array-like, shape = [n_instances]
+            The class labels.
         """
         if isinstance(self.distance, str):
             if self.distance_params is None:
@@ -110,11 +110,12 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
 
         Parameters
         ----------
-        X : aeon-compatible Panel data format, with n_samples series
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
 
         Returns
         -------
-        y : array of shape [n_samples] or [n_samples, n_outputs]
+        y : array of shape [n_instances]
             Target values for each data sample.
         """
         self.check_is_fitted()
@@ -133,7 +134,8 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
 
         Parameters
         ----------
-        X : aeon-compatible data format, Panel or Series, with n_samples series
+        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
+            The training data.
 
         Returns
         -------


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #42 

#### What does this implement/fix? Explain your changes.

Purely cosmetic PR removes mentions of the term Panel from classification, clustering and regression which to machine learning people  has no meaning at all. mtype generally changed to input type. Left the pipelines alone, they are of marginal use. Not changed any code, conversion and checking changes comes later. 
 