### PR TITLE
[BUG] Precision error on dist tests on mac

### DIFF
--- a/aeon/datasets/tests/test_data_loaders.py
+++ b/aeon/datasets/tests/test_data_loaders.py
@@ -117,6 +117,23 @@ def test_load_regression_from_repo():
     shutil.rmtree(os.path.dirname(__file__) + "/../local_data")
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of intermittent fail for read/write",
+)
+def test_load_fails():
+    data_path = os.path.join(
+        os.path.dirname(aeon.__file__),
+        "datasets/data/UnitTest/",
+    )
+    with pytest.raises(ValueError):
+        X, y, meta = load_regression("FOOBAR", extract_path=data_path)
+    with pytest.raises(ValueError):
+        X, y, meta = load_classification("FOOBAR", extract_path=data_path)
+    with pytest.raises(ValueError):
+        X, y, meta = load_forecasting("FOOBAR", extract_path=data_path)
+
+
 def test__alias_datatype_check():
     """Test the alias check"""
     assert _alias_datatype_check("FOO") == "FOO"
@@ -557,14 +574,8 @@ def test_load_forecasting():
     df, meta = load_forecasting("m1_yearly_dataset")
     assert meta == expected_metadata
     assert df.shape == (181, 3)
-    data_path = os.path.join(
-        os.path.dirname(aeon.__file__),
-        "datasets/data/UnitTest/",
-    )
     df = load_forecasting("m1_yearly_dataset", return_metadata=False)
     assert df.shape == (181, 3)
-    with pytest.raises(ValueError):
-        X, y, meta = load_forecasting("FOOBAR", extract_path=data_path)
 
 
 def test_load_regression():
@@ -585,12 +596,6 @@ def test_load_regression():
     assert isinstance(y, np.ndarray)
     assert X.shape == (201, 1, 84)
     assert y.shape == (201,)
-    data_path = os.path.join(
-        os.path.dirname(aeon.__file__),
-        "datasets/data/UnitTest/",
-    )
-    with pytest.raises(ValueError):
-        X, y, meta = load_regression("FOOBAR", extract_path=data_path)
 
 
 def test_load_classification():
@@ -611,12 +616,6 @@ def test_load_classification():
     assert isinstance(y, np.ndarray)
     assert X.shape == (42, 1, 24)
     assert y.shape == (42,)
-    data_path = os.path.join(
-        os.path.dirname(aeon.__file__),
-        "datasets/data/UnitTest/",
-    )
-    with pytest.raises(ValueError):
-        X, y, meta = load_classification("FOOBAR", extract_path=data_path)
 
 
 @pytest.mark.parametrize("freq", [None, "YS"])

--- a/aeon/distances/tests/test_distances.py
+++ b/aeon/distances/tests/test_distances.py
@@ -18,7 +18,7 @@ def _validate_distance_result(x, y, name, distance, expected_result=10):
 
     assert isinstance(dist_result, float)
     assert_almost_equal(dist_result, expected_result)
-    assert dist_result == compute_distance(x, y, metric=name)
+    assert_almost_equal(dist_result, compute_distance(x, y, metric=name))
     assert_almost_equal(dist_result, compute_distance(x, y, metric=distance))
 
     dist_result_to_self = distance(x, x)

--- a/aeon/distances/tests/test_pairwise.py
+++ b/aeon/distances/tests/test_pairwise.py
@@ -53,10 +53,10 @@ def _validate_multiple_to_multiple_result(
     assert isinstance(multiple_to_multiple_result, np.ndarray)
     assert multiple_to_multiple_result.shape == expected_size
 
-    assert np.array_equal(
+    assert_almost_equal(
         multiple_to_multiple_result, compute_pairwise_distance(x, y, metric=name)
     )
-    assert np.array_equal(
+    assert_almost_equal(
         multiple_to_multiple_result,
         compute_pairwise_distance(x, y, metric=distance),
     )
@@ -90,10 +90,10 @@ def _validate_single_to_multiple_result(
 
     assert isinstance(single_to_multiple_result, np.ndarray)
     assert single_to_multiple_result.shape[-1] == expected_size
-    assert np.array_equal(
+    assert_almost_equal(
         single_to_multiple_result, compute_pairwise_distance(x, y, metric=name)
     )
-    assert np.array_equal(
+    assert_almost_equal(
         single_to_multiple_result, compute_pairwise_distance(x, y, metric=distance)
     )
 

--- a/aeon/distances/tests/test_pairwise.py
+++ b/aeon/distances/tests/test_pairwise.py
@@ -20,10 +20,8 @@ def _validate_pairwise_result(
 
     assert isinstance(pairwise_result, np.ndarray)
     assert pairwise_result.shape == expected_size
-    assert np.array_equal(pairwise_result, compute_pairwise_distance(x, metric=name))
-    assert np.array_equal(
-        pairwise_result, compute_pairwise_distance(x, metric=distance)
-    )
+    assert_almost_equal(pairwise_result, compute_pairwise_distance(x, metric=name))
+    assert_almost_equal(pairwise_result, compute_pairwise_distance(x, metric=distance))
 
     x = _make_3d_series(x)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,6 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
-addopts =
-    --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,12 @@ multi_line_output = 3
 [tool:pytest]
 # ignore certain folders and pytest warnings
 testpaths = aeon
+addopts =
+    --doctest-modules
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
 filterwarnings =
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
shape DTW generates tiny numeric differences on mac, this tests almost equal rather than equal. 
Fixes #790 