### PR TITLE
[MNT] Uncomment `pytest` config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,10 @@ multi_line_output = 3
 testpaths = aeon
 addopts =
     --doctest-modules
-;    --durations 20
-;    --timeout 600
-;    --showlocals
-;    --numprocesses auto
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
Some of the config lines for pytest were accidently commented in #760. This uncomments them.