### PR TITLE
[MNT] Remove test_fit_does_not_overwrite_hyper_params and test_methods_have_no_side_effects from config for most deep learners CNN MLP Encoder and FCN classifiers

### DIFF
--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -85,8 +85,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_methods_have_no_side_effects",
     ],
     "MLPClassifier": [
         "test_fit_idempotent",

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -90,8 +90,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_methods_have_no_side_effects",
     ],
     "InceptionTimeClassifier": [
         "test_fit_idempotent",

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -67,8 +67,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_methods_have_no_side_effects",
     ],
     "CNNRegressor": [
         "test_fit_idempotent",
@@ -82,8 +80,6 @@ EXCLUDED_TESTS = {
         "test_fit_idempotent",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_methods_have_no_side_effects",
     ],
     "FCNClassifier": [
         "test_fit_idempotent",


### PR DESCRIPTION
This is a followup to #338 and #315 as mentioned in #187