### PR TITLE
[DOC] Add contrib.rocks image to `contributors.md` and lower all-contributors table/image size

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,11 +7,10 @@
   "files": [
     "CONTRIBUTORS.md"
   ],
-  "imageSize": 100,
-  "contributorsPerLine": 9,
+  "imageSize": 80,
+  "contributorsPerLine": 8,
   "contributorsSortAlphabetically": true,
   "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg)](#contributors)",
-  "skipCi": true,
   "contributors": [
     {
       "login": "fkiraly",

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,2 +1,13 @@
 ```{include} ../CONTRIBUTORS.md
 ```
+
+# GitHub Contributors
+
+Made with [contrib.rocks](https://contrib.rocks).
+
+<a href="https://github.com/aeon-toolkit/aeon/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=aeon-toolkit/aeon&max=500" />
+</a>
+
+Thanks to all our contributors. If you are interested in contributiong to `aeon`,
+see our [contributing guidelines](contributing).

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -13,5 +13,5 @@ Made with [contrib.rocks](https://contrib.rocks).
   <img src="https://contrib.rocks/image?repo=aeon-toolkit/aeon&max=500" />
 </a>
 
-Thanks to all our contributors. If you are interested in contributiong to `aeon`,
+Thanks to all our contributors. If you are interested in contributing to `aeon`,
 see our [contributing guidelines](contributing).

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,7 +1,11 @@
+This is a page to display the contributors to the `aeon` project. To add your
+contribution, edit the [.all-contributorsrc](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc)
+file or use the [All Contributors Bot](https://allcontributors.org/docs/en/bot/usage).
+
 ```{include} ../CONTRIBUTORS.md
 ```
 
-# GitHub Contributors
+## GitHub Contributors
 
 Made with [contrib.rocks](https://contrib.rocks).
 


### PR DESCRIPTION
Adds an image from [contrib.rocks](https://contrib.rocks) to the webpage and reduces the amount of columns and image size used by all-contributors to give each table item a bit more space.

There have been issues previously regarding displaying contributors decided via vote, but I don't feel the suggestions are feasible. https://github.com/sktime/sktime/issues/3716 seems to be defunct now, and https://github.com/sktime/sktime/issues/3717 would take an enormous amount of effort to implement and maintain.