### PR TITLE
[BUG] fix tsfresh "kind" feature extractor 

### DIFF
--- a/aeon/datatypes/_panel/_convert.py
+++ b/aeon/datatypes/_panel/_convert.py
@@ -1032,7 +1032,10 @@ convert_dict[("numpy3D", "nested_univ", "Panel")] = from_3d_numpy_to_nested_adp
 
 
 def from_3d_numpy_to_long(X, store=None):
-    Xt = from_3d_numpy_to_nested(X)
+    channel_names = []
+    for i in range(X.shape[1]):
+        channel_names.append("dim_" + str(i))
+    Xt = from_3d_numpy_to_nested(X, column_names=channel_names)
     Xt = from_nested_to_long(Xt)
     return Xt
 

--- a/aeon/transformations/panel/tsfresh.py
+++ b/aeon/transformations/panel/tsfresh.py
@@ -31,7 +31,7 @@ class _TSFreshFeatureExtractor(BaseTransformer):
         kind_to_fc_parameters=None,
         chunksize=None,
         n_jobs=1,
-        show_warnings=True,
+        show_warnings=False,
         disable_progressbar=False,
         impute_function=None,
         profiling=None,
@@ -232,8 +232,8 @@ class TSFreshFeatureExtractor(_TSFreshFeatureExtractor):
         kind_to_fc_parameters=None,
         chunksize=None,
         n_jobs=1,
-        show_warnings=True,
-        disable_progressbar=False,
+        show_warnings=False,
+        disable_progressbar=True,
         impute_function=None,
         profiling=None,
         profiling_filename=None,
@@ -363,7 +363,7 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
         heuristics are used to find the optimal chunksize. If you get out of
         memory exceptions, you can try it with the dask distributor and a
         smaller chunksize.
-    show_warnings : bool, default=True
+    show_warnings : bool, default=False
         Show warnings during the feature extraction (needed for debugging of
         calculators).
     disable_progressbar : bool, default=False
@@ -456,8 +456,8 @@ class TSFreshRelevantFeatureExtractor(_TSFreshFeatureExtractor):
         kind_to_fc_parameters=None,
         chunksize=None,
         n_jobs=1,
-        show_warnings=True,
-        disable_progressbar=False,
+        show_warnings=False,
+        disable_progressbar=True,
         impute_function=None,
         profiling=None,
         profiling_filename=None,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #381 

#### What does this implement/fix? Explain your changes.

The fix is simply to assign column/channel names of the format "dim_X" in the conversion of long format. I have also turned off the warnings by default, because it is generating 100s of lines of nonsense. If anyone really wants them, I'll put them back.
