### PR TITLE
[BUG] remove unnecessary call to os.path.dirname

### DIFF
--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -219,7 +219,7 @@ def load_from_tsfile(
     """
     # Check file ends in .ts, if not, insert
     if not full_file_path_and_name.endswith(".ts"):
-        full_file_path_and_name = os.path.join(full_file_path_and_name, ".ts")
+        full_file_path_and_name = full_file_path_and_name + ".ts"
     # Open file
     with open(full_file_path_and_name, "r", encoding="utf-8") as file:
         # Read in headers

--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -219,7 +219,7 @@ def load_from_tsfile(
     """
     # Check file ends in .ts, if not, insert
     if not full_file_path_and_name.endswith(".ts"):
-        full_file_path_and_name = full_file_path_and_name + ".ts"
+        full_file_path_and_name = os.path.join(full_file_path_and_name, ".ts")
     # Open file
     with open(full_file_path_and_name, "r", encoding="utf-8") as file:
         # Read in headers
@@ -430,7 +430,7 @@ def _load_tsc_dataset(
     """
     # Allow user to have non standard extract path
     if extract_path is not None:
-        local_module = os.path.dirname(extract_path)
+        local_module = extract_path
         local_dirname = ""
     else:
         local_module = MODULE
@@ -1176,7 +1176,7 @@ def load_regression(name, split=None, extract_path=None, return_metadata=True):
     from aeon.datasets.tser_data_lists import tser_all
 
     if extract_path is not None:
-        local_module = os.path.dirname(extract_path)
+        local_module = extract_path
         local_dirname = ""
     else:
         local_module = MODULE
@@ -1294,7 +1294,7 @@ def download_all_regression(extract_path=None):
         where to download the fip file. If none, it goes in
     """
     if extract_path is not None:
-        local_module = os.path.dirname(extract_path)
+        local_module = extract_path
         local_dirname = ""
     else:
         local_module = MODULE

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
-addopts =
-    --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,12 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
+addopts =
+    --doctest-modules
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
#### Reference Issues/PRs

fixes (hopefully) #676 

#### What does this implement/fix? Explain your changes.

load_classification/regression/forecasting had a redundant call to os.path.dirname for the extract path, perhaps a legacy of previously passing the file name with the path. This meant this fails

https://gist.github.com/BenGravell/9a0a8257d4fed5f543a721a2ad6d0ee0

removing the call makes no difference I can see, apart from removing the need for the suffix slash 