### PR TITLE
[BUG] reduce test size for MultiRocket

### DIFF
--- a/aeon/transformations/collection/rocket/tests/test_MultiRocketMultivariate.py
+++ b/aeon/transformations/collection/rocket/tests/test_MultiRocketMultivariate.py
@@ -13,18 +13,17 @@ from aeon.transformations.collection.rocket import MultiRocketMultivariate
 def test_multirocket_multivariate_on_basic_motions():
     """Test of MultiRocketMultivariate on basic motions."""
     # load training data
-    X_training, Y_training = load_basic_motions(split="train", return_X_y=True)
+    X_training, Y_training = load_basic_motions(split="train")
 
     # 'fit' MultiRocket -> infer data dimensions, generate random kernels
-    multirocket = MultiRocketMultivariate(random_state=0)
+    multirocket = MultiRocketMultivariate(random_state=0, num_kernels=100)
     multirocket.fit(X_training)
 
     # transform training data
     X_training_transform = multirocket.transform(X_training)
 
-    # test shape of transformed training data -> (number of training
-    # examples, nearest multiple of 4*84=336 < 50,000 (2*4*6_250))
-    np.testing.assert_equal(X_training_transform.shape, (len(X_training), 49_728))
+    # test shape of transformed training data  nearest multiple of 4*84=336
+    np.testing.assert_equal(X_training_transform.shape, (len(X_training), 672))
 
     # fit classifier
     classifier = make_pipeline(
@@ -34,14 +33,13 @@ def test_multirocket_multivariate_on_basic_motions():
     classifier.fit(X_training_transform, Y_training)
 
     # load test data
-    X_test, Y_test = load_basic_motions(split="test", return_X_y=True)
+    X_test, Y_test = load_basic_motions(split="test")
 
     # transform test data
     X_test_transform = multirocket.transform(X_test)
 
-    # test shape of transformed test data -> (number of test examples,
-    # nearest multiple of 4*84=336 < 50,000 (2*4*6_250))
-    np.testing.assert_equal(X_test_transform.shape, (len(X_test), 49_728))
+    # test shape of transformed training data  nearest multiple of 4*84=336
+    np.testing.assert_equal(X_test_transform.shape, (len(X_test), 672))
 
     # predict (alternatively: 'classifier.score(X_test_transform, Y_test)')
     predictions = classifier.predict(X_test_transform)


### PR DESCRIPTION
Test size for multirocket sometimes exceeds the memory allowance for CI, see
https://github.com/aeon-toolkit/aeon/actions/runs/5392735109/jobs/9791701994?pr=514
this just reduces the size to reduce the memory footprint