### PR TITLE
reduce examples time for clusterers

### DIFF
--- a/aeon/clustering/clara.py
+++ b/aeon/clustering/clara.py
@@ -87,9 +87,9 @@ class TimeSeriesCLARA(BaseClusterer):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of PAM clustering
-    >>> km = TimeSeriesCLARA(n_clusters=3, distance="dtw", random_state=1)
+    >>> km = TimeSeriesCLARA(n_clusters=3, distance="euclidean", random_state=1)
     >>> km.fit(X_train)
-    TimeSeriesCLARA(distance='dtw', n_clusters=3, random_state=1)
+    TimeSeriesCLARA(distance='euclidean', n_clusters=3, random_state=1)
     >>> preds = km.predict(X_test)
 
     References

--- a/aeon/clustering/clarans.py
+++ b/aeon/clustering/clarans.py
@@ -81,9 +81,9 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of PAM clustering
-    >>> km = TimeSeriesCLARANS(n_clusters=3, distance="dtw", random_state=1)
+    >>> km = TimeSeriesCLARANS(n_clusters=3, distance="euclidean", random_state=1)
     >>> km.fit(X_train)
-    TimeSeriesCLARANS(distance='dtw', n_clusters=3, random_state=1)
+    TimeSeriesCLARANS(distance='euclidean', n_clusters=3, random_state=1)
     >>> preds = km.predict(X_test)
 
     References

--- a/aeon/clustering/k_medoids.py
+++ b/aeon/clustering/k_medoids.py
@@ -100,9 +100,9 @@ class TimeSeriesKMedoids(BaseClusterer):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of PAM clustering
-    >>> km = TimeSeriesKMedoids(n_clusters=3, distance="dtw", random_state=1)
+    >>> km = TimeSeriesKMedoids(n_clusters=3, distance="euclidean", random_state=1)
     >>> km.fit(X_train)
-    TimeSeriesKMedoids(distance='dtw', n_clusters=3, random_state=1)
+    TimeSeriesKMedoids(distance='euclidean', n_clusters=3, random_state=1)
     >>> pam_pred = km.predict(X_test)
 
     # Example of alternate clustering


### PR DESCRIPTION
the overnight tests run everything without numba so we can properly measure coverage. The cluster examples take ages or time out with DTW, so this simply sets the distance in the examples to euclidean