### PR TITLE
[BUG] Fixes `stratified_resample` so that it works with 3D numpy

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2087,7 +2087,8 @@
         "avatar_url": "https://avatars.githubusercontent.com/u/47733489",
         "profile": "https://github.com/GuiArcencio",
         "contributions": [
-          "code"
+          "code",
+          "test"
         ]
       },
     {
@@ -2155,6 +2156,6 @@
       "contributions": [
         "code"
       ]
-    },
+    }
   ]
 }

--- a/aeon/utils/sampling.py
+++ b/aeon/utils/sampling.py
@@ -8,10 +8,10 @@ import random
 
 import numpy as np
 import pandas as pd
-import sklearn.utils
+from sklearn.utils import check_random_state
 
 
-def stratified_resample(X_train, y_train, X_test, y_test, random_state):
+def stratified_resample(X_train, y_train, X_test, y_test, random_state=None):
     """Stratified resample data without replacement using a random state.
 
     Reproducable resampling. Combines train and test, resamples to get the same class
@@ -19,62 +19,61 @@ def stratified_resample(X_train, y_train, X_test, y_test, random_state):
 
     Parameters
     ----------
-    X_train : pd.DataFrame
-        train data attributes in aeon pandas format.
+    X_train : 3D np.array of shape = (n_instances, n_dimensions, series_length),
+    2D np.array of shape = (n_instances, series_length), or pd.DataFrame
+        train data attributes.
     y_train : np.array
         train data class labels.
-    X_test : pd.DataFrame
-        test data attributes in aeon pandas format.
+    X_test : 3D np.array of shape = (n_instances, n_dimensions, series_length),
+    2D np.array of shape = (n_instances, series_length), or pd.DataFrame
+        test data attributes.
     y_test : np.array
         test data class labels as np array.
     random_state : int
-        seed to enable reproducable resamples
+        seed to enable reproduceable resamples
     Returns
     -------
     new train and test attributes and class labels.
     """
-    all_labels = np.concatenate((y_train, y_test), axis=None)
-    all_data = pd.concat([X_train, X_test])
-    random_state = sklearn.utils.check_random_state(random_state)
+    random_state = check_random_state(random_state)
+    all_labels = np.concatenate([y_train, y_test], axis=0)
+    all_data = (
+        pd.concat([X_train, X_test], ignore_index=True)
+        if isinstance(X_train, pd.DataFrame)
+        else np.concatenate([X_train, X_test], axis=0)
+    )
+
     # count class occurrences
     unique_train, counts_train = np.unique(y_train, return_counts=True)
-    unique_test, counts_test = np.unique(y_test, return_counts=True)
-    assert list(unique_train) == list(
-        unique_test
-    )  # haven't built functionality to deal with classes that exist in
+    unique_test = np.unique(y_test)
+
+    # haven't built functionality to deal with classes that exist in
     # test but not in train
-    # prepare outputs
-    X_train = pd.DataFrame()
-    y_train = np.array([])
-    X_test = pd.DataFrame()
-    y_test = np.array([])
-    # for each class
-    for label_index in range(0, len(unique_train)):
-        # derive how many instances of this class from the counts
-        num_instances = counts_train[label_index]
-        # get the indices of all instances with this class label
-        label = unique_train[label_index]
-        indices = np.where(all_labels == label)[0]
-        # shuffle them
-        random_state.shuffle(indices)
-        # take the first lot of instances for train, remainder for test
-        train_indices = indices[0:num_instances]
-        test_indices = indices[num_instances:]
-        del indices  # just to make sure it's not used!
-        # extract data from corresponding indices
-        train_instances = all_data.iloc[train_indices, :]
-        test_instances = all_data.iloc[test_indices, :]
-        train_labels = all_labels[train_indices]
-        test_labels = all_labels[test_indices]
-        # concat onto current data from previous loop iterations
-        X_train = pd.concat([X_train, train_instances])
-        X_test = pd.concat([X_test, test_instances])
-        y_train = np.concatenate([y_train, train_labels], axis=None)
-        y_test = np.concatenate([y_test, test_labels], axis=None)
-    # reset indexes to conform to aeon format.
-    X_train = X_train.reset_index(drop=True)
-    X_test = X_test.reset_index(drop=True)
-    return X_train, y_train, X_test, y_test
+    assert set(unique_train) == set(unique_test)
+
+    new_train_indices = []
+    new_test_indices = []
+    for label, count_train in zip(unique_train, counts_train):
+        class_indexes = np.argwhere(all_labels == label).ravel()
+
+        # randomizes the order and partition into train and test
+        random_state.shuffle(class_indexes)
+        new_train_indices.extend(class_indexes[:count_train])
+        new_test_indices.extend(class_indexes[count_train:])
+
+    if isinstance(X_train, pd.DataFrame):
+        new_X_train = all_data.iloc[new_train_indices]
+        new_X_test = all_data.iloc[new_test_indices]
+        new_X_train = new_X_train.reset_index(drop=True)
+        new_X_test = new_X_test.reset_index(drop=True)
+    else:
+        new_X_train = all_data[new_train_indices]
+        new_X_test = all_data[new_test_indices]
+
+    new_y_train = all_labels[new_train_indices]
+    new_y_test = all_labels[new_test_indices]
+
+    return new_X_train, new_y_train, new_X_test, new_y_test
 
 
 def random_partition(n, k=2, seed=42):

--- a/aeon/utils/sampling.py
+++ b/aeon/utils/sampling.py
@@ -20,13 +20,13 @@ def stratified_resample(X_train, y_train, X_test, y_test, random_state=None):
 
     Parameters
     ----------
