### PR TITLE
[ENH] Remove top of file warnings for soft dependencies

### DIFF
--- a/aeon/annotation/adapters/_pyod.py
+++ b/aeon/annotation/adapters/_pyod.py
@@ -13,8 +13,6 @@ __author__ = ["mloning", "satya-pattnaik", "fkiraly"]
 
 import pandas as pd
 
-_check_soft_dependencies("pyod", severity="warning")
-
 
 class PyODAnnotator(BaseSeriesAnnotator):
     """Transformer that applies outlier detector from pyOD.

--- a/aeon/annotation/hmm_learn/gaussian.py
+++ b/aeon/annotation/hmm_learn/gaussian.py
@@ -9,12 +9,9 @@ Please see the original library
 from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 __author__ = ["miraep8"]
 __all__ = ["GaussianHMM"]
-
-_check_soft_dependencies("hmmlearn.hmm", severity="warning")
 
 
 class GaussianHMM(BaseHMMLearn):

--- a/aeon/annotation/hmm_learn/gmm.py
+++ b/aeon/annotation/hmm_learn/gmm.py
@@ -9,13 +9,9 @@ Please see the original library
 from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 __author__ = ["miraep8"]
 __all__ = ["GMMHMM"]
-
-
-_check_soft_dependencies("hmmlearn.hmm", severity="warning")
 
 
 class GMMHMM(BaseHMMLearn):

--- a/aeon/annotation/hmm_learn/poisson.py
+++ b/aeon/annotation/hmm_learn/poisson.py
@@ -9,12 +9,9 @@ Please see the original library
 from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 __author__ = ["klam-data", "pyyim", "mgorlin"]
 __all__ = ["PoissonHMM"]
-
-_check_soft_dependencies("hmmlearn.hmm", severity="warning")
 
 
 class PoissonHMM(BaseHMMLearn):

--- a/aeon/benchmarking/_critical_difference.py
+++ b/aeon/benchmarking/_critical_difference.py
@@ -12,8 +12,6 @@ from scipy.stats import distributions, find_repeats, rankdata, wilcoxon
 from aeon.benchmarking.utils import get_qalpha
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("matplotlib", severity="warning")
-
 
 def _check_friedman(n_estimators, n_datasets, ranked_data, alpha):
     """

--- a/aeon/clustering/k_shapes.py
+++ b/aeon/clustering/k_shapes.py
@@ -8,8 +8,6 @@ from numpy.random import RandomState
 from aeon.clustering.base import BaseClusterer, TimeSeriesInstances
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tslearn", severity="warning")
-
 
 class TimeSeriesKShapes(BaseClusterer):
     """Kshape algorithm wrapper tslearns implementation.

--- a/aeon/clustering/kernel_k_means.py
+++ b/aeon/clustering/kernel_k_means.py
@@ -8,8 +8,6 @@ from numpy.random import RandomState
 from aeon.clustering.base import BaseClusterer, TimeSeriesInstances
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-_check_soft_dependencies("tslearn", severity="warning")
-
 
 class TimeSeriesKernelKMeans(BaseClusterer):
     """Kernel algorithm wrapper tslearns implementation.

--- a/aeon/forecasting/arima.py
+++ b/aeon/forecasting/arima.py
@@ -7,9 +7,6 @@ __author__ = ["mloning", "hyang1996", "fkiraly", "ilkersigirci"]
 __all__ = ["AutoARIMA", "ARIMA"]
 
 from aeon.forecasting.base.adapters._pmdarima import _PmdArimaAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("pmdarima", severity="warning")
 
 
 class AutoARIMA(_PmdArimaAdapter):

--- a/aeon/forecasting/bats.py
+++ b/aeon/forecasting/bats.py
@@ -13,9 +13,6 @@ __author__ = ["Martin Walter"]
 __all__ = ["BATS"]
 
 from aeon.forecasting.base.adapters import _TbatsAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("tbats", severity="warning")
 
 
 class BATS(_TbatsAdapter):

--- a/aeon/forecasting/fbprophet.py
+++ b/aeon/forecasting/fbprophet.py
@@ -9,9 +9,6 @@ __all__ = ["Prophet"]
 
 from aeon.forecasting.base._base import DEFAULT_ALPHA
 from aeon.forecasting.base.adapters import _ProphetAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("prophet", severity="warning")
 
 
 class Prophet(_ProphetAdapter):

