### PR TITLE
[BUG] Fixes `load_covid_3month` returning a non-numeric `y`

### DIFF
--- a/aeon/datasets/_single_problem_loaders.py
+++ b/aeon/datasets/_single_problem_loaders.py
@@ -1137,4 +1137,11 @@ def load_covid_3month(split=None, return_X_y=True):
     =Covid3Month
     """
     name = "Covid3Month"
-    return _load_dataset(name, split, return_X_y)
+    loaded_dataset = _load_dataset(name, split, return_X_y)
+    if return_X_y:
+        X, y = loaded_dataset
+        y = y.astype(float)
+        return X, y
+    else:
+        loaded_dataset["class_val"] = loaded_dataset["class_val"].astype(float)
+        return loaded_dataset


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #342.

#### What does this implement/fix? Explain your changes.

The function `load_covid_3month` is now correctly converting its `y` array (or `class_val` column in case `return_X_y=False`) to floats.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Since the single problem loaders cover a wide variety of problem types (classification, forecasting and now regression), each with different types of data formats, I believe the individual `load_****` functions could and should do work on their own, instead of only being wrappers to `_load_dataset`. However, other, more impactful ways of addressing this issue are possible, such as having `_load_classification_dataset` , `_load_regression_dataset`,  and `_load_forecasting_dataset`  functions instead of a single catch-all `_load_dataset`.

If the maintainers would prefer that approach, I'd be happy to work on it.

#### Did you add any tests for the change?

No.
