### PR TITLE
[DOC] Add @dguijo to core developer table and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,9 +34,8 @@ aeon/performance_metrics/annotation/ @lmmentel
 
 aeon/pipeline/ @aiwalter
 
-aeon/regression/ @MatthewMiddlehurst @TonyBagnall
-aeon/regression/feature_based/_fresh_prince.py @dguijo @MatthewMiddlehurst @TonyBagnall
-aeon/regression/deep_learning @hadifawaz1999 @MatthewMiddlehurst @TonyBagnall
+aeon/regression/ @MatthewMiddlehurst @TonyBagnall @dguijo
+aeon/regression/deep_learning @hadifawaz1999 @MatthewMiddlehurst @TonyBagnall @dguijo
 
 aeon/transformations/collection/ @MatthewMiddlehurst @TonyBagnall
 aeon/transformations/collection/dictionary_based/ @patrickzib @MatthewMiddlehurst

--- a/docs/about/core_developers.rst
+++ b/docs/about/core_developers.rst
@@ -27,6 +27,10 @@
     <p><a href='https://github.com/MatthewMiddlehurst'>Matthew Middlehurst</a></p>
     </div>
     <div>
+    <a href='https://github.com/dguijo'><img src='https://avatars.githubusercontent.com/u/47889499?v=4' class='avatar' /></a> <br />
+    <p><a href='https://github.com/dguijo'>David Guijo Rubio</a></p>
+    </div>
+    <div>
     <a href='https://github.com/patrickzib'><img src='https://avatars.githubusercontent.com/u/7783034?v=4' class='avatar' /></a> <br />
     <p><a href='https://github.com/patrickzib'>Patrick Schäfer</a></p>
     </div>


### PR DESCRIPTION
Adds @dguijo to the About webpage as a core developer and adds them to the CODEOWNERS for regression after the recent core developer vote.

If there are any other changes required/requested just post them here.