--- a/aeon/forecasting/statsforecast.py
+++ b/aeon/forecasting/statsforecast.py
@@ -9,10 +9,6 @@ __all__ = ["StatsForecastAutoARIMA"]
 from typing import Dict, Optional
 
 from aeon.forecasting.base.adapters._statsforecast import _StatsForecastAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("statsforecast", severity="warning")
-_check_soft_dependencies("pandas<2.0.0", severity="warning")
 
 
 class StatsForecastAutoARIMA(_StatsForecastAdapter):
@@ -165,7 +161,7 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
     """
 
     _tags = {
-        "python_dependencies": ["statsforecast", "pandas<2.0.0"],
+        "python_dependencies": "statsforecast",
     }
 
     def __init__(

--- a/aeon/forecasting/statsforecast.py
+++ b/aeon/forecasting/statsforecast.py
@@ -161,7 +161,7 @@ class StatsForecastAutoARIMA(_StatsForecastAdapter):
     """
 
     _tags = {
-        "python_dependencies": "statsforecast",
+        "python_dependencies": ["statsforecast", "pandas<2.0.0"],
     }
 
     def __init__(

--- a/aeon/forecasting/tbats.py
+++ b/aeon/forecasting/tbats.py
@@ -13,9 +13,6 @@ __author__ = ["Martin Walter"]
 __all__ = ["TBATS"]
 
 from aeon.forecasting.base.adapters import _TbatsAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("tbats", severity="warning")
 
 
 class TBATS(_TbatsAdapter):

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -8,9 +8,6 @@ import warnings
 import pandas as pd
 
 from aeon.forecasting.base.adapters import _StatsModelsAdapter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("pandas<2.0.0", severity="warning")
 
 
 class VARMAX(_StatsModelsAdapter):

--- a/aeon/networks/cnn.py
+++ b/aeon/networks/cnn.py
@@ -6,8 +6,6 @@ __author__ = ["James-Large", "Withington", "TonyBagnall", "hadifawaz1999"]
 from aeon.networks.base import BaseDeepNetwork
 from aeon.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class CNNNetwork(BaseDeepNetwork):
     """Establish the network structure for a CNN.

--- a/aeon/networks/encoder.py
+++ b/aeon/networks/encoder.py
@@ -6,8 +6,6 @@ __author__ = ["hadifawaz1999"]
 from aeon.networks.base import BaseDeepNetwork
 from aeon.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class EncoderNetwork(BaseDeepNetwork):
     """Establish the network structure for an Encoder.

--- a/aeon/networks/fcn.py
+++ b/aeon/networks/fcn.py
@@ -6,8 +6,6 @@ __author__ = ["James-Large", "AurumnPegasus", "hadifawaz1999"]
 from aeon.networks.base import BaseDeepNetwork
 from aeon.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class FCNNetwork(BaseDeepNetwork):
     """

--- a/aeon/networks/inception.py
+++ b/aeon/networks/inception.py
@@ -5,8 +5,6 @@ __author__ = ["James-Large", "Withington", "TonyBagnall", "hadifawaz1999"]
 from aeon.networks.base import BaseDeepNetwork
 from aeon.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class InceptionNetwork(BaseDeepNetwork):
     """InceptionTime Network.

--- a/aeon/networks/mlp.py
+++ b/aeon/networks/mlp.py
@@ -6,8 +6,6 @@ __author__ = ["James-Large", "Withington", "AurumnPegasus"]
 from aeon.networks.base import BaseDeepNetwork
 from aeon.utils.validation._dependencies import _check_dl_dependencies
 
-_check_dl_dependencies(severity="warning")
-
 
 class MLPNetwork(BaseDeepNetwork):
     """Establish the network structure for a MLP.

--- a/aeon/networks/tapnet.py
+++ b/aeon/networks/tapnet.py
@@ -15,13 +15,6 @@ from aeon.utils.validation._dependencies import (
     _check_soft_dependencies,
 )
 
-_check_soft_dependencies(
-    "keras-self-attention",
-    package_import_alias={"keras-self-attention": "keras_self_attention"},
-    severity="warning",
-)
-_check_dl_dependencies(severity="warning")
-
 
 class TapNetNetwork(BaseDeepNetwork):
     """Establish Network structure for TapNet.

--- a/aeon/transformations/collection/tsfresh.py
+++ b/aeon/transformations/collection/tsfresh.py
@@ -8,9 +8,6 @@ __all__ = ["TSFreshFeatureExtractor", "TSFreshRelevantFeatureExtractor"]
 from aeon.datatypes._panel._convert import from_3d_numpy_to_long
 from aeon.transformations.collection.base import BaseCollectionTransformer
 from aeon.utils.validation import check_n_jobs
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("tsfresh", severity="warning")
 
 
 class _TSFreshFeatureExtractor(BaseCollectionTransformer):

--- a/aeon/transformations/series/bkfilter.py
+++ b/aeon/transformations/series/bkfilter.py
@@ -15,9 +15,6 @@ import numpy as np
 import pandas as pd
 
 from aeon.transformations.base import BaseTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("statsmodels", severity="warning")
 
 
 class BKFilter(BaseTransformer):

--- a/aeon/transformations/series/filter.py
+++ b/aeon/transformations/series/filter.py
@@ -7,9 +7,6 @@ __all__ = ["Filter"]
 import numpy as np
 
 from aeon.transformations.base import BaseTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("mne", severity="warning")
 
 
 class Filter(BaseTransformer):

--- a/aeon/transformations/series/kalman_filter.py
+++ b/aeon/transformations/series/kalman_filter.py
@@ -18,9 +18,6 @@ from warnings import warn
 import numpy as np
 
 from aeon.transformations.base import BaseTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("filterpy", severity="warning")
 
 
 def _get_t_matrix(time_t, matrices, shape, time_steps):

--- a/aeon/transformations/series/matrix_profile.py
+++ b/aeon/transformations/series/matrix_profile.py
@@ -7,9 +7,6 @@ __author__ = ["mloning"]
 __all__ = ["MatrixProfileTransformer"]
 
 from aeon.transformations.base import BaseTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
-
-_check_soft_dependencies("stumpy", severity="warning")
 
 
 class MatrixProfileTransformer(BaseTransformer):

--- a/aeon/utils/mlflow_aeon.py
+++ b/aeon/utils/mlflow_aeon.py
@@ -55,6 +55,9 @@ from aeon import utils
 from aeon.utils.multiindex import flatten_multiindex
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
+if _check_soft_dependencies("mlflow", severity="none"):
+    from mlflow import pyfunc
+
 FLAVOR_NAME = "mlflow_aeon"
 
 PYFUNC_PREDICT_CONF = "pyfunc_predict_conf"
@@ -210,7 +213,6 @@ def save_model(
     >>> loaded_model.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
-    from mlflow import pyfunc
     from mlflow.exceptions import MlflowException
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
@@ -583,7 +585,6 @@ def _load_pyfunc(path):
     .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
-    from mlflow import pyfunc
     from mlflow.exceptions import MlflowException
     from mlflow.utils.model_utils import _get_flavor_configuration
 

--- a/aeon/utils/mlflow_aeon.py
+++ b/aeon/utils/mlflow_aeon.py
@@ -55,9 +55,6 @@ from aeon import utils
 from aeon.utils.multiindex import flatten_multiindex
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-if _check_soft_dependencies("mlflow", severity="warning"):
-    from mlflow import pyfunc
-
 FLAVOR_NAME = "mlflow_aeon"
 
 PYFUNC_PREDICT_CONF = "pyfunc_predict_conf"
@@ -213,6 +210,7 @@ def save_model(
     >>> loaded_model.predict(fh=[1, 2, 3])  # doctest: +SKIP
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
+    from mlflow import pyfunc
     from mlflow.exceptions import MlflowException
     from mlflow.models import Model
     from mlflow.models.model import MLMODEL_FILE_NAME
@@ -585,6 +583,7 @@ def _load_pyfunc(path):
     .. [1] https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.load_model
     """  # noqa: E501
     _check_soft_dependencies("mlflow", severity="error")
+    from mlflow import pyfunc
     from mlflow.exceptions import MlflowException
     from mlflow.utils.model_utils import _get_flavor_configuration
 

--- a/docs/developer_guide/dependencies.rst
+++ b/docs/developer_guide/dependencies.rst
@@ -43,9 +43,6 @@ To add an estimator with a soft dependency, ensure the following:
 *  the ``python_dependencies`` tag of the estimator is populated with a ``str``,
    or a ``list`` of ``str``, of import dependencies. Exceptions will automatically raised when constructing the estimator
    in an environment without the required packages.
-*  in the python module containing the estimator, the ``_check_soft_dependencies`` utility is called
-   at the top of the module, with ``severity="warning"``. This will raise an informative warning message already at module import.
-   See `here <https://github.com/aeon-toolkit/aeon/blob/main/aeon/utils/validation/_dependencies.py>`__
 *  In a case where the package import differs from the package name, i.e., ``import package_string`` is different from
    ``pip install different-package-string`` (usually the case for packages containing a dash in the name), the ``_check_soft_dependencies``
    utility should be used in ``__init__``. Both the warning and constructor call should use the ``package_import_alias`` argument for this.

--- a/extension_templates/classification.py
+++ b/extension_templates/classification.py
@@ -37,12 +37,6 @@ from aeon.classification.base import BaseClassifier
 
 # todo: add any necessary imports here
 
-# todo: if any imports are aeon soft dependencies:
-#  * make sure to fill in the "python_dependencies" tag with the package import name
-#  * add a _check_soft_dependencies warning here, example:
-# from sktime.utils.validation._dependencies import check_soft_dependencies
-# _check_soft_dependencies("soft_dependency_name", severity="warning")
-
 
 class MyTimeSeriesClassifier(BaseClassifier):
     """Custom time series classifier. todo: write docstring.
@@ -81,6 +75,9 @@ class MyTimeSeriesClassifier(BaseClassifier):
     --------
     todo: Add a simple use case example here
     """
+
+    # todo: if any imports are aeon soft dependencies:
+    #  * make sure to fill in the "python_dependencies" tag with the package import name
 
     # optional todo: override base class estimator default tags here if necessary
     # these are the default values, only add if different to these.

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -46,13 +46,6 @@ from aeon.forecasting.base import BaseForecaster
 
 # todo: add any necessary imports here
 
-# todo: if any imports are aeon soft dependencies:
-#  * make sure to fill in the "python_dependencies" tag with the package import name
-#  * add a _check_soft_dependencies warning here, example:
-#
-# from aeon.utils.validation._dependencies import check_soft_dependencies
-# _check_soft_dependencies("soft_dependency_name", severity="warning")
-
 
 class MyForecaster(BaseForecaster):
     """Custom forecaster. todo: write docstring.
@@ -74,6 +67,9 @@ class MyForecaster(BaseForecaster):
         descriptive explanation of est2
     and so on
     """
+
+    # todo: if any imports are aeon soft dependencies:
+    #  * make sure to fill in the "python_dependencies" tag with the package import name
 
     # todo: fill out estimator tags here
     #  tags are inherited from parent class if they are not set

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -44,13 +44,6 @@ from aeon.transformations.base import BaseTransformer
 
 # todo: add any necessary aeon internal imports here
 
-# todo: if any imports are aeon soft dependencies:
-#  * make sure to fill in the "python_dependencies" tag with the package import name
-#  * add a _check_soft_dependencies warning here, example:
-#
-# from aeon.utils.validation._dependencies import check_soft_dependencies
-# _check_soft_dependencies("soft_dependency_name", severity="warning")
-
 
 class MyTransformer(BaseTransformer):
     """Custom transformer. todo: write docstring.
@@ -74,6 +67,9 @@ class MyTransformer(BaseTransformer):
         descriptive explanation of est2
     and so on
     """
+
+    # todo: if any imports are aeon soft dependencies:
+    #  * make sure to fill in the "python_dependencies" tag with the package import name
 
     # todo: fill out estimator tags here
     #  tags are inherited from parent class if they are not set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ all_extras = [
     "scikit_posthocs>=0.6.5",
     "seaborn>=0.11.0",
     "statsforecast>=0.5.2",
+    "plotly-resampler>=0.9.0", # from statsforecast, needed for pandas2
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tbats>=1.1.0",


### PR DESCRIPTION
Current procedure for soft dependencies is to top a warning when imported if the soft dependency package is missing.

IMO, this does not accomplish much. Either you are directly using the contents of the package and will run into an error because of the missing dependency anyway with the relevant information, or you are indirectly importing the contents while using surrounding functionality in which case the warning is not required.

I think it would remove a lot of output clutter if we remove them. People are welcome to give their thoughts on the current procedure and the usefulness of these warnings.