### PR TITLE
[ENH] refactored predict in `BaseDeepClassifier`

### DIFF
--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -19,7 +19,6 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
-from sklearn.utils import check_random_state
 
 from aeon.classification.base import BaseClassifier
 
@@ -97,13 +96,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
 
     def _predict(self, X, **kwargs):
         probs = self._predict_proba(X, **kwargs)
-        rng = check_random_state(self.random_state)
-        return np.array(
-            [
-                self.classes_[int(rng.choice(np.flatnonzero(prob == prob.max())))]
-                for prob in probs
-            ]
-        )
+        return np.argmax(probs, axis=1)
 
     def _predict_proba(self, X, **kwargs):
         """Find probability estimates for each class for all cases in X.
@@ -126,7 +119,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         if probs.shape[1] == 1:
             # first column is probability of class 0 and second is of class 1
             probs = np.hstack([1 - probs, probs])
-        probs = probs / probs.sum(axis=1, keepdims=1)
+            probs = probs / probs.sum(axis=1, keepdims=1)
         return probs
 
     def convert_y_to_keras(self, y):

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -101,7 +101,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         # probs and break the ties at the same time.
         probs = self._predict_proba(X, **kwargs)
         return np.argmax(
-            probs + np.linspace(0.0, 0.1, num=self.n_classes_).reshape((-1, 1)), axis=1
+            probs + np.linspace(0.0, 0.1, num=self.n_classes_).reshape((1, -1)), axis=1
         )
 
     def _predict_proba(self, X, **kwargs):

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -95,8 +95,14 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         return self.history.history if self.history is not None else None
 
     def _predict(self, X, **kwargs):
+        # If the probs gave the following for a samples [0.1, 0.45, 0.45]
+        # by doing the addition of the np.linspace, we change the values in an
+        # increasing manner to avoid changing the original ordering of the
+        # probs and break the ties at the same time.
         probs = self._predict_proba(X, **kwargs)
-        return np.argmax(probs, axis=1)
+        return np.argmax(
+            probs + np.linspace(0.0, 0.1, num=self.n_classes_).reshape((-1, 1)), axis=1
+        )
 
     def _predict_proba(self, X, **kwargs):
         """Find probability estimates for each class for all cases in X.

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -119,7 +119,6 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         if probs.shape[1] == 1:
             # first column is probability of class 0 and second is of class 1
             probs = np.hstack([1 - probs, probs])
-            probs = probs / probs.sum(axis=1, keepdims=1)
         return probs
 
     def convert_y_to_keras(self, y):

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -119,6 +119,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         if probs.shape[1] == 1:
             # first column is probability of class 0 and second is of class 1
             probs = np.hstack([1 - probs, probs])
+        probs = probs / probs.sum(axis=1, keepdims=1)
         return probs
 
     def convert_y_to_keras(self, y):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our contribution guide: https://github.com/aeon-toolkit/aeon/blob/main/CONTRIBUTING.md

Feel free to delete sections of this template if they do not apply to your PR, avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Fix #448 
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests you resolved, so that they will automatically be closed when your pull request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
The implementation of `_predict`  method in `BaseDeepClassifier` is not optimal, it uses a for loop for some reason and checks the random state.. It simply should use `np.argmax`.

<!--
A clear and concise description of what you have implemented.
-->



<!--
Thanks for contributing!
-->
