### PR TITLE
[EN] Hard code deep learning exclusions from tests

### DIFF
--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -34,11 +34,13 @@ EXCLUDED_TESTS = {
     # exclude
     "InceptionTimeClassifier": [
         "test_fit_deterministic",
-        "test_persistence_via_pickle" "test_save_estimators_to_file",
+        "test_persistence_via_pickle",
+        "test_save_estimators_to_file",
     ],
     "InceptionTimeRegressor": [
         "test_fit_deterministic",
-        "test_persistence_via_pickle" "test_save_estimators_to_file",
+        "test_persistence_via_pickle",
+        "test_save_estimators_to_file",
     ],
     # issue when predicting residuals, see #3479
     "SquaringResiduals": ["test_predict_residuals"],

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -29,8 +29,17 @@ EXCLUDE_ESTIMATORS = [
     "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
 ]
 
-
 EXCLUDED_TESTS = {
+    # InceptionTimeClassifier contains deep learners, it isnt one itself, so still
+    # exclude
+    "InceptionTimeClassifier": [
+        "test_fit_deterministic",
+        "test_persistence_via_pickle" "test_save_estimators_to_file",
+    ],
+    "InceptionTimeRegressor": [
+        "test_fit_deterministic",
+        "test_persistence_via_pickle" "test_save_estimators_to_file",
+    ],
     # issue when predicting residuals, see #3479
     "SquaringResiduals": ["test_predict_residuals"],
     # known issue when X is passed, wrong time indices are returned, #1364
@@ -44,69 +53,6 @@ EXCLUDED_TESTS = {
         "test_classifier_on_unit_test_data",
         "test_classifier_on_basic_motions",
     ],
-    # TapNet fails due to Lambda layer, see #3539 and #3616
-    "TapNetClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "TapNetRegressor": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    # `test_fit_idempotent` fails with `AssertionError`, see #3616
-    "ResNetClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-        "test_fit_does_not_overwrite_hyper_params",
-        "test_methods_have_no_side_effects",
-    ],
-    "CNNClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "CNNRegressor": [
-        "test_fit_idempotent",
-    ],
-    "InceptionTimeRegressor": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "EncoderClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "FCNClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "MLPClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "InceptionTimeClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "IndividualInceptionClassifier": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "IndividualInceptionRegressor": [
-        "test_fit_idempotent",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-        "test_methods_have_no_side_effects",
-    ],
     # sth is not quite right with the RowTransformer-s changing state,
     #   but these are anyway on their path to deprecation, see #2370
     "SeriesToSeriesRowTransformer": ["test_non_state_changing_method_contract"],
@@ -114,18 +60,18 @@ EXCLUDED_TESTS = {
     "ColumnTransformer": ["test_non_state_changing_method_contract"],
     # Early classifiers (EC) intentionally retain information from previous predict
     # calls for #1 (test_non_state_changing_method_contract).
-    # #2 (test_fit_idempotent), #3 (test_persistence_via_pickle) and #4
+    # #2 (test_fit_deterministic), #3 (test_persistence_via_pickle) and #4
     # (test_save_estimators_to_file) are due to predict/predict_proba returning two
     # items and that breaking assert_array_equal.
     "TEASER": [  # EC
         "test_non_state_changing_method_contract",
-        "test_fit_idempotent",
+        "test_fit_deterministic",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
     "ProbabilityThresholdEarlyClassifier": [  # EC
         "test_non_state_changing_method_contract",
-        "test_fit_idempotent",
+        "test_fit_deterministic",
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],


### PR DESCRIPTION
see 
https://github.com/aeon-toolkit/aeon/issues/271
https://github.com/aeon-toolkit/aeon/issues/347

The deep learning algorithms are fundamentally not deterministic. They also cannot be pickled. There are three relevant tests in test_all_estimators

"test_fit_idempotent",
"test_persistence_via_pickle" 
"test_save_estimators_to_file",

firstly, I have refactored the poorly named test_fit_idempotent to test_fit_deterministic. I have then escaped tests if the estimator is a DeepClassifier or DeepRegressor. Turns out this is done all over the testing. Currently, InceptionTime is still excluded because technically it is an ensemble of deep learners, not a deep learner itself. 

