### PR TITLE
[ENH] RDST estimator test speedups

### DIFF
--- a/aeon/classification/distance_based/_elastic_ensemble.py
+++ b/aeon/classification/distance_based/_elastic_ensemble.py
@@ -84,9 +84,9 @@ class ElasticEnsemble(BaseClassifier):
     ...     distance_measures = ["dtw","ddtw"],
     ...     majority_vote=True,
     ... )
-    >>> clf.fit(X_train, y_train)
+    >>> clf.fit(X_train, y_train)   # doctest: +SKIP
     ElasticEnsemble(...)
-    >>> y_pred = clf.predict(X_test)
+    >>> y_pred = clf.predict(X_test)  # doctest: +SKIP
     """
 
     _tags = {

--- a/aeon/forecasting/base/tests/test_fh.py
+++ b/aeon/forecasting/base/tests/test_fh.py
@@ -14,7 +14,6 @@ from pytest import raises
 
 from aeon.datasets import load_airline
 from aeon.datatypes._utilities import get_cutoff
-from aeon.forecasting.arima import AutoARIMA
 from aeon.forecasting.base import ForecastingHorizon
 from aeon.forecasting.base._fh import (
     DELEGATED_METHODS,
@@ -24,6 +23,7 @@ from aeon.forecasting.base._fh import (
 from aeon.forecasting.ets import AutoETS
 from aeon.forecasting.exp_smoothing import ExponentialSmoothing
 from aeon.forecasting.model_selection import temporal_train_test_split
+from aeon.forecasting.naive import NaiveForecaster
 from aeon.forecasting.tests import (
     INDEX_TYPE_LOOKUP,
     TEST_FHS,
@@ -435,10 +435,6 @@ def test_to_absolute_int_fh_with_freq(idx: int, freq: str):
     assert_array_equal(fh + idx, absolute_int)
 
 
-@pytest.mark.skipif(
-    not _check_estimator_deps(AutoETS, severity="none"),
-    reason="skip test if required soft dependency for hmmlearn not available",
-)
 @pytest.mark.parametrize("freqstr", ["W-WED", "W-SUN", "W-SAT"])
 def test_estimator_fh(freqstr):
     """Test model fitting with anchored frequency."""
@@ -446,7 +442,7 @@ def test_estimator_fh(freqstr):
         np.random.uniform(low=2000, high=7000, size=(104,)),
         index=pd.date_range("2019-01-02", freq=freqstr, periods=104),
     )
-    forecaster = AutoETS(auto=True, sp=52, n_jobs=-1, restrict=True)
+    forecaster = NaiveForecaster()
     forecaster.fit(train)
     fh = ForecastingHorizon(np.arange(1, 27))
     pred = forecaster.predict(fh)
@@ -531,50 +527,24 @@ def test_exponential_smoothing():
     )
 
 
-# TODO: Replace this long running test with fast unit test
-@pytest.mark.skipif(
-    not _check_estimator_deps(AutoARIMA, severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
-def test_auto_arima():
-    """Test failure case from #805.
+def test_one_off_case():
+    """Test failure case from #1435.
 
-    https://github.com/sktime/sktime/issues/805#issuecomment-891848228.
+    AutoETS is replaced by NaiveForecaster.
+
+    https://github.com/sktime/sktime/issues/1435#issue-1000175469
     """
