### PR TITLE
[MNT] Changes repo owner to aeon-toolkit in `.all-contributorsrc`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "aeon",
-  "projectOwner": "aeon",
+  "projectOwner": "aeon-toolkit",
   "repoType": "github",
   "repoHost": "https://github.com",
   "commitConvention": "none",


### PR DESCRIPTION
Project owner in `.all-contributorsrc` is set to `aeon`, making the emojis in `CONTRIBUTORS.md` incorrectly link to `https://github.com/aeon/aeon/...`, which causes a 404.

I've changed it to `aeon-toolkit`.