### PR TITLE
[MNT] Exclude results loading notebook

### DIFF
--- a/build_tools/run_examples.sh
+++ b/build_tools/run_examples.sh
@@ -5,7 +5,10 @@ set -euxo pipefail
 
 CMD="jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.timeout=600"
 
-excluded=("examples/datasets/benchmarking_data.ipynb")
+excluded=(
+  "examples/datasets/benchmarking_data.ipynb"
+  "examples/benchmarking/results_loading.ipynb"
+)
 
 # Loop over all notebooks in the examples directory.
 find "examples/" -name "*.ipynb" -print0 |


### PR DESCRIPTION
The notebook loads data from an external source, so we should not run it in our CI. It is currently failing, but this is for multiple PRs so it may require looking at if it's not an external issue @TonyBagnall.