### PR TITLE
[ENH] Tidy up test exclusions

### DIFF
--- a/aeon/classification/deep_learning/tapnet.py
+++ b/aeon/classification/deep_learning/tapnet.py
@@ -270,11 +270,4 @@ class TapNetClassifier(BaseDeepClassifier):
             "dilation": 2,
             "layers": (32, 16),
         }
-        # param2 = {
-        #     "n_epochs": 20,
-        #     "use_cnn": False,
-        #     "layers": (25, 25),
-        # }
-        test_params = [param1]
-
-        return test_params
+        return [param1]

--- a/aeon/classification/interval_based/_rise.py
+++ b/aeon/classification/interval_based/_rise.py
@@ -204,14 +204,6 @@ class RandomIntervalSpectralEnsemble(BaseClassifier):
 
         super(RandomIntervalSpectralEnsemble, self).__init__()
 
-    @property
-    def feature_importances_(self):
-        """Feature importance not supported for the RISE classifier."""
-        raise NotImplementedError(
-            "The impurity-based feature importances of "
-            "RandomIntervalSpectralForest is currently not supported."
-        )
-
     def _fit(self, X, y):
         """Build a forest of trees from the training set (X, y).
 

--- a/aeon/classification/tests/test_all_classifiers.py
+++ b/aeon/classification/tests/test_all_classifiers.py
@@ -47,8 +47,24 @@ class ClassifierFixtureGenerator(BaseFixtureGenerator):
 class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
     """Module level tests for all aeon classifiers."""
 
+    def test_handles_single_class(self, estimator_instance):
+        """BASE CLASS ONLY. Test that estimator handles fit when only single class
+        label is seen.
+
+        This is important for compatibility with ensembles that sub-sample,
+        as sub-sampling stochastically produces training sets with single class label.
+        """
+        X, _ = make_3d_test_data(n_cases=10)
+        y = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+
+        error_msg = "single class label"
+
+        with pytest.warns(UserWarning, match=error_msg):
+            estimator_instance.fit(X, y)
+
     def test_multivariate_input_exception(self, estimator_instance):
-        """Test univariate classifiers raise exception on multivariate X."""
+        """BASE CLASS ONLY Test univariate classifiers raise exception on multivariate
+        X."""
         # check if multivariate input raises error for univariate classifiers
 
         # if handles multivariate, no error is to be raised
@@ -160,20 +176,6 @@ class TestAllClassifiers(ClassifierFixtureGenerator, QuickTester):
 
         # assert probabilities are the same
         _assert_array_almost_equal(y_proba, expected_probas, decimal=2)
-
-    def test_handles_single_class(self, estimator_instance):
-        """Test that estimator handles fit when only single class label is seen.
-
-        This is important for compatibility with ensembles that sub-sample,
-        as sub-sampling stochastically produces training sets with single class label.
-        """
-        X, _ = make_3d_test_data(n_cases=10)
-        y = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-
-        error_msg = "single class label"
-
-        with pytest.warns(UserWarning, match=error_msg):
-            estimator_instance.fit(X, y)
 
     def test_contracted_classifier(self, estimator_class):
         """Test classifiers that can be contracted."""

--- a/aeon/regression/deep_learning/tapnet.py
+++ b/aeon/regression/deep_learning/tapnet.py
@@ -251,8 +251,6 @@ class TapNetRegressor(BaseDeepRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        from aeon.utils.validation._dependencies import _check_soft_dependencies
-
         param1 = {
             "n_epochs": 10,
             "batch_size": 4,
@@ -261,21 +259,4 @@ class TapNetRegressor(BaseDeepRegressor):
             "kernel_size": (3, 3, 1),
             "layers": (25, 50),
         }
-        param2 = {
-            "n_epochs": 20,
-            "use_cnn": False,
-            "layers": (25, 25),
-        }
-        test_params = [param1, param2]
-
-        if _check_soft_dependencies("keras", severity="none"):
-            from keras.callbacks import LambdaCallback
-
-            test_params.append(
-                {
-                    "n_epochs": 2,
-                    "callbacks": [LambdaCallback()],
-                }
-            )
-
-        return test_params
+        return [param1]

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -7,15 +7,13 @@ from aeon.base import BaseEstimator, BaseObject
 from aeon.registry import BASE_CLASS_LIST, BASE_CLASS_LOOKUP, ESTIMATOR_TAG_LIST
 
 EXCLUDE_ESTIMATORS = [
-    # SFA is non-compliant with any transformer interfaces, #2064
+    # SFA is non-compliant with the transformer interface
     "SFA",
     # Interface is outdated, needs a rework.
     "ColumnTransformer",
-    # PlateauFinder seems to be broken, see #2259
-    "PlateauFinder",
-    # below are removed due to mac failures we don't fully understand, see #3103
-    "HIVECOTEV1",
-    "HIVECOTEV2",
+    # "PlateauFinder",
+    # "HIVECOTEV1",
+    # "HIVECOTEV2",
     "RandomIntervalSpectralEnsemble",
     "RandomInvervals",
     "RandomIntervalSegmenter",
@@ -23,15 +21,16 @@ EXCLUDE_ESTIMATORS = [
     "RandomIntervalClassifier",
     "MiniRocket",
     "MatrixProfileTransformer",
-    # tapnet based estimators fail stochastically for unknown reasons, see #3525
-    "TapNetRegressor",
-    "TapNetClassifier",
-    "ResNetClassifier",  # known ResNetClassifier sporafic failures, see #3954
+    #    "TapNetRegressor",
+    #    "TapNetClassifier",
+    "ResNetClassifier",  # known ResNetClassifier cloning failure, see #472
 ]
 
 EXCLUDED_TESTS = {
-    # InceptionTimeClassifier contains deep learners, it isnt one itself, so still
-    # exclude
+    # Classification/clustering/regression
+    # InceptionTimeClassifier contains deep learners but it isnt one itself,
+    # it inherits from BaseClassifier. Pickling will not work, so still exclude from
+    # tests.
     "InceptionTimeClassifier": [
         "test_fit_deterministic",
         "test_persistence_via_pickle",
@@ -42,24 +41,10 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    # issue when predicting residuals, see #3479
-    "SquaringResiduals": ["test_predict_residuals"],
-    # known issue when X is passed, wrong time indices are returned, #1364
-    "StackingForecaster": ["test_predict_time_index_with_X"],
-    # known side effects on multivariate arguments, #2072
-    "WindowSummarizer": ["test_methods_have_no_side_effects"],
-    # test fails in the Panel case for Differencer, see #2522
-    "Differencer": ["test_transform_inverse_transform_equivalent"],
-    # tagged in issue #2490
     "SignatureClassifier": [
         "test_classifier_on_unit_test_data",
         "test_classifier_on_basic_motions",
     ],
-    # sth is not quite right with the RowTransformer-s changing state,
-    #   but these are anyway on their path to deprecation, see #2370
-    "SeriesToSeriesRowTransformer": ["test_non_state_changing_method_contract"],
-    # ColumnTransformer still needs to be refactored, see #2537
-    "ColumnTransformer": ["test_non_state_changing_method_contract"],
     # Early classifiers (EC) intentionally retain information from previous predict
     # calls for #1 (test_non_state_changing_method_contract).
     # #2 (test_fit_deterministic), #3 (test_persistence_via_pickle) and #4
@@ -77,16 +62,30 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    "CNNNetwork": "test_inheritance",  # not a registered base class, WiP, see #3028
-    "VARMAX": [
-        "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
-        "test__y_when_refitting",  # see 3176
-    ],
+    # Transformations
+    # sth is not quite right with the RowTransformer-s changing state,
+    #   but these are anyway on their path to deprecation, see #2370
+    "SeriesToSeriesRowTransformer": ["test_non_state_changing_method_contract"],
+    # ColumnTransformer still needs to be refactored, see #2537
+    "ColumnTransformer": ["test_non_state_changing_method_contract"],
+    # Segmentation
     # GGS inherits from BaseEstimator which breaks this test
     "GreedyGaussianSegmentation": ["test_inheritance", "test_create_test_instance"],
     "InformationGainSegmentation": [
         "test_inheritance",
         "test_create_test_instance",
+    ],
+    # issue when predicting residuals, see #3479
+    "SquaringResiduals": ["test_predict_residuals"],
+    # known issue when X is passed, wrong time indices are returned, #1364
+    "StackingForecaster": ["test_predict_time_index_with_X"],
+    # known side effects on multivariate arguments, #2072
+    "WindowSummarizer": ["test_methods_have_no_side_effects"],
+    # test fails in the Panel case for Differencer, see #2522
+    "Differencer": ["test_transform_inverse_transform_equivalent"],
+    "VARMAX": [
+        "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
+        "test__y_when_refitting",  # see 3176
     ],
     # this needs to be fixed, was not tested previously due to legacy exception
     "Prophet": ":test_hierarchical_with_exogeneous",

--- a/aeon/tests/test_all_estimators.py
+++ b/aeon/tests/test_all_estimators.py
@@ -13,7 +13,6 @@ import types
 from copy import deepcopy
 from inspect import getfullargspec, isclass, signature
 from tempfile import TemporaryDirectory
-from warnings import warn
 
 import joblib
 import numpy as np
@@ -492,22 +491,6 @@ class QuickTester:
         ... )
         {'test_repr[NaiveForecaster-2]': 'PASSED'}
         """
