### PR TITLE
[BUG] Fixes `show_versions` error

### DIFF
--- a/aeon/utils/_maint/_show_versions.py
+++ b/aeon/utils/_maint/_show_versions.py
@@ -10,9 +10,9 @@ adapted from :func:`sklearn.show_versions`
 __author__ = ["mloning"]
 __all__ = ["show_versions"]
 
-import importlib
 import platform
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 
 def _get_sys_info():
@@ -67,13 +67,8 @@ def _get_deps_info():
 
     for modname in deps:
         try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            ver = get_version(mod)
-            deps_info[modname] = ver
-        except ImportError:
+            deps_info[modname] = version(modname)
+        except PackageNotFoundError:
             deps_info[modname] = None
 
     return deps_info


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #343. 

#### What does this implement/fix? Explain your changes.

Calling the `show_versions` function caused an assertion error. The cause was in the `_get_deps_info` function. Apparently, importing `pip` before `setuptools` caused some kind of version incompatibility due to `setuptools` completely replacing `distutils` in 3.11.

The error was fixed by updating the module importing code, making it more similar to the current `sklearn.show_versions` function.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Did you add any tests for the change?

Not needed.
