### PR TITLE
[BUG] try fix max for rng in ShapeletTransform

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -395,12 +395,8 @@ class RandomShapeletTransform(BaseCollectionTransformer):
 
     def _extract_random_shapelet(self, X, y, i, shapelets, max_shapelets_per_class):
         rs = 255 if self.random_state == 0 else self.random_state
-        local_max = 214748363
-        rs = (
-            None
-            if self.random_state is None
-            else (rs * 37 * (i + 1)) % local_max
-        )
+        local_max= 214748363
+        rs = None if self.random_state is None else (rs * 37 * (i + 1)) % local_max
         rng = check_random_state(rs)
 
         inst_idx = i % self.n_instances

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -395,10 +395,11 @@ class RandomShapeletTransform(BaseCollectionTransformer):
 
     def _extract_random_shapelet(self, X, y, i, shapelets, max_shapelets_per_class):
         rs = 255 if self.random_state == 0 else self.random_state
+        local_max = 214748363
         rs = (
             None
             if self.random_state is None
-            else (rs * 37 * (i + 1)) % np.iinfo(np.int32).max
+            else (rs * 37 * (i + 1)) % local_max
         )
         rng = check_random_state(rs)
 

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -395,7 +395,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
 
     def _extract_random_shapelet(self, X, y, i, shapelets, max_shapelets_per_class):
         rs = 255 if self.random_state == 0 else self.random_state
-        local_max= 214748363
+        local_max = 214748363
         rs = None if self.random_state is None else (rs * 37 * (i + 1)) % local_max
         rng = check_random_state(rs)
 


### PR DESCRIPTION

#### Reference Issues/PRs
see #711 

#### What does this implement/fix? Explain your changes.

I have no idea why ST intermittently fails on basic motions test. This is shot in the dark to see if maybe the np max function or mod operator for max values is sometimes non-deterministic. I cannot recreate locally so need to just try out on CI
 
