### PR TITLE
[MNT] docs update to fix readthedocs fail

### DIFF
--- a/docs/api_reference/datasets.rst
+++ b/docs/api_reference/datasets.rst
@@ -25,6 +25,5 @@ Datasets
     load_lynx
     load_acsf1
     load_uschange
-    load_UCR_UEA_dataset
     load_macroeconomic
     load_solar

--- a/docs/api_reference/regression.rst
+++ b/docs/api_reference/regression.rst
@@ -9,17 +9,6 @@ All regressors in ``aeon``can be listed using the ``aeon.registry.all_estimators
 using ``estimator_types="regressor"``, optionally filtered by tags.
 Valid tags can be listed using ``aeon.registry.all_tags``.
 
-Composition
------------
-
-.. currentmodule:: aeon.regression.compose
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    ComposableTimeSeriesForestRegressor
-
 Deep learning
 -------------
 


### PR DESCRIPTION
removes mentions in the api_reference to deprecated function and regressor