### PR TITLE
[Bugfix] Deprecation of tick.label in matplotlib >3.8.0

### DIFF
--- a/aeon/annotation/plotting/utils.py
+++ b/aeon/annotation/plotting/utils.py
@@ -139,10 +139,20 @@ def plot_time_series_with_profiles(
 
     for a in ax:
         for tick in a.xaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            if hasattr(tick, "label"):
+                tick.label.set_fontsize(font_size)
+            if hasattr(tick, "label1"):
+                tick.label1.set_fontsize(font_size)
+            if hasattr(tick, "label2"):
+                tick.label2.set_fontsize(font_size)
 
         for tick in a.yaxis.get_major_ticks():
-            tick.label.set_fontsize(font_size)
+            if hasattr(tick, "label"):
+                tick.label.set_fontsize(font_size)
+            if hasattr(tick, "label1"):
+                tick.label1.set_fontsize(font_size)
+            if hasattr(tick, "label2"):
+                tick.label2.set_fontsize(font_size)
 
     if true_cps is not None:
         for idx, true_cp in enumerate(true_cps):


### PR DESCRIPTION
Fixes #747.

@TonyBagnall Issue stems from updating matplotlib.