-    time_index = pd.date_range("January 1, 2021", periods=8, freq="1D")
-    X = pd.DataFrame(
-        np.random.randint(0, 4, 24).reshape(8, 3),
-        columns=["First", "Second", "Third"],
-        index=time_index,
-    )
-    y = pd.Series([1, 3, 2, 4, 5, 2, 3, 1], index=time_index)
-
-    fh_ = ForecastingHorizon(X.index[5:], is_relative=False)
-
-    a_clf = AutoARIMA(start_p=2, start_q=2, max_p=5, max_q=5)
-    clf = a_clf.fit(X=X[:5], y=y[:5])
-    y_pred_sk = clf.predict(fh=fh_, X=X[5:])
-
+    freq = "30T"
+    _y = np.arange(50) + np.random.rand(50) + np.sin(np.arange(50) / 4) * 10
+    t = pd.date_range("2021-09-19", periods=50, freq=freq)
+    y = pd.Series(_y, index=t)
+    y.index = y.index.to_period(freq=freq)
+    forecaster = NaiveForecaster()
+    forecaster.fit(y)
+    y_pred = forecaster.predict(fh=[1, 2, 3])
     pd.testing.assert_index_equal(
-        y_pred_sk.index, pd.date_range("January 6, 2021", periods=3, freq="1D")
-    )
-
-    time_index = pd.date_range("January 1, 2021", periods=8, freq="2D")
-    X = pd.DataFrame(
-        np.random.randint(0, 4, 24).reshape(8, 3),
-        columns=["First", "Second", "Third"],
-        index=time_index,
-    )
-    y = pd.Series([1, 3, 2, 4, 5, 2, 3, 1], index=time_index)
-
-    fh = ForecastingHorizon(X.index[5:], is_relative=False)
-
-    a_clf = AutoARIMA(start_p=2, start_q=2, max_p=5, max_q=5)
-    clf = a_clf.fit(X=X[:5], y=y[:5])
-    y_pred_sk = clf.predict(fh=fh, X=X[5:])
-
-    pd.testing.assert_index_equal(
-        y_pred_sk.index, pd.date_range("January 11, 2021", periods=3, freq="2D")
+        y_pred.index,
+        pd.date_range("2021-09-19", periods=53, freq=freq)[-3:].to_period(freq=freq),
     )
 
 

--- a/aeon/forecasting/compose/tests/test_reduce_global.py
+++ b/aeon/forecasting/compose/tests/test_reduce_global.py
@@ -229,11 +229,11 @@ def test_list_reduction(y, index_names):
 
 def test_equality_transfo_nontranso():
     """Test that recursive reducers return same results for global / local forecasts."""
-    y = load_airline()
-    y_train, y_test = temporal_train_test_split(y, test_size=30)
+    y = load_airline()[:36]
+    y_train, y_test = temporal_train_test_split(y, test_size=12)
     fh = ForecastingHorizon(y_test.index, is_relative=False)
 
