### PR TITLE
[BUG] change XTick variable from label to label1

### DIFF
--- a/aeon/annotation/plotting/utils.py
+++ b/aeon/annotation/plotting/utils.py
@@ -139,10 +139,10 @@ def plot_time_series_with_profiles(
 
     for a in ax:
         for tick in a.xaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
 
         for tick in a.yaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            tick.label1.set_fontsize(font_size)
 
     if true_cps is not None:
         for idx, true_cp in enumerate(true_cps):


### PR DESCRIPTION
fixes #747 

matplotlib has changed XTick variable label  into two, label1 and label2. This updates the annotation util usage causing a fail on all PRs 