### PR TITLE
[BUG] RDST bugfixes

### DIFF
--- a/aeon/distances/__init__.py
+++ b/aeon/distances/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Distance computation."""
-__author__ = ["chrisholder", "TonyBagnall"]
+__author__ = ["chrisholder", "TonyBagnall", "baraline"]
 __all__ = [
     "create_bounding_matrix",
     "squared_distance",
     "squared_pairwise_distance",
     "euclidean_distance",
     "euclidean_pairwise_distance",
+    "manhattan_distance",
+    "manhattan_pairwise_distance",
     "dtw_distance",
     "dtw_pairwise_distance",
     "dtw_cost_matrix",
@@ -95,6 +97,7 @@ from aeon.distances._lcss import (
     lcss_distance,
     lcss_pairwise_distance,
 )
+from aeon.distances._manhattan import manhattan_distance, manhattan_pairwise_distance
 from aeon.distances._msm import (
     msm_alignment_path,
     msm_cost_matrix,

--- a/aeon/distances/_manhattan.py
+++ b/aeon/distances/_manhattan.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+__author__ = ["chrisholder", "TonyBagnall", "baraline"]
+
+import numpy as np
+from numba import njit
+
+from aeon.distances._utils import reshape_pairwise_to_multiple
+
+
+@njit(cache=True, fastmath=True)
+def manhattan_distance(x: np.ndarray, y: np.ndarray) -> float:
+    r"""Compute the manhattan distance between two time series.
+
+    The manhattan distance between two time series is defined as:
+    .. math::
+        manhattan(x, y) = \sum_{i=1}^{n} |x_i - y_i|
+
+    Parameters
+    ----------
+    x: np.ndarray, of shape (n_channels, n_timepoints) or (n_timepoints,)
+        First time series.
+    y: np.ndarray, of shape (m_channels, m_timepoints) or (m_timepoints,)
+        Second time series.
+
+    Returns
+    -------
+    float
+        manhattan distance between x and y.
+
+    Raises
+    ------
+    ValueError
+        If x and y are not 1D or 2D arrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.distances import manhattan_distance
+    >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+    >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
+    >>> manhattan_distance(x, y)
+    100.0
+    """
+    if x.ndim == 1 and y.ndim == 1:
+        return _univariate_manhattan_distance(x, y)
+    if x.ndim == 2 and y.ndim == 2:
+        return _manhattan_distance(x, y)
+    raise ValueError("x and y must be 1D or 2D")
+
+
+@njit(cache=True, fastmath=True)
+def _manhattan_distance(x: np.ndarray, y: np.ndarray) -> float:
+    distance = 0.0
+    min_val = min(x.shape[0], y.shape[0])
+    for i in range(min_val):
+        distance += _univariate_manhattan_distance(x[i], y[i])
+    return distance
+
+
+@njit(cache=True, fastmath=True)
+def _univariate_manhattan_distance(x: np.ndarray, y: np.ndarray) -> float:
+    distance = 0.0
+    min_length = min(x.shape[0], y.shape[0])
+    for i in range(min_length):
+        difference = x[i] - y[i]
+        distance += abs(difference)
+    return distance
+
+
+@njit(cache=True, fastmath=True)
+def manhattan_pairwise_distance(X: np.ndarray, y: np.ndarray = None) -> np.ndarray:
+    """Compute the manhattan pairwise distance between a set of time series.
+
+    Parameters
+    ----------
+    X: np.ndarray, of shape (n_instances, n_channels, n_timepoints) or
+            (n_instances, n_timepoints) or (n_timepoints,)
+        A collection of time series instances.
+    y: np.ndarray, of shape (m_instances, m_channels, m_timepoints) or
+            (m_instances, m_timepoints) or (m_timepoints,), default=None
+        A collection of time series instances.
+
+
+    Returns
+    -------
+    np.ndarray (n_instances, n_instances)
+        manhattan pairwise matrix between the instances of X.
+
+    Raises
+    ------
+    ValueError
+        If X is not 2D or 3D array when only passing X.
+        If X and y are not 1D, 2D or 3D arrays when passing both X and y.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.distances import manhattan_pairwise_distance
+    >>> X = np.array([[[1, 2, 3, 4]],[[4, 5, 6, 3]], [[7, 8, 9, 3]]])
+    >>> manhattan_pairwise_distance(X)
+    array([[ 0., 10., 19.],
+           [10.,  0.,  9.],
+           [19.,  9.,  0.]])
+
+    >>> X = np.array([[[1, 2, 3]],[[4, 5, 6]], [[7, 8, 9]]])
+    >>> y = np.array([[[11, 12, 13]],[[14, 15, 16]], [[17, 18, 19]]])
+    >>> manhattan_pairwise_distance(X, y)
+    array([[30., 39., 48.],
+           [21., 30., 39.],
+           [12., 21., 30.]])
+
+    >>> X = np.array([[[1, 2, 3]],[[4, 5, 6]], [[7, 8, 9]]])
+    >>> y_univariate = np.array([[11, 12, 13],[14, 15, 16], [17, 18, 19]])
+    >>> manhattan_pairwise_distance(X, y_univariate)
+    array([[30.],
+           [21.],
+           [12.]])
+
+    """
+    if y is None:
+        # To self
+        if X.ndim == 3:
+            return _manhattan_pairwise_distance(X)
+        elif X.ndim == 2:
+            _X = X.reshape((X.shape[0], 1, X.shape[1]))
+            return _manhattan_pairwise_distance(_X)
+        raise ValueError("X must be 2D or 3D array")
+    _x, _y = reshape_pairwise_to_multiple(X, y)
+    return _manhattan_from_multiple_to_multiple_distance(_x, _y)
+
+
+@njit(cache=True, fastmath=True)
+def _manhattan_pairwise_distance(X: np.ndarray) -> np.ndarray:
+    n_instances = X.shape[0]
+    distances = np.zeros((n_instances, n_instances))
+
+    for i in range(n_instances):
+        for j in range(i + 1, n_instances):
+            distances[i, j] = manhattan_distance(X[i], X[j])
+            distances[j, i] = distances[i, j]
+
+    return distances
+
+
+@njit(cache=True, fastmath=True)
+def _manhattan_from_multiple_to_multiple_distance(
+    x: np.ndarray, y: np.ndarray
+) -> np.ndarray:
+    n_instances = x.shape[0]
+    m_instances = y.shape[0]
+    distances = np.zeros((n_instances, m_instances))
+
+    for i in range(n_instances):
+        for j in range(m_instances):
+            distances[i, j] = manhattan_distance(x[i], y[j])
+    return distances

--- a/aeon/transformations/collection/tests/test_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/tests/test_dilated_shapelet_transform.py
@@ -5,16 +5,20 @@ __author__ = ["baraline"]
 
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+)
 
 from aeon.datasets import load_basic_motions
+from aeon.distances import manhattan_distance
 from aeon.transformations.collection.dilated_shapelet_transform import (
     RandomDilatedShapeletTransform,
-    compute_normalized_shapelet_dist_vector,
     compute_shapelet_dist_vector,
     compute_shapelet_features,
-    compute_shapelet_features_normalized,
-    sliding_mean_std_one_series,
+    get_all_subsequences,
+    normalize_subsequences,
 )
 from aeon.utils.numba.stats import is_prime
 
@@ -32,15 +36,57 @@ def test_shapelet_prime_dilation():
 
 
 @pytest.mark.parametrize("dtype", DATATYPES)
+def test_normalize_subsequences(dtype):
+    X = np.asarray([[[1, 1, 1]], [[1, 1, 1]]], dtype=dtype)
+    X_norm = normalize_subsequences(X, X.mean(axis=2), X.std(axis=2))
+    assert np.all(X_norm == 0)
+    assert np.all(X.shape == X_norm.shape)
+
+
+@pytest.mark.parametrize("dtype", DATATYPES)
+def test_get_all_subsequences(dtype):
+    X = np.asarray([[1, 2, 3, 4, 5, 6, 7, 8]], dtype=dtype)
+    length = 3
+    dilation = 1
+    X_subs = get_all_subsequences(X, length, dilation)
+    X_true = np.asarray(
+        [
+            [[1, 2, 3]],
+            [[2, 3, 4]],
+            [[3, 4, 5]],
+            [[4, 5, 6]],
+            [[5, 6, 7]],
+            [[6, 7, 8]],
+        ],
+        dtype=dtype,
+    )
+    assert_array_equal(X_subs, X_true)
+
+    length = 3
+    dilation = 2
+    X_subs = get_all_subsequences(X, length, dilation)
+    X_true = np.asarray(
+        [
+            [[1, 3, 5]],
+            [[2, 4, 6]],
+            [[3, 5, 7]],
+            [[4, 6, 8]],
+        ],
+        dtype=dtype,
+    )
+    assert_array_equal(X_subs, X_true)
+
+
+@pytest.mark.parametrize("dtype", DATATYPES)
 def test_compute_shapelet_features(dtype):
     X = np.asarray([[1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 2]], dtype=dtype)
     values = np.asarray([[1, 1, 2]], dtype=dtype)
     length = 3
     dilation = 1
     threshold = 0.01
-
+    X_subs = get_all_subsequences(X, length, dilation)
     _min, _argmin, SO = compute_shapelet_features(
-        X, values, length, dilation, threshold
+        X_subs, values, length, dilation, threshold, manhattan_distance
     )
 
     # On some occasion, float32 precision with fasmath retruns things like
@@ -51,9 +97,9 @@ def test_compute_shapelet_features(dtype):
 
     dilation = 2
     threshold = 0.1
-
+    X_subs = get_all_subsequences(X, length, dilation)
     _min, _argmin, SO = compute_shapelet_features(
-        X, values, length, dilation, threshold
+        X_subs, values, length, dilation, threshold, manhattan_distance
     )
 
     assert_almost_equal(_min, 0.0, decimal=4)
@@ -62,9 +108,9 @@ def test_compute_shapelet_features(dtype):
 
     dilation = 4
     threshold = 2
-
+    X_subs = get_all_subsequences(X, length, dilation)
     _min, _argmin, SO = compute_shapelet_features(
-        X, values, length, dilation, threshold
+        X_subs, values, length, dilation, threshold, manhattan_distance
     )
 
     assert_almost_equal(_min, 0.0, decimal=4)
@@ -73,86 +119,18 @@ def test_compute_shapelet_features(dtype):
 
 
 @pytest.mark.parametrize("dtype", DATATYPES)
-def test_compute_shapelet_features_normalized(dtype):
-    X = np.asarray(
-        [[0, 3 * 1, 1 * 1, 2 * 1, 0, 3 * 2, 1 * 2, 2 * 2, 0, 3 * 3, 1 * 3, 2 * 3]],
-        dtype=dtype,
-    )
-    values = np.asarray([[3 * 4, 1 * 4, 2 * 4]], dtype=dtype)
-    length = 3
-    dilation = 1
-    threshold = 0.01
-
-    X_means, X_stds = sliding_mean_std_one_series(X, length, dilation)
-    means = values.mean(axis=1)
-    stds = values.std(axis=1)
-
-    _min, _argmin, SO = compute_shapelet_features_normalized(
-        X, values, length, dilation, threshold, X_means, X_stds, means, stds
-    )
-    # On some occasion, float32 precision with fasmath retruns things like
-    # 2.1835059227370834e-07 instead of 0
-    assert_almost_equal(_min, 0.0)
-    assert _argmin == 1.0
-    assert SO == 3.0
-
-    values = np.asarray([[5 * 4, 5 * 5, 5 * 6]], dtype=dtype)
-    dilation = 4
-    means = values.mean(axis=1)
-    stds = values.std(axis=1)
-
-    _min, _argmin, SO = compute_shapelet_features_normalized(
-        X, values, length, dilation, threshold, X_means, X_stds, means, stds
-    )
-
-    assert_almost_equal(_min, 0.0)
-    # Scale invariance should match with the sets of 3*
-    assert _argmin == 1.0
-    # And should also do so for the 1* and 2*, all spaced by dilation 4
-    assert SO == 3.0
-
-
-@pytest.mark.parametrize("dtype", DATATYPES)
-def test_compute_normalized_shapelet_dist_vector(dtype):
-    # Constant case is tested with dtype int
-    for length in [3, 5]:
-        for dilation in [1, 3, 5]:
-            X = (np.random.rand(3, 50)).astype(dtype)
-            values = np.random.rand(3, length).astype(dtype)
-            d_vect = compute_normalized_shapelet_dist_vector(
-                X, values, length, dilation, values.mean(axis=1), values.std(axis=1)
-            )
-            norm_values = values - values.mean(axis=1, keepdims=True)
-            for i_channel in range(X.shape[0]):
-                if values[i_channel].std() > 0:
-                    norm_values[i_channel] /= values[i_channel].std()
-
-            true_vect = np.zeros(X.shape[1] - (length - 1) * dilation)
-            for i_sub in range(true_vect.shape[0]):
-                _idx = [i_sub + j * dilation for j in range(length)]
-                for i_channel in range(X.shape[0]):
-                    norm_sub = X[i_channel, _idx]
-                    norm_sub = norm_sub - norm_sub.mean()
-                    if norm_sub.std() > 0:
-                        norm_sub /= norm_sub.std()
-                    for i_l in range(length):
-                        _v = norm_values[i_channel, i_l] - norm_sub[i_l]
-                        true_vect[i_sub] += _v * _v
-
-            assert_array_almost_equal(d_vect, true_vect)
-
-
-@pytest.mark.parametrize("dtype", DATATYPES)
 def test_compute_shapelet_dist_vector(dtype):
     X = np.random.rand(3, 50).astype(dtype)
     for length in [3, 5]:
         for dilation in [1, 3, 5]:
             values = np.random.rand(3, length).astype(dtype)
-            d_vect = compute_shapelet_dist_vector(X, values, length, dilation)
+            X_subs = get_all_subsequences(X, length, dilation)
+            d_vect = compute_shapelet_dist_vector(
+                X_subs, values, length, dilation, manhattan_distance
+            )
             true_vect = np.zeros(X.shape[1] - (length - 1) * dilation)
             for i_sub in range(true_vect.shape[0]):
                 _idx = [i_sub + j * dilation for j in range(length)]
-                for i_channel in range(X.shape[0]):
-                    _sub = X[i_channel, _idx]
-                    true_vect[i_sub] += ((values[i_channel] - _sub) ** 2).sum()
+                _sub = X[:, _idx]
+                true_vect[i_sub] += manhattan_distance(values, _sub)
             assert_array_almost_equal(d_vect, true_vect)

--- a/aeon/utils/numba/general.py
+++ b/aeon/utils/numba/general.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """General numba utilities."""
 
-__author__ = ["MatthewMiddlehurst"]
+__author__ = ["MatthewMiddlehurst", "baraline"]
 __all__ = [
     "unique_count",
     "first_order_differences",
@@ -415,51 +415,54 @@ def sliding_mean_std_one_series(
     """
     n_channels, n_timestamps = X.shape
     n_subs = n_timestamps - (length - 1) * dilation
