### PR TITLE
[BUG] fix all_estimators to work with tags that are lists of strings not just single strings

### DIFF
--- a/aeon/registry/_lookup.py
+++ b/aeon/registry/_lookup.py
@@ -390,7 +390,15 @@ def _check_tag_cond(estimator, filter_tags=None, as_dataframe=True):
     for key, value in filter_tags.items():
         if not isinstance(value, list):
             value = [value]
-        cond_sat = cond_sat and estimator.get_class_tag(key) in set(value)
+        tags = estimator.get_class_tag(key)
+        if isinstance(tags, list):
+            in_list = False
+            for s in tags:
+                if s in value:
+                    in_list = True
+            cond_sat = cond_sat and in_list
+        else:
+            cond_sat = cond_sat and tags in value
 
     return cond_sat
 

--- a/aeon/registry/tests/test_lookup.py
+++ b/aeon/registry/tests/test_lookup.py
@@ -16,7 +16,6 @@ VALID_SCITYPES_SET = set(BASE_CLASS_SCITYPE_LIST + ["estimator"])
 # some scitypes have no associated tags yet
 SCITYPES_WITHOUT_TAGS = [
     "series-annotator",
-    "clusterer",
     "object",
     "splitter",
     "network",

--- a/aeon/registry/tests/test_lookup.py
+++ b/aeon/registry/tests/test_lookup.py
@@ -229,3 +229,21 @@ def test_scitype_inference(estimator_scitype):
     assert (
         inferred_scitype == estimator_scitype
     ), "one of scitype, _check_estimator_types is incorrect, these should be inverses"
+
+
+def test_list_tag_lookup():
+    """Check that all estimators can handle tags lists rather than single strings.
+
+    DummyClassifier has two internal datatypes, "numpy3D" and "np-list". This test
+    checks that DummyClassifier is returned with either of these argument.s
+    """
+    matches = all_estimators(
+        estimator_types="classifier", filter_tags={"X_inner_mtype": "np-list"}
+    )
+    names = [t[0] for t in matches]
+    assert "DummyClassifier" in names
+    matches = all_estimators(
+        estimator_types="classifier", filter_tags={"X_inner_mtype": "numpy3D"}
+    )
+    names = [t[0] for t in matches]
+    assert "DummyClassifier" in names


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #182 

#### What does this implement/fix? Explain your changes.

The bug in #182 was caused by all_estimators not handling the case when a tag can have multiple values. So, for example, to handle multiple possible input types, the dummy classifier
        "X_inner_mtype": ["np-list", "numpy3D"],
we have inherited all this, but it allows classifiers to handle both equal and unequal length, and all_estimators as a tag filter is useful. However, all_estimators assumes that the result of a call of (for example)

estimator.get_class_tag("X_inner_type") 

returns a string, rather than a list. This just adds a test of whether a list is returned and acts accordingly. This example

```python
from aeon.registry import all_estimators
f4=all_estimators("classifier",filter_tags={"X_inner_mtype": "np-list"})
print(f4)
```
now returns the only classifier currently able to handle unequal length. This is not tested currently, but I really dont want to spend more time looking at this code than strictly necessary

