### PR TITLE
[ENH] Allow KNN to take unequal length series. 

### DIFF
--- a/aeon/classification/compose/tests/test_pipeline.py
+++ b/aeon/classification/compose/tests/test_pipeline.py
@@ -8,7 +8,7 @@ __all__ = []
 from sklearn.preprocessing import StandardScaler
 
 from aeon.classification.compose import ClassifierPipeline
-from aeon.classification.distance_based import KNeighborsTimeSeriesClassifier
+from aeon.classification.convolution_based import RocketClassifier
 from aeon.transformations.panel.pad import PaddingTransformer
 from aeon.transformations.series.exponent import ExponentTransformer
 from aeon.transformations.series.impute import Imputer
@@ -26,7 +26,7 @@ def test_dunder_mul():
     t1 = ExponentTransformer(power=4)
     t2 = ExponentTransformer(power=0.25)
 
-    c = KNeighborsTimeSeriesClassifier()
+    c = RocketClassifier(num_kernels=50)
     t12c_1 = t1 * (t2 * c)
     t12c_2 = (t1 * t2) * c
     t12c_3 = t1 * t2 * c
@@ -51,7 +51,7 @@ def test_mul_sklearn_autoadapt():
 
     t1 = ExponentTransformer(power=2)
     t2 = StandardScaler()
-    c = KNeighborsTimeSeriesClassifier()
+    c = RocketClassifier(num_kernels=50)
 
     t12c_1 = t1 * (t2 * c)
     t12c_2 = (t1 * t2) * c
@@ -69,7 +69,7 @@ def test_mul_sklearn_autoadapt():
 
 def test_missing_unequal_tag_inference():
     """Test that ClassifierPipeline infers missing/unequal tags correctly."""
-    c = KNeighborsTimeSeriesClassifier()
+    c = RocketClassifier(num_kernels=50)
     c1 = ExponentTransformer() * PaddingTransformer() * ExponentTransformer() * c
     c2 = ExponentTransformer() * ExponentTransformer() * c
     c3 = Imputer() * ExponentTransformer() * c

--- a/aeon/classification/compose/tests/test_pipeline.py
+++ b/aeon/classification/compose/tests/test_pipeline.py
@@ -51,7 +51,7 @@ def test_mul_sklearn_autoadapt():
 
     t1 = ExponentTransformer(power=2)
     t2 = StandardScaler()
-    c = RocketClassifier(num_kernels=50)
+    c = RocketClassifier(num_kernels=50, random_state=RAND_SEED)
 
     t12c_1 = t1 * (t2 * c)
     t12c_2 = (t1 * t2) * c

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """KNN time series classification.
 
-This class is a KNN classifier which supports time series distance measures.
+A KNN classifier which supports time series distance measures.
 The class has hardcoded string references to numba based distances in aeon.distances.
-It can also be used with callables, or aeon (pairwise transformer) estimators.
+It can also be used with callable distance functions.
 """
 
 __author__ = ["TonyBagnall", "GuiArcencio"]

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -65,6 +65,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
     _tags = {
         "capability:multivariate": True,
+        "capability:unequal_length": True,
+        "X_inner_mtype": ["np-list", "numpy3D"],
         "algorithm_type": "distance",
     }
 
@@ -95,9 +97,12 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
-            The training data.
-        y : array-like, shape = [n_instances]
+        X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
+        shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
+                If the series are all equal length, a numpy3D will be passed. If
+                unequal, a list of 2D numpy arrays is passed, which may have
+                different lengths.
+        y : array-like, shape = (n_cases)
             The class labels.
         """
         if isinstance(self.distance, str):
@@ -112,19 +117,22 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
-            The training data.
+        X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
+        shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
+                If the series are all equal length, a numpy3D will be passed. If
+                unequal, a list of 2D numpy arrays is passed, which may have
+                different lengths.
 
         Returns
         -------
-        p : array of shape = [n_instances, n_classes]
+        p : array of shape = (n_cases, n_classes_)
             The class probabilities of the input samples. Classes are ordered
             by lexicographic order.
         """
         self.check_is_fitted()
 
-        preds = np.zeros((X.shape[0], len(self.classes_)))
-        for i in range(X.shape[0]):
+        preds = np.zeros((len(X), len(self.classes_)))
+        for i in range(len(X)):
             idx, weights = self._kneighbors(X[i])
             for id, w in zip(idx, weights):
                 predicted_class = self.y_[id]
