### PR TITLE
set random_state in rotation forest

### DIFF
--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -219,7 +219,9 @@ class ShapeletTransformClassifier(BaseClassifier):
         )
 
         self._estimator = _clone_estimator(
-            RotationForestClassifier() if self.estimator is None else self.estimator,
+            RotationForestClassifier(random_state=self.random_state)
+            if self.estimator is None
+            else self.estimator,
             self.random_state,
         )
 


### PR DESCRIPTION
#### Reference Issues/PRs
see #711 

#### What does this implement/fix? Explain your changes.

attempts to fix the sporadic fail by setting the random_state in RotationForestClassifier