### PR TITLE
[MNT] Add new `sweep` rules and make current rules more specific

### DIFF
--- a/sweep.yaml
+++ b/sweep.yaml
@@ -23,4 +23,7 @@ sandbox:
 
 rules:
   - "There should not be large chunks of code that are just commented out. Docstrings and explanations in code are okay though."
-  - "Update the relevant API page in 'docs/api_reference/' when new public functions and classes are added and not included in the API documentation. Only add functions and classes which are not already in the relevant API documentation and avoid duplicate entries."
+  - "Any clearly inefficient or redundant code can be optimized or refactored. Any improvements should not change the functionality of the code."
+  - "All public classes and functions should have a numpydoc style docstring. This should include a description of the class or function, the parameters, the class attributes or function return values, and a usage example for the class or function."
+  - "Update the relevant API page in 'docs/api_reference/' when new public functions and classes are added and not included in the API documentation. For example, if a new function is added to 'aeon/distances/', a `sphinx.ext.autosummary link` should also be added to 'docs/api_reference/distances.rst'. New sections in the page should not be created for individual functions and classes, add it to the most relevant existing one. Only add functions and classes which are not already in the relevant API page and avoid duplicate entries."
+  - "We use unit tests for our code. If we have 'class.py', there can be a 'tests/test_class.py' relative to the directory of the file. It is not necessary to create a test file for each new class and function, but any file specific tests should be in similarly named file."


### PR DESCRIPTION
Sweep is now posting on each PR using the rules system. This PR adds a couple of new rules.

Could be useful as a reminder to add things like the API docs, and if anyone wants to give the AI a go on their PR good luck to them 🙂 

Depending on the results some of these may be removed or tweaked.