### PR TITLE
[DOC] Regression notebook update

### DIFF
--- a/examples/regression/regression.ipynb
+++ b/examples/regression/regression.ipynb
@@ -3,31 +3,33 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# Time Series Regression (TSR) with aeon\n",
-    "\n",
+    "# Time Series Extrinsic Regression (TSER) with aeon\n",
     "\n",
     "Time Series Regression (TSR) involves training a model from a collection of time\n",
     "series (real valued, ordered, data) in order to predict a continuous target variable.\n",
     "\n",
-    "<img src=\"img/tser.png\" width=\"600\" alt=\"time series regression\"> [<i>&#x200B;\n",
-    "</i>](img/tser.png)\n",
-    "\n",
     "There are two types of TSR.\n",
     "\n",
-    "1) Time Series Forecasting Regression (TSFR) relates to\n",
-    "forecasting reduced to regression through a sliding window. This is the more familiar\n",
-    " type to most people\n",
+    "1) Time Series Forecasting Regression (TSFR) relates to forecasting reduced to regression \n",
+    "through a sliding window. This is the more familiar type to most people. The notebook\n",
+    "for forecasting using supervised regressors can be found [here](../forecasting/forecasting_sklearn.ipynb).\n",
     "\n",
-    "2) Time Series *Extrinsic* Regression (TSER). Tan et al. [1] formally specified a\n",
-    "related, but distinct, type of time series regression problem: . Rather than being derived from a forecasting problem, TSER involves a predictive model built on time series to predict a real-valued variable distinct from the training input series. For example, shows soil spectrograms which can be used to estimate the potassium concentration.\n",
-    " Ground truth is found through expensive lab based experiments that take some time. Spectrograms (ordered data series we treat as time series) are cheap to obtain and the data can be collected in any environment. An accurate regressor from spectrogram to concentration would make land and crop management more efficient.\n",
+    "2) Time Series *Extrinsic* Regression (TSER) was formally specified in Tan et al. [1] as a\n",
+    "related, but distinct, type of time series regression problem. Rather than being derived from a \n",
+    "forecasting problem, TSER involves a predictive model built on time series to predict a real-valued \n",
+    "variable distinct from the training input series. \n",
     "\n",
-    "<img src=\"img/spectra.png\" width=\"600\" alt=\"spectrograph example\">\n",
-    "[<i>&#x200B;\n",
-    "</i>](img/spectra.png)\n",
+    "This notebook focuses on the `aeon` regression module, which consists of algorithms for TSER. \n",
     "\n",
