### PR TITLE
[MNT] Change `esig` dependency version requirements to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 all_extras = [
     "cloudpickle",
     "dask",
-    "esig>=0.9.7; python_version < '3.11'",
+    "esig>=0.9.7,<0.9.8.3; python_version < '3.11'",
     "filterpy>=1.4.5",
     "h5py",
     "hmmlearn>=0.2.7",
@@ -62,7 +62,7 @@ all_extras = [
     "kotsu>=0.3.1",
     "matplotlib>=3.3.2",
     "mne",
-    "pmdarima>=1.8.0,!=1.8.1,<3.0.0",
+    "pmdarima>=1.8.0,<3.0.0",
     "prophet>=1.1",
     "pyod>=0.8.0",
     "scikit_posthocs>=0.6.5",


### PR DESCRIPTION
Currently the wheels for the latest version on Windows 3.9 are breaking.