### PR TITLE
[REF] change single class use case

### DIFF
--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -91,9 +91,13 @@ class BaseClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : 3D np.array (any number of channels, equal length series)
-                of shape [n_instances, n_channels, n_timepoints]
+                of shape (n_instances, n_channels, n_timepoints)
             or 2D np.array (univariate, equal length series)
-                of shape [n_instances, n_timepoints]
+                of shape (n_instances, n_timepoints)
+            or list of numpy arrays (any number of channels, unequal length series)
+                of shape [n_instances], 2D np.array n_channels, n_timepoints_i), where
+                n_timepoints_i is length of series i
+            other types are allowed and converted into one of the above.
         y : 1D np.array, of shape [n_instances] - class labels for fitting
             indices correspond to instance indices in X
 
@@ -160,8 +164,14 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array of shape (n_instances, n_channels, n_timepoints)
-            or 2D np.array of shape (n_instances, n_timepoints)
+        X : 3D np.array (any number of channels, equal length series)
+                of shape (n_instances, n_channels, n_timepoints)
+            or 2D np.array (univariate, equal length series)
+                of shape (n_instances, n_timepoints)
+            or list of numpy arrays (any number of channels, unequal length series)
+                of shape [n_instances], 2D np.array n_channels, n_timepoints_i), where
+                n_timepoints_i is length of series i
+            other types are allowed and converted into one of the above.
 
         Returns
         -------
@@ -186,8 +196,14 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array of shape (n_cases, n_channels, n_timepoints)
-            or 2D np.array of shape (n_cases, n_timepoints)
+        X : 3D np.array (any number of channels, equal length series)
+                of shape (n_instances, n_channels, n_timepoints)
+            or 2D np.array (univariate, equal length series)
+                of shape (n_instances, n_timepoints)
+            or list of numpy arrays (any number of channels, unequal length series)
+                of shape [n_instances], 2D np.array n_channels, n_timepoints_i), where
+                n_timepoints_i is length of series i
+            other types are allowed and converted into one of the above.
 
         Returns
         -------
@@ -215,9 +231,13 @@ class BaseClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : 3D np.array (any number of channels, equal length series)
-                of shape [n_instances, n_channels, n_timepoints]
+                of shape (n_instances, n_channels, n_timepoints)
             or 2D np.array (univariate, equal length series)
-                of shape [n_instances, n_timepoints]
+                of shape (n_instances, n_timepoints)
+            or list of numpy arrays (any number of channels, unequal length series)
+                of shape [n_instances], 2D np.array n_channels, n_timepoints_i), where
+                n_timepoints_i is length of series i
+            other types are allowed and converted into one of the above.
         y : 1D np.ndarray of shape [n_instances] - class labels (ground truth)
             indices correspond to instance indices in X
 
@@ -262,10 +282,10 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
+                3D np.ndarray of shape = (n_instances, n_channels, n_timepoints)
             if self.get_tag("X_inner_mtype") = "np-list":
                 list of 2D np.ndarray of shape = [n_instances]
-        y : 1D np.array of int, of shape [n_instances] - class labels for fitting
+        y : 1D np.array of int, of shape (n_instances,) - class labels for fitting
             indices correspond to instance indices in X
 
         Returns
@@ -290,13 +310,13 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
+                3D np.ndarray of shape = (n_instances, n_channels, n_timepoints)
             if self.get_tag("X_inner_mtype") = "np-list":
-                list of 2D np.ndarray of shape = [n_instances]
+                list of 2D np.ndarray of shape = (n_instances,)
 
         Returns
         -------
-        y : 1D np.array of int, of shape [n_instances] - predicted class labels
+        y : 1D np.array of int, of shape (n_instances,) - predicted class labels
             indices correspond to instance indices in X
         """
         ...
@@ -312,7 +332,9 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
+                3D np.ndarray of shape = (n_instances, n_channels, n_timepoints)
+            if self.get_tag("X_inner_mtype") = "np-list":
+                list of 2D np.ndarray of shape = (n_instances,)
 
         Returns
         -------

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -85,44 +85,6 @@ class BaseClassifier(BaseEstimator, ABC):
         super(BaseClassifier, self).__init__()
         _check_estimator_deps(self)
 
-    def __rmul__(self, other):
-        """Magic * method, return concatenated ClassifierPipeline, transformers on left.
-
-        Overloaded multiplication operation for classifiers. Implemented for `other`
-        being a transformer, otherwise returns `NotImplemented`.
-
-        Parameters
-        ----------
-        other: `aeon` transformer, must inherit from BaseTransformer
-            otherwise, `NotImplemented` is returned
-
-        Returns
-        -------
-        ClassifierPipeline object, concatenation of `other` (first) with `self` (last).
-        """
-        from aeon.classification.compose import ClassifierPipeline
-        from aeon.transformations.base import BaseTransformer
-        from aeon.transformations.compose import TransformerPipeline
-        from aeon.transformations.series.adapt import TabularToSeriesAdaptor
-
-        # behaviour is implemented only if other inherits from BaseTransformer
-        #  in that case, distinctions arise from whether self or other is a pipeline
-        #  todo: this can probably be simplified further with "zero length" pipelines
-        if isinstance(other, BaseTransformer):
-            # ClassifierPipeline already has the dunder method defined
-            if isinstance(self, ClassifierPipeline):
-                return other * self
-            # if other is a TransformerPipeline but self is not, first unwrap it
-            elif isinstance(other, TransformerPipeline):
-                return ClassifierPipeline(classifier=self, transformers=other.steps)
-            # if neither self nor other are a pipeline, construct a ClassifierPipeline
-            else:
-                return ClassifierPipeline(classifier=self, transformers=[other])
-        elif is_sklearn_transformer(other):
-            return TabularToSeriesAdaptor(other) * self
-        else:
-            return NotImplemented
-
     def fit(self, X, y):
         """Fit time series classifier to training data.
 
