### PR TITLE
[DOC] Developer and `conda` install instructions 

### DIFF
--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -5,7 +5,7 @@ contribute to the `aeon` codebase and documentation. The following guide will wa
 through downloading the latest development source code from GitHub and installing
 the package.
 
-Prior to these steps, we highly recommend creating a [virtual environment](../installation.md#Using-a-pip-venv)
+Prior to these steps, we highly recommend creating a [virtual environment](../installation.md#using-a-pip-venv)
 for the installation.
 
 ## Step 1 - Clone the repository

--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -8,7 +8,7 @@ the package.
 Prior to these steps, we highly recommend creating a [virtual environment](../installation.md#Using-a-pip-venv)
 for the installation.
 
-## Step 1 - Clone the git repository
+## Step 1 - Clone the repository
 
 The `aeon` repository should be cloned to a local directory using [Git](https://git-scm.com/).
 

--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -5,7 +5,7 @@ contribute to the `aeon` codebase and documentation. The following guide will wa
 through downloading the latest development source code from GitHub and installing
 the package.
 
-Prior to these steps, we highly recommend creating a [virtual environment](#Using-a-pip-venv)
+Prior to these steps, we highly recommend creating a [virtual environment](../installation.md#Using-a-pip-venv)
 for the installation.
 
 ## Step 1 - Clone the git repository

--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -1,124 +1,69 @@
 # Developer Installation
 
-To install the latest development version of ``aeon``, or earlier versions, the sequence of steps is as follows:
+Building the `aeon` package from source is a requirement for users who wish to
+contribute to the `aeon` codebase and documentation. The following guide will walk
+through downloading the latest development source code from GitHub and installing
+the package.
 
-Step 1 - ``git`` clone the ``aeon`` repository, the latest version or an earlier version.
-Step 2 - ensure build requirements are satisfied
-Step 3 - ``pip`` install the package from a ``git`` clone, with the ``editable`` parameter.
+Prior to these steps, we highly recommend creating a [virtual environment](#Using-a-pip-venv)
+for the installation.
 
-Detail instructions for all steps are given below.
-For brevity, we discuss steps 1 and 3 first; step 2 is discussed at the end, as it will depend on the operating system.
+## Step 1 - Clone the git repository
 
-## Step 1 - clone the git repository
+The `aeon` repository should be cloned to a local directory using [Git](https://git-scm.com/).
 
-The ``aeon`` repository should be cloned to a local directory, using a graphical user interface, or the command line.
-
-Using the ``git`` command line, the sequence of commands to install the latest version is as follows:
-
-```{code-block} powershell
-    git clone https://github.com/aeon-toolkit/aeon.git
-    cd aeon
-    git checkout main
-    git pull
-```
-
-To build a previous version, replace line 3 with:
+Using the `git` command line, the following commands will clone the `main` branch of the
+repository to a local directory:
 
 ```{code-block} powershell
-    git checkout <VERSION>
+git clone https://github.com/aeon-toolkit/aeon.git
+cd aeon
 ```
 
-This will checkout the code for the version ``<VERSION>``, where ``<VERSION>`` is a valid version string.
-Valid version strings are the repository's ``git`` tags, which can be inspected by running ``git tag``.
+If you plan to make a pull request on the GitHub repository, you should first [fork](https://github.com/aeon-toolkit/aeon/fork)
+the repository and clone your fork instead of the main repository.
 
-You can also [download](https://github.com/aeon-toolkit/aeon/releases) a zip archive of the version from GitHub.
+## Step 2 - Building `aeon` from source
 
-## Step 2 - satisfying build requirements
-
-Before carrying out step 3, the ``aeon`` build requirements need to be satisfied.
-Details for this differ by operating system, and can be found in the `aeon build requirements` section below.
-
-Typically, the set-up steps needs to be carried out only once per system.
-
-## Step 3 - building aeon from source
-
-To build and install ``aeon`` from source, navigate to the local clone's root directory and type:
+To build and install ``aeon`` from source, navigate to the local clone's root directory
+and type:
 
 ```{code-block} powershell
-    pip install .
+pip install --editable .[dev]
 ```
 
-Alternatively, the ``.`` may be replaced with a full or relative path to the root directory.
+Alternatively, the `.` may be replaced with a full or relative path to the root
+directory.
 
-For a developer install that updates the package each time the local source code is changed, install ``aeon`` in editable mode, via:
+This will install the `aeon` package in editable mode with dependencies required for
+development. The `--editable` flag allows you to edit the code in-place and have the
+changes reflected in the installed package without having to re-install the package.
+
+If you need to work with optional dependencies, it you can also install the `all_extras`
+extras:
 
 ```{code-block} powershell
-    pip install --editable .[dev]
-```
-
-This allows editing and extending the code in-place. See also
-`pip reference on editable installs <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).
-
-```{note}
-    You will have to re-run:
-
-    pip install --editable .
-
-    every time the source code of a compiled extension is changed (for
-    instance when switching branches or pulling changes from upstream).
-```
-
-## Building binary packages and installers
-
-The ``.whl`` package and ``.exe`` installers can be built with:
-
-```{code-block} powershell
-    pip install build
-    python -m build --wheel
-```
-
-The resulting packages are generated in the ``dist/`` folder.
-
-
-## aeon build requirements
-
-This section outlines the ``aeon`` build requirements. These are required for:
-
-* installing ``aeon`` from source, e.g., development versions
-* the advanced developer set-up
-
-
-## Setting up a development environment
-
-First set up a new virtual environment. Our instructions will go through the commands to set up a ``conda`` environment which is recommended for aeon development.
-This relies on an `anaconda installation <https://www.anaconda.com/products/individual#windows>`_. The process will be similar for ``venv`` or other virtual environment managers.
-
-In the ``anaconda prompt`` terminal:
-
-1. Navigate to your local aeon folder :code:`cd aeon`
-
-2. Create new environment with python 3.8: :code:`conda create -n aeon-dev python=3.8`
-
-   .. warning::
-       If you already have an environment called "aeon-dev" from a previous attempt you will first need to remove this.
-
-3. Activate the environment: :code:`conda activate aeon-dev`
-
-4. Build an editable version of aeon :code:`pip install -e .[all_extras,dev]`
-
-5. If everything has worked you should see message "successfully installed aeon"
-
-Some users have experienced issues when installing NumPy, particularly version 1.19.4.
-
-```{note}
-    If step 4. results in a "no matches found" error, it may be due to how your shell handles special characters.
-
-    - Possible solution: use quotation marks:
-
-      pip install -e ."[all_extras,dev]"
+pip install --editable .[dev,all_extras]
 ```
 
 ```{note}
-    Another option under Windows is to follow the instructions for `Unix-like OS`_, using the Windows Subsystem for Linux (WSL).
-    For installing WSL, follow the instructions `here <https://docs.microsoft.com/en-us/windows/wsl/install-win10#step-2---check-requirements-for-running-wsl-2>`_.
+    If this results in a "no matches found" error, it may be due to how your shell
+    handles special characters. Try surrounding the dependency portion with quotes i.e.
+
+    pip install --editable ."[dev]"
 ```
+
+## Step 3 - Install pre-commit
+
+The `aeon` repository uses [pre-commit](https://pre-commit.com/) to run a series of
+checks on the codebase before committing changes. To install pre-commit, run:
+
+```{code-block} powershell
+pre-commit install
+```
+
+This will run various code-quality hooks on the codebase before committing changes,
+potentially changing the formatting of your code.
+
+This is a requirement to make a pull request, and only in exceptional circumstances
+will a pull request be accepted without passing pre-commit checks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 hide-toc: true
 ---
 
-# <h1 align="center">Welcome to aeon</h1>
+<h1 style="text-align: center;">Welcome to aeon</h1>
 
-aeon is a scikit learn compatible toolkit for time series tasks such as
+`aeon` is a scikit-learn compatible toolkit for time series tasks such as
 forecasting, classification and clustering.</p>
 
 - Provides a broad library of time series algorithms, including the latest advances.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,8 @@ on macOS, Ubuntu and Windows servers by our development CI.
 When it comes to installing `aeon`, there are currently three primary options:
 - [Install the latest release from PyPi.](#Install-the-latest-release-from-PyPi)
 This is the recommended option for most users.
+- [Install the latest release from conda-forge.](#Install-the-latest-release-from-conda-forge)
+An alternative release installation using conda.
 - [Install the latest development version from GitHub via pip.](#Install-the-latest-development-version-using-pip)
 This will include the latest features and bug fixes, but can be more unstable than the
 latest release.
@@ -71,6 +73,27 @@ from `all_extras`), see the
 [pyproject.toml](https://github.com/aeon-toolkit/aeon/blob/main/pyproject.toml)
 configuration file.
 
+## Install the latest release from conda-forge
+
+`aeon` releases are also available via [conda-forge](https://anaconda.org/conda-forge/aeon).
+Run the following to create a new environment for aeon and install the package:
+
+```{code-block} powershell
+conda create -n aeon-env -c conda-forge aeon
+conda activate aeon-env
+```
+
+Post-installation you can verify that `aeon` has been installed correctly by running
+the following:
+
+```{code-block} powershell
+conda list aeon  # see information about the installation i.e. version and file location
+conda list  # see all installed packages for the current environment
+```
+
+Currently for `conda` installations, optional dependencies must be installed
+separately.
+
 ## Install the latest development version using pip
 
 Like the above method, we recommend creating a [virtual environment](#Using-a-pip-venv)
@@ -106,7 +129,7 @@ section apply here as well.
 
 In order to avoid potential conflicts with other packages, we strongly recommended
 using a [virtual environment (venv)](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/)
-for the above installation options.
+or a fresh `conda` environment for the above installation options.
 
 You can create a virtual environment using the following commands. The name virtual
 environment name `aeon-venv` can be replaced with a name of your choosing.


### PR DESCRIPTION
Rewrites the developer install instructions page into a simplified 3 step guide including pre-commit.

Adds some instructions for installing from conda-forge.

Resolves #33 