-    lag_vec = list(range(12, 0, -1))
+    lag_vec = list(range(6, 0, -1))
     kwargs = {
         "lag_feature": {
             "lag": lag_vec,

--- a/aeon/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/aeon/forecasting/model_evaluation/tests/test_evaluate.py
@@ -252,10 +252,10 @@ def test_evaluate_hierarchical(backend):
         return None
 
     y = _make_hierarchical(
-        random_state=0, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+        random_state=0, hierarchy_levels=(2, 2), min_timepoints=12, max_timepoints=12
     )
     X = _make_hierarchical(
-        random_state=42, hierarchy_levels=(2, 2), min_timepoints=20, max_timepoints=20
+        random_state=42, hierarchy_levels=(2, 2), min_timepoints=12, max_timepoints=12
     )
     y = y.sort_index()
     X = X.sort_index()

--- a/aeon/forecasting/tests/test_interval_wrappers.py
+++ b/aeon/forecasting/tests/test_interval_wrappers.py
@@ -77,27 +77,27 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
     This checks refit and update strategies as well as expanding and sliding window
     splitters.
     """
-    y = load_airline()
+    y = load_airline()[:60]
 
     if splitter == SlidingWindowSplitter:
         cv = splitter(
-            fh=np.arange(1, 13),
-            window_length=48,
-            step_length=12,
+            fh=np.arange(1, 7),
+            window_length=24,
+            step_length=6,
         )
     elif splitter == ExpandingWindowSplitter:
         cv = splitter(
-            fh=np.arange(1, 13),
-            initial_window=48,
-            step_length=12,
+            fh=np.arange(1, 7),
+            initial_window=24,
+            step_length=6,
         )
 
     f = NaiveForecaster()
 
     if wrapper == ConformalIntervals:
-        interval_forecaster = wrapper(f, initial_window=24, sample_frac=sample_frac)
+        interval_forecaster = wrapper(f, initial_window=12, sample_frac=sample_frac)
     else:
-        interval_forecaster = wrapper(f, initial_window=24)
+        interval_forecaster = wrapper(f, initial_window=12)
 
     results = evaluate(
         forecaster=interval_forecaster,
@@ -111,5 +111,5 @@ def test_evaluate_with_window_splitters(wrapper, splitter, strategy, sample_frac
         backend=None,
     )
 
-    assert len(results) == 8
+    assert len(results) == 5
     assert not results.test_PinballLoss.isna().any()

--- a/aeon/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
+++ b/aeon/performance_metrics/forecasting/probabilistic/tests/test_probabilistic_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for probabilistic quantiles."""
+"""Tests for performance metrics."""
 import warnings
 
 import numpy as np
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 
 from aeon.forecasting.model_selection import temporal_train_test_split
-from aeon.forecasting.naive import NaiveForecaster, NaiveVariance
 from aeon.performance_metrics.forecasting.probabilistic import (
     ConstraintViolation,
     EmpiricalCoverage,
@@ -26,84 +25,78 @@ interval_metrics = [
     ConstraintViolation,
 ]
 
-all_metrics = quantile_metrics + interval_metrics
+all_metrics = interval_metrics + quantile_metrics
+
+alpha_s = [0.5]
+alpha_m = [0.05, 0.5, 0.95]
+coverage_s = 0.9
+coverage_m = [0.7, 0.8, 0.9, 0.99]
 
 
-y_uni = _make_series(n_columns=1)
-y_train_uni, y_test_uni = temporal_train_test_split(y_uni)
-fh_uni = np.arange(len(y_test_uni)) + 1
-f_uni = NaiveVariance(NaiveForecaster())
-f_uni.fit(y_train_uni)
+@pytest.fixture
+def sample_data(request):
+    n_columns, coverage_or_alpha, pred_type = request.param
 
-y_multi = _make_series(n_columns=3)
-y_train_multi, y_test_multi = temporal_train_test_split(y_multi)
-fh_multi = np.arange(len(y_test_multi)) + 1
-f_multi = NaiveVariance(NaiveForecaster())
-f_multi.fit(y_train_multi)
-"""
-Cases we need to test
-score average = TRUE/FALSE
-multivariable = TRUE/FALSE
-multiscores = TRUE/FALSE
+    y = _make_series(n_columns=n_columns)
+    y_train, y_test = temporal_train_test_split(y)
 
-Data types
-Univariate and single score
-Univariate and multi score
-Multivariate and single score
-Multivariate and multiscor
+    if pred_type == "interval":
+        interval_pred = {}
+        for col in range(n_columns):
+            if n_columns == 1:
+                y_vals = y_test
+            else:
+                y_vals = y_test.iloc[:, col]
+            for coverage in np.array([coverage_or_alpha]).flatten():
+                interval_pred[(col, coverage, "lower")] = (
+                    y_vals * np.random.uniform(0.9, 1.1, len(y_vals)) * (1 - coverage)
+                )
+                interval_pred[(col, coverage, "upper")] = (
+                    y_vals * np.random.uniform(0.9, 1.1, len(y_vals)) * (1 + coverage)
+                )
+        interval_pred = pd.DataFrame.from_dict(interval_pred)
+        return y_test, interval_pred
 
-For each of the data types we need to test with score average = T/F \
-    and multioutput with "raw_values" and "uniform_average"
-"""
-quantile_pred_uni_s = f_uni.predict_quantiles(fh=fh_uni, alpha=[0.5])
-interval_pred_uni_s = f_uni.predict_interval(fh=fh_uni, coverage=0.9)
-quantile_pred_uni_m = f_uni.predict_quantiles(fh=fh_uni, alpha=[0.05, 0.5, 0.95])
-interval_pred_uni_m = f_uni.predict_interval(fh=fh_uni, coverage=[0.7, 0.8, 0.9, 0.99])
+    elif pred_type == "quantile":
+        quantile_pred = {}
+        for col in range(n_columns):
+            if n_columns == 1:
+                y_vals = y_test
+            else:
+                y_vals = y_test.iloc[:, col]
+            for alpha in coverage_or_alpha:
+                quantile_pred[(col, alpha)] = (
+                    y_vals * np.random.uniform(0.9, 1.1, len(y_vals)) * (0.5 + alpha)
+                )
+        quantile_pred = pd.DataFrame.from_dict(quantile_pred)
+        return y_test, quantile_pred
 
-quantile_pred_multi_s = f_multi.predict_quantiles(fh=fh_multi, alpha=[0.5])
-interval_pred_multi_s = f_multi.predict_interval(fh=fh_multi, coverage=0.9)
-quantile_pred_multi_m = f_multi.predict_quantiles(fh=fh_multi, alpha=[0.05, 0.5, 0.95])
-interval_pred_multi_m = f_multi.predict_interval(
-    fh=fh_multi, coverage=[0.7, 0.8, 0.9, 0.99]
-)
-
-uni_data = [
-    quantile_pred_uni_s,
-    interval_pred_uni_s,
-    quantile_pred_uni_m,
-    interval_pred_uni_m,
-]
-
-multi_data = [
-    quantile_pred_multi_s,
-    interval_pred_multi_s,
-    quantile_pred_multi_m,
-    interval_pred_multi_m,
-]
-
-quantile_data = [
-    quantile_pred_uni_s,
-    quantile_pred_uni_m,
-    quantile_pred_multi_s,
-    quantile_pred_multi_m,
-]
-
-interval_data = [
-    interval_pred_uni_s,
-    interval_pred_uni_m,
-    interval_pred_multi_s,
-    interval_pred_multi_m,
-]
+    return
 
 
+# Test the parametrized fixture
 @pytest.mark.parametrize(
-    "y_true, y_pred",
-    list(zip([y_test_uni] * 4, uni_data)) + list(zip([y_test_multi] * 4, multi_data)),
+    "sample_data",
+    [
+        (1, alpha_s, "quantile"),
+        (3, alpha_s, "quantile"),
+        (1, alpha_m, "quantile"),
+        (3, alpha_m, "quantile"),
+        (1, coverage_s, "interval"),
+        (3, coverage_s, "interval"),
+        (1, coverage_m, "interval"),
+        (3, coverage_m, "interval"),
+    ],
+    indirect=True,
 )
-@pytest.mark.parametrize("metric", all_metrics)
-@pytest.mark.parametrize("multioutput", ["uniform_average", "raw_values"])
-@pytest.mark.parametrize("score_average", [True, False])
-def test_output(metric, score_average, multioutput, y_true, y_pred):
+def test_sample_data(sample_data):
+    y_true, y_pred = sample_data
+    assert isinstance(y_true, (pd.Series, pd.DataFrame))
+    assert isinstance(y_pred, pd.DataFrame)
+
+
+def helper_check_output(metric, score_average, multioutput, sample_data):
+    y_true, y_pred = sample_data
     """Test output is correct class and shape for given data."""
     loss = metric.create_test_instance()
     loss.set_params(score_average=score_average, multioutput=multioutput)
@@ -165,32 +158,85 @@ def test_output(metric, score_average, multioutput, y_true, y_pred):
         assert len(eval_loss) == no_vars
 
 
-@pytest.mark.parametrize("Metric", quantile_metrics)
 @pytest.mark.parametrize(
-    "y_pred, y_true", list(zip(quantile_data, [y_test_uni] * 2 + [y_test_multi] * 2))
+    "sample_data",
+    [
+        (1, alpha_s, "quantile"),
+        (3, alpha_s, "quantile"),
+        (1, alpha_m, "quantile"),
+        (3, alpha_m, "quantile"),
+    ],
+    indirect=True,
 )
-def test_evaluate_alpha_positive(Metric, y_pred, y_true):
+@pytest.mark.parametrize("metric", all_metrics)
+@pytest.mark.parametrize("multioutput", ["uniform_average", "raw_values"])
+@pytest.mark.parametrize("score_average", [True, False])
+def test_output_quantiles(metric, score_average, multioutput, sample_data):
+    helper_check_output(metric, score_average, multioutput, sample_data)
+
+
+@pytest.mark.parametrize(
+    "sample_data",
+    [
+        (1, coverage_s, "interval"),
+        (3, coverage_s, "interval"),
+        (1, coverage_m, "interval"),
+        (3, coverage_m, "interval"),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("metric", all_metrics)
+@pytest.mark.parametrize("multioutput", ["uniform_average", "raw_values"])
+@pytest.mark.parametrize("score_average", [True, False])
+def test_output_intervals(metric, score_average, multioutput, sample_data):
+    helper_check_output(metric, score_average, multioutput, sample_data)
+
+
+@pytest.mark.parametrize("metric", quantile_metrics)
+@pytest.mark.parametrize(
+    "sample_data",
+    [
+        (1, alpha_s, "quantile"),
+        (3, alpha_s, "quantile"),
+        (1, alpha_m, "quantile"),
+        (3, alpha_m, "quantile"),
+    ],
+    indirect=True,
+)
+def test_evaluate_alpha_positive(metric, sample_data):
     """Tests output when required quantile is present."""
     # 0.5 in test quantile data don't raise error.
-    Loss = Metric.create_test_instance().set_params(alpha=0.5, score_average=False)
+
+    y_true, y_pred = sample_data
+
+    Loss = metric.create_test_instance().set_params(alpha=0.5, score_average=False)
     res = Loss(y_true=y_true, y_pred=y_pred)
     assert len(res) == 1
 
     if all(x in y_pred.columns.get_level_values(1) for x in [0.5, 0.95]):
-        Loss = Metric.create_test_instance().set_params(
+        Loss = metric.create_test_instance().set_params(
             alpha=[0.5, 0.95], score_average=False
         )
         res = Loss(y_true=y_true, y_pred=y_pred)
         assert len(res) == 2
 
 
-@pytest.mark.parametrize("Metric", quantile_metrics)
+# This test tests quantile data
 @pytest.mark.parametrize(
-    "y_pred, y_true", list(zip(quantile_data, [y_test_uni] * 2 + [y_test_multi] * 2))
+    "sample_data",
+    [
+        (1, alpha_s, "quantile"),
+        (3, alpha_s, "quantile"),
+        (1, alpha_m, "quantile"),
+        (3, alpha_m, "quantile"),
+    ],
+    indirect=True,
 )
-def test_evaluate_alpha_negative(Metric, y_pred, y_true):
+@pytest.mark.parametrize("metric", quantile_metrics)
+def test_evaluate_alpha_negative(metric, sample_data):
     """Tests whether correct error raised when required quantile not present."""
+    y_true, y_pred = sample_data
     with pytest.raises(ValueError):
         # 0.3 not in test quantile data so raise error.
-        Loss = Metric.create_test_instance().set_params(alpha=0.3)
+        Loss = metric.create_test_instance().set_params(alpha=0.3)
         res = Loss(y_true=y_true, y_pred=y_pred)  # noqa

--- a/aeon/transformations/collection/dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/dilated_shapelet_transform.py
@@ -121,13 +121,12 @@ class RandomDilatedShapeletTransform(BaseTransformer):
     ...     RandomDilatedShapeletTransform
     ... )
     >>> from aeon.datasets import load_unit_test
-    >>> X_train, y_train = load_unit_test(split="train", return_X_y=True)
+    >>> X_train, y_train = load_unit_test(split="train")
     >>> t = RandomDilatedShapeletTransform(
     ...     max_shapelets=10
     ... )
-    >>> t.fit(X_train, y_train)
-    RandomDilatedShapeletTransform(...)
-    >>> X_t = t.transform(X_train)
+    >>> t.fit(X_train, y_train) # doctest: +SKIP
+    >>> X_t = t.transform(X_train) # doctest: +SKIP
     """
 
     _tags = {
@@ -173,7 +172,7 @@ class RandomDilatedShapeletTransform(BaseTransformer):
         y: array-like or list, default=None
             The class values for X. If not specified, a random sample (i.e. not of the
             same class) will be used when computing the threshold for the Shapelet
-            Occurence feature.
+            Occurrence feature.
 
         Returns
         -------

--- a/aeon/transformations/collection/dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/dilated_shapelet_transform.py
@@ -334,7 +334,7 @@ class RandomDilatedShapeletTransform(BaseTransformer):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
         if parameter_set == "default":
-            params = {"max_shapelets": 10}
+            params = {"max_shapelets": 10, "shapelet_lengths": [3, 4, 5]}
         else:
             raise NotImplementedError(
                 "The parameter set {} is not yet implemented".format(parameter_set)

--- a/aeon/transformations/collection/tests/test_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/tests/test_dilated_shapelet_transform.py
@@ -11,8 +11,6 @@ from numpy.testing import (
     assert_array_equal,
 )
 
-# from aeon.datasets import load_basic_motions, load_unit_test
-from aeon.datasets import load_basic_motions
 from aeon.distances import manhattan_distance
 from aeon.transformations.collection.dilated_shapelet_transform import (
     RandomDilatedShapeletTransform,
@@ -21,6 +19,7 @@ from aeon.transformations.collection.dilated_shapelet_transform import (
     get_all_subsequences,
     normalize_subsequences,
 )
+from aeon.utils._testing.collection import make_3d_test_data
 from aeon.utils.numba.stats import is_prime
 
 DATATYPES = ["int64", "float64"]
@@ -81,11 +80,10 @@ def test_rdst_on_basic_motions():
 
 
 def test_shapelet_prime_dilation():
-    X_train, y_train = load_basic_motions(split="train")
-    indices = np.random.RandomState(4).choice(len(y_train), 3, replace=False)
+    X_train, y_train = make_3d_test_data(n_cases=5, n_channels=2, n_timepoints=12)
     rdst = RandomDilatedShapeletTransform(
         max_shapelets=10, use_prime_dilations=True
-    ).fit(X_train[indices], y_train[indices])
+    ).fit(X_train, y_train)
     dilations = rdst.shapelets_[2]
     assert np.all([d == 1 or is_prime(d) for d in dilations])
 

--- a/aeon/utils/tests/test_check_estimator.py
+++ b/aeon/utils/tests/test_check_estimator.py
@@ -5,12 +5,12 @@ __author__ = ["fkiraly"]
 
 import pytest
 
-from aeon.classification.feature_based import Catch22Classifier
+from aeon.classification import DummyClassifier
 from aeon.transformations.series.exponent import ExponentTransformer
 from aeon.utils.estimator_checks import check_estimator
 from aeon.utils.estimators import MockForecaster
 
-EXAMPLE_CLASSES = [Catch22Classifier, MockForecaster, ExponentTransformer]
+EXAMPLE_CLASSES = [DummyClassifier, MockForecaster, ExponentTransformer]
 
 
 @pytest.mark.parametrize("estimator_class", EXAMPLE_CLASSES)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,12 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
+addopts =
+    --doctest-modules
+    --durations 100
+    --timeout 600
+    --showlocals
+    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
-addopts =
-    --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
#### Reference Issues/PRs
dependent on #701 
see #712 #59 #118 
#### What does this implement/fix? Explain your changes.

looking to speed up RDST slow tests.

1. RDST: two attempts
     the test_prime is occasionally very slow. I suspect this is because testing primes with larger lengths can sometimes degenerate and take too long. Now running this test with series length 12, rather than basic_motions which is length 100
2. RDST test parameters
  I've hard coded possible shapelet lengths for tests to be "shapelet_lengths": [3, 4, 5] in hope that speeds things up