@@ -546,6 +508,43 @@ class BaseClassifier(BaseEstimator, ABC):
         if y is None:
             return X
         return X, y
+
+    def __rmul__(self, other):
+        """Magic * method, return concatenated ClassifierPipeline, transformers on left.
+
+        Overloaded multiplication operation for classifiers. Implemented for `other`
+        being a transformer, otherwise returns `NotImplemented`.
+
+        Parameters
+        ----------
+        other: `aeon` transformer, must inherit from BaseTransformer
+            otherwise, `NotImplemented` is returned
+
+        Returns
+        -------
+        ClassifierPipeline object, concatenation of `other` (first) with `self` (last).
+        """
+        from aeon.classification.compose import ClassifierPipeline
+        from aeon.transformations.base import BaseTransformer
+        from aeon.transformations.compose import TransformerPipeline
+        from aeon.transformations.series.adapt import TabularToSeriesAdaptor
+
+        # behaviour is implemented only if other inherits from BaseTransformer
+        #  in that case, distinctions arise from whether self or other is a pipeline
+        if isinstance(other, BaseTransformer):
+            # ClassifierPipeline already has the dunder method defined
+            if isinstance(self, ClassifierPipeline):
+                return other * self
+            # if other is a TransformerPipeline but self is not, first unwrap it
+            elif isinstance(other, TransformerPipeline):
+                return ClassifierPipeline(classifier=self, transformers=other.steps)
+            # if neither self nor other are a pipeline, construct a ClassifierPipeline
+            else:
+                return ClassifierPipeline(classifier=self, transformers=[other])
+        elif is_sklearn_transformer(other):
+            return TabularToSeriesAdaptor(other) * self
+        else:
+            return NotImplemented
 
 
 def _get_n_cases(X):

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -91,10 +91,10 @@ class BaseClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : 3D np.array (any number of channels, equal length series)
-                of shape [n_instances, n_channels, series_length]
+                of shape [n_instances, n_channels, n_timepoints]
             or 2D np.array (univariate, equal length series)
-                of shape [n_instances, series_length]
-        y : 1D np.array of int, of shape [n_instances] - class labels for fitting
+                of shape [n_instances, n_timepoints]
+        y : 1D np.array, of shape [n_instances] - class labels for fitting
             indices correspond to instance indices in X
 
         Returns
@@ -160,12 +160,12 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array of shape (n_instances, n_channels, series_length)
-            or 2D np.array of shape (n_instances, series_length)
+        X : 3D np.array of shape (n_instances, n_channels, n_timepoints)
+            or 2D np.array of shape (n_instances, n_timepoints)
 
         Returns
         -------
