### PR TITLE
[DOC] Change README logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <a href="https://aeon-toolkit.org"><img src="./docs/images/logo/aeon-logo-blue-compact.png" width="50%" alt="aeon logo" /></a>
+    <a href="https://aeon-toolkit.org"><img src="https://github.com/aeon-toolkit/aeon/blob/main/docs/images/logo/aeon-logo-blue-compact.png" width="50%" alt="aeon logo" /></a>
 </p>
 
 # ⌛ Welcome to **aeon**


### PR DESCRIPTION
The current one is relative and doesnt show up on PyPi