-    "Both types require time series regressors. `aeon` contain a range of regressors,\n",
-    "broadly aligned with classifiers.\n"
+    "<img src=\"img/tser.png\" width=\"600\" alt=\"time series regression\">\n",
+    "\n",
+    "An example TSER problem is shown in the below image of soil spectrograms which can be used to estimate\n",
+    "the potassium concentration. Ground truth is found through expensive \n",
+    "lab based experiments that take some time. Spectrograms (ordered data series we treat as time series) \n",
+    "are cheap to obtain and the data can be collected in any environment. An accurate regressor from spectrogram \n",
+    "to concentration would make land and crop management more efficient.\n",
+    "\n",
+    "<img src=\"img/spectra.png\" width=\"600\" alt=\"spectrograph example\">"
    ],
    "metadata": {
     "collapsed": false
@@ -38,10 +40,9 @@
    "source": [
     "## Data Storage and Problem Types\n",
     "\n",
-    "Regressors take time series input as either 3D numpy of shape\n",
-    "`(n_cases,n_channels, n_timepoints)` for equal length series or as a list of 2D numpy\n",
-    " of length `[n_cases]`. All regressors work with equal length problems. Regression\n",
-    "functionality for unequal length is currently limited.\n",
+    "Regressors take time series input as either 3D numpy of shape`(n_cases, n_channels, n_timepoints)` for \n",
+    "equal length series or as a list of 2D numpy of length `[n_cases]`. All regressors work with equal \n",
+    "length problems. Regression functionality for unequal length is currently limited.\n",
     "\n",
     "`aeon` ships two example regression problems in the `datasets` module:"
    ],
@@ -51,13 +52,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "outputs": [
     {
      "data": {
       "text/plain": "(140, 1, 84)"
      },
-     "execution_count": 1,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,23 +73,27 @@
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
-    "covid_train, covid_trainy = load_covid_3month(split=\"train\")\n",
-    "covid_test, covid_testy = load_covid_3month(split=\"test\")\n",
-    "cardano_train, cardano_trainy = load_cardano_sentiment(split=\"train\")\n",
-    "cardano_test, cardano_testy = load_cardano_sentiment(split=\"test\")\n",
+    "covid_train, covid_train_y = load_covid_3month(split=\"train\")\n",
+    "covid_test, covid_test_y = load_covid_3month(split=\"test\")\n",
+    "cardano_train, cardano_train_y = load_cardano_sentiment(split=\"train\")\n",
+    "cardano_test, cardano_test_y = load_cardano_sentiment(split=\"test\")\n",
     "covid_train.shape"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:31.722451500Z",
+     "start_time": "2023-08-23T19:10:31.704499Z"
+    }
    }
   },
   {
    "cell_type": "markdown",
    "source": [
-    "Covid 3 is from the [monash tser archive](http://tseregression.org/) who in turn got\n",
+    "Covid3Month is from the [monash tser archive](http://tseregression.org/) who in turn got\n",
     "the data from [WHO's COVID-19 database](https://covid19.who.int/). The goal of this dataset is to predict\n",
-    " COVID-19's death rate on 1st April 2020 for  each country using daily confirmed\n",
-    " cases for the last three months.\n",
+    "COVID-19's death rate on 1st April 2020 for each country using daily confirmed cases for the last three months.\n",
+    "\n",
     "This dataset contains 201 time series (140 train, 61 test), where each time series is\n",
     "the daily confirmed cases for a country. The data is univariate, each series length 84."
    ],
@@ -98,13 +103,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "outputs": [
     {
      "data": {
-      "text/plain": "[<matplotlib.lines.Line2D at 0x2305154c700>]"
+      "text/plain": "[<matplotlib.lines.Line2D at 0x1a6ce6517e0>]"
      },
-     "execution_count": 2,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -124,18 +129,22 @@
     "plt.plot(covid_train[2][0])"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:31.860693700Z",
+     "start_time": "2023-08-23T19:10:31.721454600Z"
+    }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "outputs": [
     {
      "data": {
       "text/plain": "(74, 2, 24)"
      },
-     "execution_count": 3,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -144,20 +153,22 @@
     "cardano_train.shape"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:31.879699600Z",
+     "start_time": "2023-08-23T19:10:31.860693700Z"
+    }
    }
   },
   {
    "cell_type": "markdown",
    "source": [
-    "the\n",
-    "    CardanoSentiment dataset was created By combining historical sentiment data for\n",
-    "    Cardano cryptocurrency, extracted from EODHistoricalData and made available on\n",
-    "    Kaggle, with historical price data for the same cryptocurrency extracted from\n",
-    "    CryptoDataDownload. The predictors are hourly close price (in USD) and traded\n",
-    "     volume during a day, resulting in 2-dimensional time series of length 24. The\n",
-    "     response variable is the normalized sentiment score on the day spanned by the\n",
-    "     timepoints."
+    "The CardanoSentiment dataset was created By combining historical sentiment data for\n",
+    "Cardano cryptocurrency, extracted from EODHistoricalData and made available on\n",
+    "Kaggle, with historical price data for the same cryptocurrency extracted from\n",
+    "CryptoDataDownload. The predictors are hourly close price (in USD) and traded\n",
+    "volume during a day, resulting in 2-dimensional time series of length 24. The\n",
+    "response variable is the normalized sentiment score on the day spanned by the timepoints."
    ],
    "metadata": {
     "collapsed": false
@@ -165,13 +176,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "outputs": [
     {
      "data": {
-      "text/plain": "[<matplotlib.lines.Line2D at 0x230515a0df0>]"
+      "text/plain": "[<matplotlib.lines.Line2D at 0x1a6ce6bb880>]"
      },
-     "execution_count": 4,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -191,7 +202,11 @@
     "plt.plot(cardano_train[2][0])"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:32.017935500Z",
+     "start_time": "2023-08-23T19:10:31.868671600Z"
+    }
    }
   },
   {
@@ -216,14 +231,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "outputs": [
     {
      "data": {
       "text/plain": "                                       name  \\\n0                              CNNRegressor   \n1          CanonicalIntervalForestRegressor   \n2                          Catch22Regressor   \n3                            DrCIFRegressor   \n4                            DummyRegressor   \n5                              FCNRegressor   \n6                      FreshPRINCERegressor   \n7                    InceptionTimeRegressor   \n8              IndividualInceptionRegressor   \n9                   IntervalForestRegressor   \n10            KNeighborsTimeSeriesRegressor   \n11                  RandomIntervalRegressor   \n12  RandomIntervalSpectralEnsembleRegressor   \n13                        RegressorPipeline   \n14                          ResNetRegressor   \n15                          RocketRegressor   \n16                 SklearnRegressorPipeline   \n17                          TapNetRegressor   \n18                TimeSeriesForestRegressor   \n\n                                            estimator  \n0   <class 'aeon.regression.deep_learning.cnn.CNNR...  \n1   <class 'aeon.regression.interval_based._cif.Ca...  \n2   <class 'aeon.regression.feature_based._catch22...  \n3   <class 'aeon.regression.interval_based._drcif....  \n4     <class 'aeon.regression._dummy.DummyRegressor'>  \n5   <class 'aeon.regression.deep_learning.fcn.FCNR...  \n6   <class 'aeon.regression.feature_based._fresh_p...  \n7   <class 'aeon.regression.deep_learning.inceptio...  \n8   <class 'aeon.regression.deep_learning.inceptio...  \n9   <class 'aeon.regression.interval_based._interv...  \n10  <class 'aeon.regression.distance_based._time_s...  \n11  <class 'aeon.regression.interval_based._interv...  \n12  <class 'aeon.regression.interval_based._rise.R...  \n13  <class 'aeon.regression.compose._pipeline.Regr...  \n14  <class 'aeon.regression.deep_learning.resnet.R...  \n15  <class 'aeon.regression.convolution_based._roc...  \n16  <class 'aeon.regression.compose._pipeline.Skle...  \n17  <class 'aeon.regression.deep_learning.tapnet.T...  \n18  <class 'aeon.regression.interval_based._tsf.Ti...  ",
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>estimator</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CNNRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.cnn.CNNR...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CanonicalIntervalForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._cif.Ca...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Catch22Regressor</td>\n      <td>&lt;class 'aeon.regression.feature_based._catch22...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>DrCIFRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._drcif....</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>DummyRegressor</td>\n      <td>&lt;class 'aeon.regression._dummy.DummyRegressor'&gt;</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>FCNRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.fcn.FCNR...</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>FreshPRINCERegressor</td>\n      <td>&lt;class 'aeon.regression.feature_based._fresh_p...</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>InceptionTimeRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.inceptio...</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>IndividualInceptionRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.inceptio...</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>IntervalForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._interv...</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>KNeighborsTimeSeriesRegressor</td>\n      <td>&lt;class 'aeon.regression.distance_based._time_s...</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>RandomIntervalRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._interv...</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>RandomIntervalSpectralEnsembleRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._rise.R...</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>RegressorPipeline</td>\n      <td>&lt;class 'aeon.regression.compose._pipeline.Regr...</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>ResNetRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.resnet.R...</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>RocketRegressor</td>\n      <td>&lt;class 'aeon.regression.convolution_based._roc...</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>SklearnRegressorPipeline</td>\n      <td>&lt;class 'aeon.regression.compose._pipeline.Skle...</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>TapNetRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.tapnet.T...</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>TimeSeriesForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._tsf.Ti...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 5,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,7 +249,11 @@
     "all_estimators(\"regressor\", as_dataframe=True)"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:32.074782800Z",
+     "start_time": "2023-08-23T19:10:32.015968700Z"
+    }
    }
   },
   {
@@ -250,31 +269,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "outputs": [
     {
      "data": {
       "text/plain": "0.17823940618016532"
      },
-     "execution_count": 6,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from aeon.datasets import load_covid_3month\n",
     "from aeon.regression.distance_based import KNeighborsTimeSeriesRegressor\n",
     "\n",
-    "covid_train, covid_trainy = load_covid_3month(split=\"train\")\n",
-    "covid_test, covid_testy = load_covid_3month(split=\"test\")\n",
     "knn = KNeighborsTimeSeriesRegressor()\n",
-    "knn.fit(covid_train, covid_trainy)\n",
+    "knn.fit(covid_train, covid_train_y)\n",
     "p = knn.predict(covid_test)\n",
-    "sse = np.sum((covid_testy - p) * (covid_testy - p))\n",
+    "sse = np.sum((covid_test_y - p) * (covid_test_y - p))\n",
     "sse"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:32.387392900Z",
+     "start_time": "2023-08-23T19:10:32.075780800Z"
+    }
    }
   },
   {
@@ -289,14 +309,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "outputs": [
     {
      "data": {
       "text/plain": "                                       name  \\\n0                              CNNRegressor   \n1          CanonicalIntervalForestRegressor   \n2                          Catch22Regressor   \n3                            DrCIFRegressor   \n4                            DummyRegressor   \n5                              FCNRegressor   \n6                      FreshPRINCERegressor   \n7                    InceptionTimeRegressor   \n8              IndividualInceptionRegressor   \n9                   IntervalForestRegressor   \n10            KNeighborsTimeSeriesRegressor   \n11                  RandomIntervalRegressor   \n12  RandomIntervalSpectralEnsembleRegressor   \n13                          ResNetRegressor   \n14                          RocketRegressor   \n15                          TapNetRegressor   \n16                TimeSeriesForestRegressor   \n\n                                            estimator  \n0   <class 'aeon.regression.deep_learning.cnn.CNNR...  \n1   <class 'aeon.regression.interval_based._cif.Ca...  \n2   <class 'aeon.regression.feature_based._catch22...  \n3   <class 'aeon.regression.interval_based._drcif....  \n4     <class 'aeon.regression._dummy.DummyRegressor'>  \n5   <class 'aeon.regression.deep_learning.fcn.FCNR...  \n6   <class 'aeon.regression.feature_based._fresh_p...  \n7   <class 'aeon.regression.deep_learning.inceptio...  \n8   <class 'aeon.regression.deep_learning.inceptio...  \n9   <class 'aeon.regression.interval_based._interv...  \n10  <class 'aeon.regression.distance_based._time_s...  \n11  <class 'aeon.regression.interval_based._interv...  \n12  <class 'aeon.regression.interval_based._rise.R...  \n13  <class 'aeon.regression.deep_learning.resnet.R...  \n14  <class 'aeon.regression.convolution_based._roc...  \n15  <class 'aeon.regression.deep_learning.tapnet.T...  \n16  <class 'aeon.regression.interval_based._tsf.Ti...  ",
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>name</th>\n      <th>estimator</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CNNRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.cnn.CNNR...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CanonicalIntervalForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._cif.Ca...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Catch22Regressor</td>\n      <td>&lt;class 'aeon.regression.feature_based._catch22...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>DrCIFRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._drcif....</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>DummyRegressor</td>\n      <td>&lt;class 'aeon.regression._dummy.DummyRegressor'&gt;</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>FCNRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.fcn.FCNR...</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>FreshPRINCERegressor</td>\n      <td>&lt;class 'aeon.regression.feature_based._fresh_p...</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>InceptionTimeRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.inceptio...</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>IndividualInceptionRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.inceptio...</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>IntervalForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._interv...</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>KNeighborsTimeSeriesRegressor</td>\n      <td>&lt;class 'aeon.regression.distance_based._time_s...</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>RandomIntervalRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._interv...</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>RandomIntervalSpectralEnsembleRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._rise.R...</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>ResNetRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.resnet.R...</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>RocketRegressor</td>\n      <td>&lt;class 'aeon.regression.convolution_based._roc...</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>TapNetRegressor</td>\n      <td>&lt;class 'aeon.regression.deep_learning.tapnet.T...</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>TimeSeriesForestRegressor</td>\n      <td>&lt;class 'aeon.regression.interval_based._tsf.Ti...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 7,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,18 +327,22 @@
     ")"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:32.443244300Z",
+     "start_time": "2023-08-23T19:10:32.387392900Z"
+    }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 16,
    "outputs": [
     {
      "data": {
-      "text/plain": "[<matplotlib.lines.Line2D at 0x2306c945610>]"
+      "text/plain": "[<matplotlib.lines.Line2D at 0x1a6ce73ded0>]"
      },
-     "execution_count": 8,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -336,28 +360,33 @@
     "\n",
     "fp = KNeighborsTimeSeriesRegressor()\n",
     "dummy = DummyRegressor()\n",
-    "dummy.fit(cardano_train, cardano_trainy)\n",
-    "knn.fit(cardano_train, cardano_trainy)\n",
+    "dummy.fit(cardano_train, cardano_train_y)\n",
+    "knn.fit(cardano_train, cardano_train_y)\n",
     "pred = knn.predict(cardano_test)\n",
-    "res_knn = cardano_testy - pred\n",
-    "res_dummy = cardano_testy - dummy.predict(cardano_test)\n",
+    "res_knn = cardano_test_y - pred\n",
+    "res_dummy = cardano_test_y - dummy.predict(cardano_test)\n",
     "plt.title(\"Raw residuals\")\n",
     "plt.plot(res_knn)\n",
     "plt.plot(res_dummy)"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T19:10:32.623088500Z",
+     "start_time": "2023-08-23T19:10:32.445212600Z"
+    }
    }
   },
   {
    "cell_type": "markdown",
    "source": [
-    "References\n",
+    "## References\n",
+    "\n",
     "[1] Tan et al. \"Time series extrinsic regression\", Data Mining and Knowledge\n",
     "Discovery, 35(3), 2021\n",
+    "\n",
     "[2] Guijo-Rubio et al. \"Unsupervised Feature Based Algorithms for Time Series\n",
-    "Extrinsic Regression\", ArXiv, 2023\n",
-    "\n"
+    "Extrinsic Regression\", ArXiv, 2023"
    ],
    "metadata": {
     "collapsed": false

--- a/examples/regression/regression.ipynb
+++ b/examples/regression/regression.ipynb
@@ -384,7 +384,6 @@
     "\n",
     "[1] Tan et al. \"Time series extrinsic regression\", Data Mining and Knowledge\n",
     "Discovery, 35(3), 2021\n",
-    "\n",
     "[2] Guijo-Rubio et al. \"Unsupervised Feature Based Algorithms for Time Series\n",
     "Extrinsic Regression\", ArXiv, 2023"
    ],


### PR DESCRIPTION
Emphasises the notebook more as a TSER notebook, aimed at introducing the `regression` package. Includes a link to the `forecasting_sklearn` notebook for the forecasting alternative.

See #647.