### PR TITLE
[MNT] Unstable extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ all_extras = [
     "pyod>=0.8.0",
     "scikit_posthocs>=0.6.5",
     "seaborn>=0.11.0",
-    # "statsforecast>=0.5.2",
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tbats>=1.1.0",
@@ -77,7 +76,10 @@ all_extras = [
     "xarray",
     "mlflow",
 ]
-
+unstable_extras = [
+    "statsforecast>=0.5.2", # has issues with pandas 2.0
+    "pycatch22",  # known to fail installation on some setups
+]
 dev = [
     "backoff",
     "httpx",


### PR DESCRIPTION
Includes a dependencies groups for imports which exist in the package, but cause issues when included in `all_extras` currently.

Resolves #289 