### PR TITLE
[MNT] Add workflow to update `pre-commit` hooks and make a PR

### DIFF
--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -1,0 +1,27 @@
+name: Update pre-commit Hooks
+
+on:
+  schedule:
+    # every Monday at 12:30 AM UTC
+    - cron:  "30 0 * * 1"
+
+jobs:
+  pre-commit-auto-update:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
+
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "Automated `pre-commit` hook update"
+          branch: pre-commit-hooks-update
+          title: "[MNT] Automated `pre-commit` hook update"
+          body: "Automated weekly update to `.pre-commit-config.yaml` hook versions."
+          labels: maintenance, no changelog


### PR DESCRIPTION
This workflow will automatically update the `pre-commit` hooks in .pre-commit-config.yaml and create a PR with the changes (I hope).

It is difficult to test this actually works, but seems low risk even if it does not initially.