+    if n_subs <= 0:
+        raise ValueError(
+            "Invalid input parameter for sliding mean and std computations"
+        )
     mean = np.zeros((n_channels, n_subs))
     std = np.zeros((n_channels, n_subs))
 
-    for i_channel in prange(n_channels):
-        mod_dil = n_subs % dilation
-        for i_mod_dilation in prange(dilation):
-            if i_mod_dilation + (length - 1) * dilation >= n_timestamps:
-                break
+    for i_mod_dil in prange(dilation):
+        # Array mainting indexes of a dilated subsequence
+        _idx_sub = np.zeros(length, dtype=np.int32)
+        for i_length in prange(length):
+            _idx_sub[i_length] = (i_length * dilation) + i_mod_dil
 
-            _idx = i_mod_dilation
-            _sum = 0
-            _sum2 = 0
-            # Init First sums
-            for _ in prange(length):
-                _v = X[i_channel, _idx]
-                _sum += _v
-                _sum2 += _v * _v
-                _idx += dilation
+        _sum = np.zeros(n_channels)
+        _sum2 = np.zeros(n_channels)
 
-            mean[i_channel, i_mod_dilation] = _sum / length
-            _s = (_sum2 / length) - (mean[i_channel, i_mod_dilation] ** 2)
-            if _s > 0:
-                std[i_channel, i_mod_dilation] = _s**0.5
-            # Number of remaining subsequence for each starting i_mod_dilation index
+        # Initialize first subsequence if it is valid
+        if np.all(_idx_sub < n_timestamps):
+            for i_length in prange(length):
+                _idx_sub[i_length] = (i_length * dilation) + i_mod_dil
+                for i_channel in prange(n_channels):
+                    _v = X[i_channel, _idx_sub[i_length]]
+                    _sum[i_channel] += _v
+                    _sum2[i_channel] += _v * _v
 