-        y : 1D np.array of int, of shape [n_instances] - predicted class labels
+        y : 1D np.array, of shape [n_instances] - predicted class labels
             indices correspond to instance indices in X
         """
         self.check_is_fitted()
@@ -186,8 +186,8 @@ class BaseClassifier(BaseEstimator, ABC):
 
         Parameters
         ----------
-        X : 3D np.array of shape (n_cases, n_channels, series_length)
-            or 2D np.array of shape (n_cases, series_length)
+        X : 3D np.array of shape (n_cases, n_channels, n_timepoints)
+            or 2D np.array of shape (n_cases, n_timepoints)
 
         Returns
         -------
@@ -215,9 +215,9 @@ class BaseClassifier(BaseEstimator, ABC):
         Parameters
         ----------
         X : 3D np.array (any number of channels, equal length series)
-                of shape [n_instances, n_channels, series_length]
+                of shape [n_instances, n_channels, n_timepoints]
             or 2D np.array (univariate, equal length series)
-                of shape [n_instances, series_length]
+                of shape [n_instances, n_timepoints]
         y : 1D np.ndarray of shape [n_instances] - class labels (ground truth)
             indices correspond to instance indices in X
 
@@ -262,7 +262,9 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, series_length]
+                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
+            if self.get_tag("X_inner_mtype") = "np-list":
+                list of 2D np.ndarray of shape = [n_instances]
         y : 1D np.array of int, of shape [n_instances] - class labels for fitting
             indices correspond to instance indices in X
 
@@ -288,7 +290,9 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, series_length]
+                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
+            if self.get_tag("X_inner_mtype") = "np-list":
+                list of 2D np.ndarray of shape = [n_instances]
 
         Returns
         -------
@@ -308,7 +312,7 @@ class BaseClassifier(BaseEstimator, ABC):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_channels, series_length]
+                3D np.ndarray of shape = [n_instances, n_channels, n_timepoints]
 
         Returns
         -------

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -100,9 +100,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
     # todo: add any parameters to constructor
     def __init__(self, param_a, param_b="default", param_c=None):
         # estimators should precede parameters
-        #  if estimators have default values, set None and initalize below
+        #  if estimators have default values, set None and initialize below
         # Note that parameters passed and set in constructor should not be changed
-        # in order to comply withe scikit learn strucutre. Intead, copy into local
+        # in order to comply withe scikit learn structure. Instead, copy into local
         # variables and use them.
 
         # todo: copy parameters to self, use same names

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -99,11 +99,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
 
     # todo: add any parameters to constructor
     def __init__(self, param_a, param_b="default", param_c=None):
-        # estimators should precede parameters
-        #  if estimators have default values, set None and initialize below
         # Note that parameters passed and set in constructor should not be changed
-        # in order to comply withe scikit learn structure. Instead, copy into local
-        # variables and use them.
+        # anywhere else. This is in order to comply with scikit learn structure.
+        # Instead, copy into local variables in fit and predict and use these.
 
         # todo: copy parameters to self, use same names
         self.param_a = param_a

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -86,8 +86,8 @@ class MyTimeSeriesClassifier(BaseClassifier):
     # these are the default values, only add if different to these.
     _tags = {
         "X_inner_mtype": "numpy3D",  # which type do _fit/_predict accept, usually
-        # this is usually "numpy3D" Other types are allowable, see
-        # datatypes/panel/_registry.py for options.
+        # this is usually "numpy3D" for equal length time series, np-list for unequal
+        # length time series, see datatypes/panel/_registry.py for options.
         "capability:multivariate": False,
         "capability:unequal_length": False,
         "capability:missing_values": False,
@@ -97,10 +97,13 @@ class MyTimeSeriesClassifier(BaseClassifier):
         "python_version": None,  # PEP 440 python version specifier to limit versions
     }
 
-    # todo: add any hyper-parameters and components to constructor
+    # todo: add any parameters to constructor
     def __init__(self, param_a, param_b="default", param_c=None):
         # estimators should precede parameters
         #  if estimators have default values, set None and initalize below
+        # Note that parameters passed and set in constructor should not be changed
+        # in order to comply withe scikit learn strucutre. Intead, copy into local
+        # variables and use them.
 
         # todo: copy parameters to self, use same names
         self.param_a = param_a
@@ -151,7 +154,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+                3D np.ndarray of shape = (n_instances, n_channels, n_timepoints)
+            if self.get_tag("X_inner_mtype") = "np-list":
+                list of 2D np.ndarray of shape = (n_instances,)
 
         Returns
         -------
@@ -178,7 +183,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
         ----------
         X : guaranteed to be of a type in self.get_tag("X_inner_mtype")
             if self.get_tag("X_inner_mtype") = "numpy3D":
-                3D np.ndarray of shape = [n_instances, n_dimensions, series_length]
+                3D np.ndarray of shape = (n_instances, n_channels, n_timepoints)
+            if self.get_tag("X_inner_mtype") = "np-list":
+                list of 2D np.ndarray of shape = (n_instances,)
 
         Returns
         -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,14 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
+    --durations 10
+    --timeout 600
+    --cov aeon
+    --cov-report xml
+    --cov-report html
+    --showlocals
+    --matrixdesign True
+    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,6 @@ addopts =
     --ignore examples
     --ignore docs
     --doctest-modules
-    --durations 10
-    --timeout 600
-    --cov aeon
-    --cov-report xml
-    --cov-report html
-    --showlocals
-    --matrixdesign True
-    -n auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

We have an internal mechanism in base classifier for the edge case when all the y values seen in fit are the same. The predict and predict_proba then just return that value or prob = 1 of that value.

this was done by a call to check_is_scitype, which involves multiple scans of the data. This simplifies it by using len, except for the edge case of using multi index DataFrame. 

Also removed a pointless duplication in tests and moved the overloaded operator to the bottom of the file and changed series_length to n_timepoints. 