-        # todo 0.17.0: remove this code block
-        if return_exceptions is None and raise_exceptions is None:
-            raise_exceptions = False
-
-        if return_exceptions is not None and raise_exceptions is None:
-            warn(
-                "The return_exceptions argument of check_estimator has been deprecated "
-                "since 0.15.1, and will be replaced by raise_exceptions in 0.17.0. "
-                "For safe deprecation: use raise_exceptions argument instead of "
-                "return_exceptions when using keywords. Avoid positional use, instead "
-                "ensure to use keywords. When not using keywords, the "
-                "default behaviour will not change."
-            )
-            raise_exceptions = not return_exceptions
-        # end block to remove
-
         tests_to_run = self._check_None_str_or_list_of_str(
             tests_to_run, var_name="tests_to_run"
         )
@@ -1195,7 +1178,7 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
             (including hyper-parameters and fitted parameters)
         2. expected output type of the method matches actual output type
             - only for abstract BaseEstimator methods, common to all estimator scitypes
-            list of BaseEstimator methdos tested: get_fitted_params
+            list of BaseEstimator methods tested: get_fitted_params
             scitype specific method outputs are tested in TestAll[estimatortype] class
         """
         estimator = estimator_instance
@@ -1294,7 +1277,7 @@ class TestAllEstimators(BaseFixtureGenerator, QuickTester):
             and method_nsc == "predict_proba"
         ):
             return None
-        # escape Deep estimators they dont use pickle
+        # escape Deep estimators since they dont use pickle
         if isinstance(estimator_instance, (BaseDeepClassifier, BaseDeepRegressor)):
             return None
 

--- a/aeon/transformations/panel/summarize/_extract.py
+++ b/aeon/transformations/panel/summarize/_extract.py
@@ -96,8 +96,8 @@ class PlateauFinder(BaseTransformer):
         -------
         X : pandas data frame
         """
