### PR TITLE
[MNT] Add new periodic tests and tidy workflows

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -10,6 +10,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-manifest:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-manifest --hook-stage manual
+
+  pre-commit:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
+
+      - name: Check for missing init files
+        run: build_tools/fail_on_missing_init_files.sh
+        shell: bash
+
   run-notebook-examples:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -1,4 +1,4 @@
-name: PR examples
+name: PR Examples
 
 on:
   push:

--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -29,7 +29,14 @@ jobs:
       - name: List changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}'
 
-      - uses: pre-commit/action@v3.0.0
+      - if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
+        name: Full pre-commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
+      - if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
+        name: Local pre-commit
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -88,7 +88,7 @@ jobs:
 
   codecov:
     # run the code coverage job if a PR has the 'codecov actions' label
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'codecov actions')
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'codecov actions') }}
 
     needs: test-nosoftdeps
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 jobs:
-  check_manifest:
+  check-manifest:
     runs-on: ubuntu-22.04
 
     steps:
@@ -20,7 +20,7 @@ jobs:
         with:
           extra_args: check-manifest --hook-stage manual
 
-  build_project:
+  build-project:
     needs: check_manifest
     runs-on: ubuntu-22.04
 
@@ -41,8 +41,9 @@ jobs:
         with:
           name: dist
           path: dist/*
+          retention-days: 5
 
-  test_wheels:
+  test-wheels:
     needs: build_project
     runs-on: ${{ matrix.os }}
 
@@ -81,7 +82,7 @@ jobs:
       - name: Tests
         run: python -m pytest
 
-  upload_wheels:
+  upload-wheels:
     needs: test_wheels
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   generate-markdown-and-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+
     steps:
       - uses: actions/checkout@v3
 
@@ -26,8 +27,8 @@ jobs:
 
       - uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "Automated CONTRIBUTORS.md update"
+          commit-message: "Automated `CONTRIBUTORS.md` update"
           branch: update_contributors
-          title: "[MNT] Automated CONTRIBUTORS.md update"
-          body: "Automated update to CONTRIBUTORS.md caused by an update to the .all-contributorsrc file."
+          title: "[MNT] Automated `CONTRIBUTORS.md` update"
+          body: "Automated update to CONTRIBUTORS.md caused by an update to the `.all-contributorsrc` file."
           labels: maintenance, no changelog


### PR DESCRIPTION
Adds a `check-manifest` test to the nightly tests. This will check if the manifest is up-to-date rather than doing it right before a release. The MANIFEST.in file determines which files are included when we make a release.

Adds a full `pre-commit` run. This should be fast, and will catch any breakages due to updates or similar.

Enabled the use of the `full pre-commit` label to run the pre-commit on all files instead of changed ones in a PR.