### PR TITLE
[MNT] Remove InceptionTime estimators from test exclusion

### DIFF
--- a/aeon/classification/deep_learning/inception_time.py
+++ b/aeon/classification/deep_learning/inception_time.py
@@ -145,6 +145,8 @@ class InceptionTimeClassifier(BaseClassifier):
     _tags = {
         "python_dependencies": "tensorflow",
         "capability:multivariate": True,
+        "non-deterministic": True,
+        "cant-pickle": True,
         "algorithm_type": "deeplearning",
     }
 

--- a/aeon/regression/deep_learning/inception_time.py
+++ b/aeon/regression/deep_learning/inception_time.py
@@ -147,6 +147,8 @@ class InceptionTimeRegressor(BaseRegressor):
     _tags = {
         "python_dependencies": "tensorflow",
         "capability:multivariate": True,
+        "non-deterministic": True,
+        "cant-pickle": True,
         "algorithm_type": "deeplearning",
     }
 

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -29,18 +29,6 @@ if os.environ.get("NUMBA_DISABLE_JIT") == "1":
     EXCLUDE_ESTIMATORS.append("StatsForecastAutoARIMA")
 
 EXCLUDED_TESTS = {
-    # InceptionTimeClassifier contains deep learners, it isnt one itself, so still
-    # exclude
-    "InceptionTimeClassifier": [
-        "test_fit_deterministic",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
-    "InceptionTimeRegressor": [
-        "test_fit_deterministic",
-        "test_persistence_via_pickle",
-        "test_save_estimators_to_file",
-    ],
     # issue when predicting residuals, see #3479
     "SquaringResiduals": ["test_predict_residuals"],
     # known issue when X is passed, wrong time indices are returned, #1364
@@ -76,7 +64,6 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    "CNNNetwork": "test_inheritance",  # not a registered base class, WiP, see #3028
     "VARMAX": [
         "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
         "test__y_when_refitting",  # see 3176


### PR DESCRIPTION
see #347 
Adds the `non-deterministic` and `cant-pickle` tags used by other deep learners and enables the previous disabled tests. Also adds back the CNNNetwork test.