-            n_subs_mod_d = n_subs // dilation
-            if mod_dil > 0:
-                n_subs_mod_d += 1
-                mod_dil -= 1
-            # Iteratively update sums
-            start_idx_sub = i_mod_dilation + dilation
-            for _ in prange(1, n_subs_mod_d):
-                # New value, not present in the previous subsequence
-                _v_new = X[i_channel, start_idx_sub + ((length - 1) * dilation)]
-                # Index of the old value, not present in the current subsequence
-                _v_old = X[i_channel, start_idx_sub - dilation]
-
-                _sum += _v_new - _v_old
-                _sum2 += (_v_new * _v_new) - (_v_old * _v_old)
-
-                mean[i_channel, start_idx_sub] = _sum / length
-                _s = (_sum2 / length) - (mean[i_channel, start_idx_sub] ** 2)
+            # Compute means and stds
+            for i_channel in prange(n_channels):
+                mean[i_channel, i_mod_dil] = _sum[i_channel] / length
+                _s = (_sum2[i_channel] / length) - (mean[i_channel, i_mod_dil] ** 2)
                 if _s > 0:
-                    std[i_channel, start_idx_sub] = _s**0.5
-                start_idx_sub += dilation
+                    std[i_channel, i_mod_dil] = _s**0.5
+
+        _idx_sub += dilation
+        # As long as subsequences further subsequences are valid
+        while np.all(_idx_sub < n_timestamps):
+            # Update sums and mean stds arrays
+            for i_channel in prange(n_channels):
+                _v_new = X[i_channel, _idx_sub[-1]]
+                _v_old = X[i_channel, _idx_sub[0] - dilation]
+                _sum[i_channel] += _v_new - _v_old
+                _sum2[i_channel] += (_v_new * _v_new) - (_v_old * _v_old)
+
+                mean[i_channel, _idx_sub[0]] = _sum[i_channel] / length
+                _s = (_sum2[i_channel] / length) - (mean[i_channel, _idx_sub[0]] ** 2)
+                if _s > 0:
+                    std[i_channel, _idx_sub[0]] = _s**0.5
+            _idx_sub += dilation
+
     return mean, std
 
 