-    X_train : 3D np.array of shape = (n_instances, n_dimensions, series_length),
-    2D np.array of shape = (n_instances, series_length), or pd.DataFrame
+    X_train : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints), list of
+    shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i), or pd.DataFrame
         train data attributes.
     y_train : np.array
         train data class labels.
-    X_test : 3D np.array of shape = (n_instances, n_dimensions, series_length),
-    2D np.array of shape = (n_instances, series_length), or pd.DataFrame
+    X_test : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints), list of
+    shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i), or pd.DataFrame
         test data attributes.
     y_test : np.array
         test data class labels as np array.
@@ -71,7 +71,7 @@ def stratified_resample(X_train, y_train, X_test, y_test, random_state=None):
     elif isinstance(X_train, list):
         new_X_train = list(all_data[i] for i in new_train_indices)
         new_X_test = list(all_data[i] for i in new_test_indices)
-    else:
+    else:  # 3D or 2D numpy
         new_X_train = all_data[new_train_indices]
         new_X_test = all_data[new_test_indices]
 

--- a/aeon/utils/tests/test_sampling.py
+++ b/aeon/utils/tests/test_sampling.py
@@ -2,15 +2,15 @@
 """Testing sampling utilities."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
-from aeon.datasets import load_unit_test
-from aeon.datatypes import check_is_scitype
 from aeon.utils._testing.deep_equals import deep_equals
 from aeon.utils.sampling import random_partition, stratified_resample
 
 NK_FIXTURES = [(10, 3), (15, 5), (19, 6), (3, 1), (1, 2)]
 SEED_FIXTURES = [42, 0, 100, -5]
+INPUT_TYPES = ["numpy3D", "np-list", "pd.DataFrame"]
 
 
 @pytest.mark.parametrize("n, k", NK_FIXTURES)
@@ -47,21 +47,39 @@ def test_seed(n, k, seed):
     assert deep_equals(part, part2)
 
 
-def test_stratified_resample():
-    """Test resampling returns valid data structure and maintains class distribution."""
-    trainX, trainy = load_unit_test(split="TRAIN", return_type="nested_univ")
-    testX, testy = load_unit_test(split="TEST", return_type="nested_univ")
-    new_trainX, new_trainy, new_testX, new_testy = stratified_resample(
-        trainX, trainy, testX, testy, 0
+@pytest.mark.parametrize("input_type", INPUT_TYPES)
+def test_stratified_resample(input_type):
+    random_state = np.random.RandomState(0)
+    if input_type == "numpy3D":
+        X_train = random_state.random((10, 1, 100))
+        X_test = random_state.random((10, 1, 100))
+    elif input_type == "np-list":
+        X_train = [random_state.random((1, 100)) for _ in range(10)]
+        X_test = [random_state.random((1, 100)) for _ in range(10)]
+    else:
+        train_series = [pd.Series(random_state.random(100)) for _ in range(10)]
+        test_series = [pd.Series(random_state.random(100)) for _ in range(10)]
+        X_train = pd.DataFrame({"dim_0": train_series})
+        X_test = pd.DataFrame({"dim_0": test_series})
+    y_train = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+    y_test = np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1])
+
+    new_X_train, new_y_train, new_X_test, new_y_test = stratified_resample(
+        X_train, y_train, X_test, y_test, 0
     )
 
-    valid_train = check_is_scitype(new_trainX, scitype="Panel")
-    valid_test = check_is_scitype(new_testX, scitype="Panel")
-    assert valid_test and valid_train
-    # count class occurrences
-    unique_train, counts_train = np.unique(trainy, return_counts=True)
-    unique_test, counts_test = np.unique(testy, return_counts=True)
-    unique_train_new, counts_train_new = np.unique(new_trainy, return_counts=True)
-    unique_test_new, counts_test_new = np.unique(new_testy, return_counts=True)
-    assert list(counts_train_new) == list(counts_train)
-    assert list(counts_test_new) == list(counts_test)
+    # Valid return type
+    assert type(X_train) == type(new_X_train) and type(X_test) == type(new_X_test)
+
+    classes_train, classes_count_train = np.unique(y_train, return_counts=True)
+    classes_test, classes_count_test = np.unique(y_test, return_counts=True)
+    classes_new_train, classes_count_new_train = np.unique(
+        new_y_train, return_counts=True
+    )
+    classes_new_test, classes_count_new_test = np.unique(new_y_test, return_counts=True)
+
+    # Assert same class distributions
+    assert np.all(classes_train == classes_new_train)
+    assert np.all(classes_count_train == classes_count_new_train)
+    assert np.all(classes_test == classes_new_test)
+    assert np.all(classes_count_test == classes_count_new_test)

--- a/aeon/utils/tests/test_sampling.py
+++ b/aeon/utils/tests/test_sampling.py
@@ -65,7 +65,7 @@ def test_stratified_resample(input_type):
     y_test = np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1])
 
     new_X_train, new_y_train, new_X_test, new_y_test = stratified_resample(
-        X_train, y_train, X_test, y_test, 0
+        X_train, y_train, X_test, y_test, random_state
     )
 
     # Valid return type


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #459.

#### What does this implement/fix? Explain your changes.

Makes the `stratified_resample` function work with 3D and 2D numpy arrays, and DataFrames for backwards compatibility.

#### What should a reviewer concentrate their feedback on?

I've remade the function so that it deals mostly with indexes. This makes the function agnostic (for the most part) to the underlying implementation of `X_train` and `X_test`.

It still, however, can't deal with lists of 2D arrays (such as unequal length datasets). I can easily add that if necessary.

