### PR TITLE
[MNT] remove exclusions

### DIFF
--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -63,9 +63,6 @@ EXCLUDED_TESTS = {
         "test_inheritance",
         "test_create_test_instance",
     ],
-    # this needs to be fixed, was not tested previously due to legacy exception
-    "Prophet": ":test_hierarchical_with_exogeneous",
-    # Prophet does not support datetime indices, see #2475 for the known issue
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -36,9 +36,6 @@ EXCLUDED_TESTS = {
         "test_classifier_on_unit_test_data",
         "test_classifier_on_basic_motions",
     ],
-    # sth is not quite right with the RowTransformer-s changing state,
-    #   but these are anyway on their path to deprecation, see #2370
-    "SeriesToSeriesRowTransformer": ["test_non_state_changing_method_contract"],
     # Early classifiers (EC) intentionally retain information from previous predict
     # calls for #1 (test_non_state_changing_method_contract).
     # #2 (test_fit_deterministic), #3 (test_persistence_via_pickle) and #4

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -23,14 +23,6 @@ if os.environ.get("NUMBA_DISABLE_JIT") == "1":
     EXCLUDE_ESTIMATORS.append("StatsForecastAutoARIMA")
 
 EXCLUDED_TESTS = {
-    # issue when predicting residuals, see #3479
-    "SquaringResiduals": ["test_predict_residuals"],
-    # known issue when X is passed, wrong time indices are returned, #1364
-    "StackingForecaster": ["test_predict_time_index_with_X"],
-    # known side effects on multivariate arguments, #2072
-    "WindowSummarizer": ["test_methods_have_no_side_effects"],
-    # test fails in the Panel case for Differencer, see #2522
-    "Differencer": ["test_transform_inverse_transform_equivalent"],
     # Early classifiers (EC) intentionally retain information from previous predict
     # calls for #1 (test_non_state_changing_method_contract).
     # #2 (test_fit_deterministic), #3 (test_persistence_via_pickle) and #4
@@ -48,11 +40,8 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    "VARMAX": [
-        "test_update_predict_single",  # see 2997, sporadic failure, unknown cause
-        "test__y_when_refitting",  # see 3176
-    ],
-    # GGS inherits from BaseEstimator which breaks this test
+    # GGS inherits from BaseEstimator which breaks this test: see issue #699
+    # https://github.com/aeon-toolkit/aeon/issues/699
     "GreedyGaussianSegmentation": ["test_inheritance", "test_create_test_instance"],
     "InformationGainSegmentation": [
         "test_inheritance",

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -12,11 +12,7 @@ from aeon.registry import BASE_CLASS_LIST, BASE_CLASS_LOOKUP, ESTIMATOR_TAG_LIST
 # per os/version default is False, can be set to True by pytest --prtesting True flag
 PR_TESTING = False
 
-EXCLUDE_ESTIMATORS = [
-    # tapnet is being reworked, will remove exclusion after refactor
-    "TapNetRegressor",
-    "TapNetClassifier",
-]
+EXCLUDE_ESTIMATORS = []
 
 # the test currently fails when numba is disabled. See issue #622
 if os.environ.get("NUMBA_DISABLE_JIT") == "1":

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -36,13 +36,16 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    # GGS inherits from BaseEstimator which breaks this test: see issue #699
+    # GGS inherits from BaseEstimator which breaks this test: see
     # https://github.com/aeon-toolkit/aeon/issues/699
     "GreedyGaussianSegmentation": ["test_inheritance", "test_create_test_instance"],
     "InformationGainSegmentation": [
         "test_inheritance",
         "test_create_test_instance",
     ],
+    # test fails several variants of inversion, see
+    # https://github.com/aeon-toolkit/aeon/issues/700
+    "Differencer": ["test_transform_inverse_transform_equivalent"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/aeon/tests/_config.py
+++ b/aeon/tests/_config.py
@@ -31,11 +31,6 @@ EXCLUDED_TESTS = {
     "WindowSummarizer": ["test_methods_have_no_side_effects"],
     # test fails in the Panel case for Differencer, see #2522
     "Differencer": ["test_transform_inverse_transform_equivalent"],
-    # tagged in issue #2490
-    "SignatureClassifier": [
-        "test_classifier_on_unit_test_data",
-        "test_classifier_on_basic_motions",
-    ],
     # Early classifiers (EC) intentionally retain information from previous predict
     # calls for #1 (test_non_state_changing_method_contract).
     # #2 (test_fit_deterministic), #3 (test_persistence_via_pickle) and #4

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
-addopts =
-    --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,12 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
+addopts =
+    --doctest-modules
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
See #347 

This PR unexcludes

1.     "SeriesToSeriesRowTransformer": ["test_non_state_changing_method_contract"],
no longer exists

2. "Prophet": ":test_hierarchical_with_exogeneous" # Issue fixed by prophet

3.    "SignatureClassifier": [
        "test_classifier_on_unit_test_data",
        "test_classifier_on_basic_motions",
    ],

passes test_all_classifiers, may be mac or intermittent?

4. SquaringResiduals": ["test_predict_residuals"],
5. "StackingForecaster": ["test_predict_time_index_with_X"],
6. "WindowSummarizer": ["test_methods_have_no_side_effects"],
7. VARMAX": [
"test_update_predict_single",
"test__y_when_refitting",

all pass locally on test_all_forecasters (1hr 16 mins version), test_all_classifiers and test_all_estimators. This has passed 3 times  on CI


This just leaves the 

1. early classifiers
2. Differencer #700 
3. The segmenters #699 

If we get sporadic fails we can properly investigate and possibly exclude with a better idea of why. 