--- a/aeon/utils/numba/tests/test_general.py
+++ b/aeon/utils/numba/tests/test_general.py
@@ -56,8 +56,8 @@ def test_get_subsequence_with_mean_std(dtype):
 @pytest.mark.parametrize("dtype", DATATYPES)
 def test_sliding_mean_std_one_series(dtype):
     X = np.random.rand(3, 150).astype(dtype)
-    for length in [3, 5, 11]:
-        for dilation in [1, 3, 5, 6]:
+    for length in [5, 50]:
+        for dilation in [1, 3]:
             mean, std = sliding_mean_std_one_series(X, length, dilation)
             for i_sub in range(X.shape[1] - (length - 1) * dilation):
                 _idx = [i_sub + j * dilation for j in range(length)]
@@ -71,6 +71,14 @@ def test_sliding_mean_std_one_series(dtype):
                 else:
                     assert_array_almost_equal(X[:, _idx].mean(axis=1), mean[:, i_sub])
                     assert_array_almost_equal(X[:, _idx].std(axis=1), std[:, i_sub])
+
+    # Test error on wrong dimension
+    error_str = "Invalid input parameter for sliding mean and std computations"
+    with pytest.raises(ValueError, match=error_str):
+        mean, std = sliding_mean_std_one_series(X, 100, 3)
+
+    with pytest.raises(ValueError, match=error_str):
+        mean, std = sliding_mean_std_one_series(X, 100, 3)
 
 
 @pytest.mark.parametrize("dtype", DATATYPES)


### PR DESCRIPTION
This PR introduce bug fixes for RDST transformer to make its performance equal to the performance of the original implementation in the convst package.

#### What does this implement/fix? Explain your changes.

- Additional Fixes for #474 
- Distance function as argument, with Manhattan distance as default, as in convst.
- Added Manhattan distance to aeon distances
- Fixed the initialization of the lambda threshold, it was only considering the lower bound and not both the lower and upper bounds.
- Refactored distance vector and shapelet feature extraction
- Removed the tentative optimization of using MASS algorithm to compute normalized distance profiles, this will be introduced in a future PR using the distance function argument to specify if it shall be used or not.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- @MatthewMiddlehurst noted some huge accuracy difference between the convst implementation and this one, I validated locally that the differences are gone, but a check from someone else would be nice.

#### Did you add any tests for the change?

Unit test were added for the new functions, and I updated the one for #474

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc).
- [X] Optionally, I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
- [X] For new estimators, I've added the estimator to the online documentation.