-        self._starts = []
-        self._lengths = []
+        _starts = []
+        _lengths = []
 
         # find plateaus (segments of the same value)
         for x in X[:, 0]:
@@ -123,8 +123,8 @@ class PlateauFinder(BaseTransformer):
             starts = starts[lengths >= self.min_length]
             lengths = lengths[lengths >= self.min_length]
 
-            self._starts.append(starts)
-            self._lengths.append(lengths)
+            _starts.append(starts)
+            _lengths.append(lengths)
 
         # put into dataframe
         Xt = pd.DataFrame()
@@ -132,8 +132,8 @@ class PlateauFinder(BaseTransformer):
             "channel_",
             "nan" if np.isnan(self.value) else str(self.value),
         )
-        Xt["%s_starts" % column_prefix] = pd.Series(self._starts)
-        Xt["%s_lengths" % column_prefix] = pd.Series(self._lengths)
+        Xt["%s_starts" % column_prefix] = pd.Series(_starts)
+        Xt["%s_lengths" % column_prefix] = pd.Series(_lengths)
 
         Xt = Xt.applymap(lambda x: pd.Series(x))
         return Xt


### PR DESCRIPTION
This PR tidies up some of the exclusions in testing/_config.py and updates some of the issues

1. Removes exclusions I dont think we need any more. Many referenced issues in the bad place which have since been closed. If they cause intermittent failure, I would like to see the fails, raise an issue and re-exclude again.
 2. Removes a redundant function from RISE
 3. Changes PlateauFinder to not store the intervals it uses
 

#### Reference Issues/PRs
#472 #347 