@@ -139,18 +147,21 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
-            The training data.
+        X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
+        shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
+                If the series are all equal length, a numpy3D will be passed. If
+                unequal, a list of 2D numpy arrays is passed, which may have
+                different lengths.
 
         Returns
         -------
-        y : array of shape [n_instances]
+        y : array of shape (n_cases)
             Class labels for each data sample.
         """
         self.check_is_fitted()
 
-        preds = np.empty(X.shape[0], dtype=self.classes_.dtype)
-        for i in range(X.shape[0]):
+        preds = np.empty(len(X), dtype=self.classes_.dtype)
+        for i in range(len(X)):
             scores = np.zeros(len(self.classes_))
             idx, weights = self._kneighbors(X[i])
             for id, w in zip(idx, weights):
@@ -168,8 +179,11 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.array of shape = [n_instances, n_dimensions, series_length]
-            The training data.
+        X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
+        shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
+                If the series are all equal length, a numpy3D will be passed. If
+                unequal, a list of 2D numpy arrays is passed, which may have
+                different lengths.
 
         Returns
         -------
@@ -178,9 +192,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ws : array
             Array representing the weights of each neighbor.
         """
-        distances = np.array(
-            [self.metric_(X, self.X_[j]) for j in range(self.X_.shape[0])]
-        )
+        distances = np.array([self.metric_(X, self.X_[j]) for j in range(len(self.X_))])
 
         # Find indices of k nearest neighbors using partitioning:
         # [0..k-1], [k], [k+1..n-1]

--- a/aeon/registry/_tags.py
+++ b/aeon/registry/_tags.py
@@ -198,17 +198,19 @@ ESTIMATOR_TAG_REGISTER = [
         "capability:multivariate",
         [
             "classifier",
+            "clusterer",
             "early_classifier",
             "param_est",
             "regressor",
         ],
         "bool",
-        "can the classifier classify time series with 2 or more variables?",
+        "can the estimator classify time series with 2 or more variables?",
     ),
     (
         "capability:unequal_length",
         [
             "classifier",
+            "clusterer",
             "early_classifier",
             "regressor",
             "transformer",
@@ -223,12 +225,13 @@ ESTIMATOR_TAG_REGISTER = [
         "capability:missing_values",
         [
             "classifier",
+            "clusterer",
             "early_classifier",
             "param_est",
             "regressor",
         ],
         "bool",
-        "can the classifier handle missing data (NA, np.nan) in inputs?",
+        "can the estimator handle missing data (NA, np.nan) in inputs?",
     ),
     (
         "capability:unequal_length:removes",

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,14 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
+    --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,6 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/aeon-toolkit/aeon/blob/main/CONTRIBUTING.md

Feel free to delete sections of this template if they do not apply to your PR, avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Part of #408 
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests you resolved, so that they will automatically be closed when your pull request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

this adds  unequal length capability to KNN. This is trivial following the distances refactor, I've not written a proper test yet, but this works fine

```python
from aeon.classification.distance_based import KNeighborsTimeSeriesClassifier
from aeon.datasets import load_plaid, load_japanese_vowels

def plaid(cls):
    X, y = load_plaid(split="TRAIN")
    X = X[:50]
    y = y[:50]
    X_test, y_test = load_plaid(split="TEST")
    X_test = X_test[:50]
    y_test = y_test[:50]
    cls.fit(X,y)
    preds = cls.predict(X_test)
    print("PLAID preds = ",preds)
    print("score =",cls.score(X_test, y_test))

def jap_vowels(cls):
    X, y = load_japanese_vowels(split="TRAIN")
    X = X[:50]
    y = y[:50]
    X_test, y_test = load_japanese_vowels(split="TEST")
    X_test = X_test[:50]
    y_test = y_test[:50]
    cls.fit(X,y)
    preds = cls.predict(X_test)
    print("JAP VOWELS preds = ",preds)
    print("score =",cls.score(X_test, y_test))

distances = ["erp","edr","dtw","ddtw","lcss","twe","msm","wdtw","wddtw"]
for d in distances:
    print(" KNN with distance ",d)
    plaid(KNeighborsTimeSeriesClassifier(distance=d))
plaid(DummyClassifier())
for d in distances:
    print(" KNN with distance ",d)
    jap_vowels(KNeighborsTimeSeriesClassifier(distance=d))
```

#### Did you add any tests for the change?

no, will do that with EE


