### PR TITLE
[MNT] Set upper bound for `tslearn` to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ all_extras = [
     "tensorflow-probability",
     "tensorflow",
     "tsfresh>=0.20.0",
-    "tslearn>=0.5.2",
+    "tslearn>=0.5.2,<0.6.0",
     "xarray",
     "mlflow<2.4.0", # see https://github.com/mlflow/mlflow/issues/8629
 ]


### PR DESCRIPTION
New version has a bug importing `torch` which breaks CI.