### PR TITLE
[MNT] Rename `--matrixdesign` and update documentation

### DIFF
--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -8,9 +8,9 @@ import os
 from aeon.base import BaseEstimator, BaseObject
 from aeon.registry import BASE_CLASS_LIST, BASE_CLASS_LOOKUP, ESTIMATOR_TAG_LIST
 
-# whether to subsample estimators per os/version partition matrix design
-# default is False, can be set to True by pytest --matrixdesign True flag
-MATRIXDESIGN = False
+# whether to use smaller parameter matrices for test generation and subsample estimators
+# per os/version default is False, can be set to True by pytest --prtesting True flag
+PR_TESTING = False
 
 EXCLUDE_ESTIMATORS = [
     # SFA is non-compliant with any transformer interfaces, #2064

--- a/aeon/tests/test_all_estimators.py
+++ b/aeon/tests/test_all_estimators.py
@@ -5,7 +5,7 @@
 adapted from scikit-learn's estimator_checks
 """
 
-__author__ = ["mloning", "fkiraly", "achieveordie"]
+__author__ = ["mloning", "fkiraly", "achieveordie", "MatthewMiddlehurst"]
 
 import numbers
 import types
@@ -29,9 +29,9 @@ from aeon.regression.deep_learning.base import BaseDeepRegressor
 from aeon.tests._config import (
     EXCLUDE_ESTIMATORS,
     EXCLUDED_TESTS,
-    MATRIXDESIGN,
     NON_STATE_CHANGING_METHODS,
     NON_STATE_CHANGING_METHODS_ARRAYLIKE,
+    PR_TESTING,
     VALID_ESTIMATOR_BASE_TYPES,
     VALID_ESTIMATOR_TAGS,
 )
@@ -61,12 +61,12 @@ def subsample_by_version_os(x):
     Ensures each estimator is tested at least once on every OS and python version,
     if combined with a matrix of OS/versions.
 
-    Currently assumes that matrix includes py3.8-3.10, and win/ubuntu/mac.
+    Currently assumes that matrix includes py3.8-3.11, and win/ubuntu/mac.
     """
     import platform
     import sys
 
-    ix = sys.version_info.minor % 3
+    ix = sys.version_info.minor % 4
     os_str = platform.system()
     if os_str == "Windows":
         ix = ix
@@ -191,10 +191,11 @@ class BaseFixtureGenerator:
             return_names=False,
             exclude_estimators=EXCLUDE_ESTIMATORS,
         )
+
         # subsample estimators by OS & python version
         # this ensures that only a 1/3 of estimators are tested for a given combination
         # but all are tested on every OS at least once, and on every python version once
-        if MATRIXDESIGN:
+        if PR_TESTING:
             est_list = subsample_by_version_os(est_list)
         return est_list
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
+# copyright: aeon developers, BSD-3-Clause License (see LICENSE file)
 """Main configuration file for pytest.
 
 Contents:
-adds a --matrixdesign option to pytest
-this allows to turn on/off the sub-sampling in the tests (for shorter runtime)
-"on" condition is partition/block design to ensure each estimator full tests are run
-    on each operating system at least once, and on each python version at least once,
-    but not necessarily on each operating system / python version combination
-by default, this is off, including for default local runs of pytest
+Adds a --prtesting option to pytest.
+This allows for smaller parameter matrices to be used for certain tests and enables
+sub-sampling in the tests (for shorter runtime) ensuring that each estimators full
+tests are run on each operating system at least once, and on each python version at
+least once, but not necessarily on each operating system / python version combination.
 """
-# copyright: aeon developers, BSD-3-Clause License (see LICENSE file)
 
-__author__ = ["fkiraly"]
+__author__ = ["fkiraly", "MatthewMiddlehurst"]
 
 from aeon.tests import _config
 
@@ -19,13 +18,17 @@ from aeon.tests import _config
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
     parser.addoption(
-        "--matrixdesign",
+        "--prtesting",
         default=False,
-        help="sub-sample estimators in tests by os/version matrix partition design",
+        help=(
+            "Toggle for PR test configuration. Uses smaller parameter matrices for "
+            "test generation and sub-samples estimators in tests by workflow os/py "
+            "version."
+        ),
     )
 
 
 def pytest_configure(config):
     """Pytest configuration preamble."""
-    if config.getoption("--matrixdesign") in [True, "True"]:
-        _config.MATRIXDESIGN = True
+    if config.getoption("--prtesting") in [True, "True"]:
+        _config.PR_TESTING = True


### PR DESCRIPTION
#### Reference Issues/PRs

Should probably wait for these first
#597
#437

#### What does this implement/fix? Explain your changes.

Updates the name and comments for "matrixdesign" testing to better reflect its usage as a toggle for faster PR testing.


