### PR TITLE
[DOC] Remove meetup and sponsor cards from get involved

### DIFF
--- a/docs/get_involved.rst
+++ b/docs/get_involved.rst
@@ -9,7 +9,6 @@ Get Involved
 
    get_involved/contributing
    get_involved/mentoring
-   get_involved/meetups
    get_involved/code_of_conduct
    get_involved/governance
 
@@ -54,42 +53,6 @@ If you get stuck, please don’t hesitate to chat with us or raise an issue.
             :expand:
 
             Mentoring
-
-    .. grid-item-card::
-        :text-align: center
-
-        Sponsoring
-
-        ^^^
-
-        Fund aeon maintenance and development.
-
-        +++
-
-        .. button-link:: https://opencollective.com/aeon
-            :color: primary
-            :click-parent:
-            :expand:
-
-            Donate
-
-    .. grid-item-card::
-        :text-align: center
-
-        Meet-ups
-
-        ^^^
-
-        Join our discussions, tutorials, workshops and sprints!
-
-        +++
-
-        .. button-ref:: meetups
-            :color: primary
-            :click-parent:
-            :expand:
-
-            Participate
 
     .. grid-item-card::
         :text-align: center

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,14 +153,13 @@ installation
 get_started
 api_reference
 examples.md
-get_involved
-users
 ```
 
 ```{toctree}
 :caption: Developing aeon
 :hidden:
 
+get_involved
 developers
 ```
 
@@ -170,4 +169,11 @@ developers
 
 contributors.md
 about.md
+```
+
+```{toctree}
+:caption: Other
+:hidden:
+
+users
 ```


### PR DESCRIPTION
The meetups page no longer exists, and the sponsor buttons links to some random open collective (https://opencollective.com/aeon)