### PR TITLE
[MNT] Add auto label and welcoming comment workflow for PRs 

### DIFF
--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,10 +1,7 @@
 name: PR Opened
 on:
-  pull_request:
-    branches:
-      - main
-#  pull_request_target:
-#    types: [opened]
+  pull_request_target:
+    types: [opened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,0 +1,37 @@
+name: PR Opened
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  # based on the scikit-learn 1.3.1 PR labelers
+  labeler:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: build_tools
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install PyGithub
+        run: pip install -Uq PyGithub
+
+      - name: Label pull request
+        id: label-pr
+        run: python build_tools/pr_labeler.py
+        env:
+          CONTEXT_GITHUB: ${{ toJson(github) }}
+
+      - name: Write pull request comment
+        run: python build_tools/pr_open_commenter.py ${{ steps.label-pr.outputs.title-labels }} ${{ steps.label-pr.outputs.title-labels-new }} ${{ steps.label-pr.outputs.content-labels }} ${{ steps.label-pr.outputs.content-labels-status }}
+        env:
+          CONTEXT_GITHUB: ${{ toJson(github) }}

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,7 +1,10 @@
 name: PR Opened
 on:
-  pull_request_target:
-    types: [opened]
+  pull_request:
+    branches:
+      - main
+#  pull_request_target:
+#    types: [opened]
 
 permissions:
   contents: read

--- a/aeon/classification/deep_learning/inception_time.py
+++ b/aeon/classification/deep_learning/inception_time.py
@@ -24,103 +24,101 @@ class InceptionTimeClassifier(BaseClassifier):
 
     Parameters
     ----------
-        n_classifiers       : int, default = 5,
-            the number of Inception models used for the
-            Ensemble in order to create
-            InceptionTime.
-        depth               : int, default = 6,
+    n_classifiers       : int, default = 5,
+        the number of Inception models used for the
+        Ensemble in order to create
+        InceptionTime.
+    depth               : int, default = 6,
             the number of inception modules used
-        nb_filters          : int or list of int32, default = 32,
-            the number of filters used in one inception
-            module, if not a list,
-            the same number of filters is used in
-            all inception modules
-        nb_conv_per_layer   : int or list of int, default = 3,
-            the number of convolution layers in each inception
-            module, if not a list,
-            the same number of convolution layers is used
-            in all inception modules
-        kernel_size         : int or list of int, default = 40,
-            the head kernel size used for each inception
-            module, if not a list,
-            the same is used in all inception modules
-        use_max_pooling     : bool or list of bool, default = True,
-            conditioning whether or not to use max pooling layer
-            in inception modules,if not a list,
-            the same is used in all inception modules
-        max_pool_size       : int or list of int, default = 3,
-            the size of the max pooling layer, if not a list,
-            the same is used in all inception modules
-        strides             : int or list of int, default = 1,
-            the strides of kernels in convolution layers for each
-            inception module, if not a list,
-            the same is used in all inception modules
-        dilation_rate       : int or list of int, default = 1,
-            the dilation rate of convolutions in each inception
-            module, if not a list,
-            the same is used in all inception modules
-        padding             : str or list of str, default = "same",
-            the type of padding used for convoltuon for each
-            inception module, if not a list,
-            the same is used in all inception modules
-        activation          : str or list of str, default = "relu",
-            the activation function used in each inception
-            module, if not a list,
-            the same is used in all inception modules
-        use_bias            : bool or list of bool, default = False,
-            conditioning whether or not convolutions should
-            use bias values in each inception
-            module, if not a list,
-            the same is used in all inception modules
-        use_residual : bool, default = True,
-            condition whether or not to use residual
-            connections all over Inception
-        use_bottleneck : bool, default = True,
-            condition whether or not to use bottlenecks
-            all over Inception
-        bottleneck_size : int, default = 32,
-            the bottleneck size in case use_bottleneck = True
-        use_custom_filters : bool, default = True,
-            condition on whether or not to use custom
-            filters in the first inception module
-        batch_size : int, default = 64
-            the number of samples per gradient update.
-        use_mini_batch_size : bool, default = False
-            condition on using the mini batch size
-            formula Wang et al.
-        n_epochs : int, default = 1500
-            the number of epochs to train the model.
-        callbacks : callable or None, default
-        ReduceOnPlateau and ModelCheckpoint
-            list of tf.keras.callbacks.Callback objects.
-        file_path : str, default = "./"
-            file_path when saving model_Checkpoint callback
-        save_best_model : bool, default = False
-            Whether or not to save the best model, if the
-            modelcheckpoint callback is used by default,
-            this condition, if True, will prevent the
-            automatic deletion of the best saved model from
-            file and the user can choose the file name
-        save_last_model     : bool, default = False
-            Whether or not to save the last model, last
-            epoch trained, using the base class method
-            save_last_model_to_file
-        best_file_name      : str, default = "best_model"
-            The name of the file of the best model, if
-            save_best_model is set to False, this parameter
-            is discarded
-        last_file_name      : str, default = "last_model"
-            The name of the file of the last model, if
-            save_last_model is set to False, this parameter
-            is discarded
-        random_state        : int, default = 0
-            seed to any needed random actions.
-        verbose             : boolean, default = False
-            whether to output extra information
-        optimizer           : keras optimizer, default = Adam
-        loss                : keras loss,
-                              default = categorical_crossentropy
-        metrics             : keras metrics, default = None,
+    nb_filters          : int or list of int32, default = 32,
+        the number of filters used in one inception
+        module, if not a list,
+        the same number of filters is used in
+        all inception modules
+    nb_conv_per_layer   : int or list of int, default = 3,
+        the number of convolution layers in each inception
+        module, if not a list,
+        the same number of convolution layers is used
+        in all inception modules
+    kernel_size         : int or list of int, default = 40,
+        the head kernel size used for each inception
+        module, if not a list,
+        the same is used in all inception modules
+    use_max_pooling     : bool or list of bool, default = True,
+        conditioning whether or not to use max pooling layer
+        in inception modules,if not a list,
+        the same is used in all inception modules
+    max_pool_size       : int or list of int, default = 3,
+        the size of the max pooling layer, if not a list,
+        the same is used in all inception modules
+    strides             : int or list of int, default = 1,
+        the strides of kernels in convolution layers for each
+        inception module, if not a list,
+        the same is used in all inception modules
+    dilation_rate       : int or list of int, default = 1,
+        the dilation rate of convolutions in each inception
+        module, if not a list,
+        the same is used in all inception modules
+    padding             : str or list of str, default = "same",
+        the type of padding used for convoltuon for each
+        inception module, if not a list,
+        the same is used in all inception modules
+    activation          : str or list of str, default = "relu",
+        the activation function used in each inception
+        module, if not a list,
+        the same is used in all inception modules
+    use_bias            : bool or list of bool, default = False,
+        conditioning whether or not convolutions should
+        use bias values in each inception
+        module, if not a list,
+        the same is used in all inception modules
+    use_residual : bool, default = True,
+        condition whether or not to use residual
+        connections all over Inception
+    use_bottleneck : bool, default = True,
+        condition whether or not to use bottlenecks
+        all over Inception
+    bottleneck_size : int, default = 32,
+        the bottleneck size in case use_bottleneck = True
+    use_custom_filters : bool, default = True,
+        condition on whether or not to use custom
+        filters in the first inception module
+    batch_size : int, default = 64
+        the number of samples per gradient update.
+    use_mini_batch_size : bool, default = False
+        condition on using the mini batch size
+        formula Wang et al.
+    n_epochs : int, default = 1500
+        the number of epochs to train the model.
+    callbacks : callable or None, default = ReduceOnPlateau and ModelCheckpoint
+        list of tf.keras.callbacks.Callback objects.
+    file_path : str, default = "./"
+        file_path when saving model_Checkpoint callback
+    save_best_model : bool, default = False
+        Whether or not to save the best model, if the
+        modelcheckpoint callback is used by default,
+        this condition, if True, will prevent the
+        automatic deletion of the best saved model from
+        file and the user can choose the file name
+    save_last_model     : bool, default = False
+        Whether or not to save the last model, last
+        epoch trained, using the base class method
+        save_last_model_to_file
+    best_file_name      : str, default = "best_model"
+        The name of the file of the best model, if
+        save_best_model is set to False, this parameter
+        is discarded
+    last_file_name      : str, default = "last_model"
+        The name of the file of the last model, if
+        save_last_model is set to False, this parameter
+        is discarded
+    random_state        : int, default = 0
+        seed to any needed random actions.
+    verbose             : boolean, default = False
+        whether to output extra information
+    optimizer           : keras optimizer, default = Adam
+    loss                : keras loss, default = categorical_crossentropy
+    metrics             : keras metrics, default = None,
         will be set to accuracy as default if None
 
     Notes

--- a/aeon/transformations/collection/catch22.py
+++ b/aeon/transformations/collection/catch22.py
@@ -46,7 +46,7 @@ feature_names = [
 class Catch22(BaseCollectionTransformer):
     """Canonical Time-series Characteristics (Catch22).
 
-    Overview: Input n series with d dimensions of length m
+    Overview: Input n series with d dimensions of length m.
     Transforms series into the 22 Catch22 [1]_ features extracted from the hctsa [2]_
     toolbox.
 

--- a/build_tools/pr_labeler.py
+++ b/build_tools/pr_labeler.py
@@ -1,0 +1,91 @@
+"""Labels PRs based on title and change list.
+
+Must be run in a github action with the pull_request_target event.
+
+Based on the scikit-learn v1.3.1 label_title_regex.py script.
+"""
+
+import json
+import os
+import re
+
+from github import Github
+
+context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
+
+repo = context_dict["repository"]
+g = Github(context_dict["token"])
+repo = g.get_repo(repo)
+pr_number = context_dict["event"]["number"]
+pr = repo.get_pull(number=pr_number)
+labels = [label.name for label in pr.get_labels()]
+
+# title labels
+title = pr.title
+
+title_regex_to_labels = [
+    (r"\bENH\b", "enhancement"),
+    (r"\bMNT\b", "maintenance"),
+    (r"\bBUG\b", "bug"),
+    (r"\bDOC\b", "documentation"),
+    (r"\bGOV\b", "governance"),
+]
+
+title_labels = [
+    label for regex, label in title_regex_to_labels if re.search(regex, title)
+]
+title_labels_to_add = list(set(title_labels) - set(labels))
+
+# content labels
+paths = [file.filename for file in pr.get_files()]
+
+content_paths_to_labels = [
+    ("aeon/anomaly_detection/", "anomaly detection"),
+    ("aeon/benchmarking/", "benchmarking"),
+    ("aeon/classification/", "classification"),
+    ("aeon/clustering/", "clustering"),
+    ("aeon/datasets/", "datasets"),
+    ("aeon/datatypes/", "datatypes"),
+    ("aeon/distances/", "distances"),
+    ("examples/", "examples"),
+    ("aeon/forecasting/", "forecasting"),
+    ("aeon/networks/", "networks"),
+    ("aeon/regression/", "regression"),
+    ("aeon/segmentation/", "segmentation"),
+    ("aeon/similarity_search/", "similarity search"),
+    ("aeon/transformations/", "transformations"),
+]
+
+present_content_labels = [
+    label for _, label in content_paths_to_labels if label in labels
+]
+
+content_labels = [
+    label
+    for package, label in content_paths_to_labels
+    if any([package in path for path in paths])
+]
+content_labels = list(set(content_labels))
+
+content_labels_to_add = content_labels
+content_labels_status = "used"
+if len(present_content_labels) > 0:
+    content_labels_to_add = []
+    content_labels_status = "ignored"
+if len(content_labels) > 3:
+    content_labels_to_add = []
+    content_labels_status = (
+        "large" if content_labels_status != "ignored" else "ignored+large"
+    )
+
+# add to PR
+if title_labels_to_add or content_labels_to_add:
+    pr.add_to_labels(*title_labels_to_add + content_labels_to_add)
+
+with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+    print(f"title-labels={title_labels}".replace(" ", ""), file=fh)  # noqa: T201
+    print(  # noqa: T201
+        f"title-labels-new={title_labels_to_add}".replace(" ", ""), file=fh
+    )
+    print(f"content-labels={content_labels}".replace(" ", ""), file=fh)  # noqa: T201
+    print(f"content-labels-status={content_labels_status}", file=fh)  # noqa: T201

--- a/build_tools/pr_open_commenter.py
+++ b/build_tools/pr_open_commenter.py
@@ -1,0 +1,104 @@
+"""Writes a comment on PR opening.
+
+Includes output from the labeler action.
+"""
+
+import json
+import os
+import sys
+
+from github import Github
+
+context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
+
+repo = context_dict["repository"]
+g = Github(context_dict["token"])
+repo = g.get_repo(repo)
+pr_number = context_dict["event"]["number"]
+pr = repo.get_pull(number=pr_number)
+
+print(sys.argv)  # noqa
+title_labels = sys.argv[1][1:-1].split(",")
+title_labels_new = sys.argv[2][1:-1].split(",")
+content_labels = sys.argv[3][1:-1].split(",")
+content_labels_status = sys.argv[4]
+
+labels = [(label.name, label.color) for label in repo.get_labels()]
+title_labels = [
+    "$\\color{#%s}{\\textsf{%s}}$" % (color, label)
+    for label, color in labels
+    if label in title_labels
+]
+title_labels_new = [
+    "$\\color{#%s}{\\textsf{%s}}$" % (color, label)
+    for label, color in labels
+    if label in title_labels_new
+]
+content_labels = [
+    "$\\color{#%s}{\\textsf{%s}}$" % (color, label)
+    for label, color in labels
+    if label in content_labels
+]
+
+title_labels_str = ""
+if len(title_labels) == 0:
+    title_labels_str = (
+        "I did not find any labels to add based on the title. Please "
+        "add the ENH, MNT, BUG, DOC and/or GOV tag to your pull "
+        "requests titles. For now you can add the labels manually."
+    )
+elif len(title_labels_new) != 0:
+    arr_str = str(title_labels_new).strip("[]").replace("'", "")
+    title_labels_str = (
+        "I have added the following labels to this PR based on the title: "
+        f"**[ {arr_str} ]**."
+    )
+    if len(title_labels) != len(title_labels_new):
+        arr_str = (
+            str(set(title_labels) - set(title_labels_new)).strip("[]").replace("'", "")
+        )
+        title_labels_str += (
+            f" The following labels were already present: **[ {arr_str} ]**"
+        )
+
+content_labels_str = ""
+if len(content_labels) != 0:
+    if content_labels_status == "used":
+        arr_str = str(content_labels).strip("[]").replace("'", "")
+        content_labels_str = (
+            "I have added the following labels to this PR based on "
+            f"the changes made: **[ {arr_str} ]**. Feel free "
+            "to change these if they do not properly represent the PR."
+        )
+    elif content_labels_status == "ignored":
+        arr_str = str(content_labels).strip("[]").replace("'", "")
+        content_labels_str = (
+            "I would have added the following labels to this PR "
+            f"based on the changes made: **[ {arr_str} ]**, "
+            "however some package labels are already present."
+        )
+    elif content_labels_status == "large":
+        content_labels_str = (
+            "This PR changes too many different packages (>3) for "
+            "automatic addition of labels, please manually add package "
+            "labels if relevant."
+        )
+elif title_labels_str == "":
+    content_labels_str = (
+        "I did not find any labels to add that did not already "
+        "exist. If the content of your PR changes, make sure to "
+        "update the labels accordingly."
+    )
+
+pr.create_issue_comment(
+    f"""
+## Thank you for contributing to `aeon`!
+
+{title_labels_str}
+{content_labels_str}
+
+The "Checks" tab above or the panel below will show the status of our automated tests. From the panel below you can click on "Details" to the right of the check to see more information if there is a failure. If our `pre-commit` code quality check fails, any trivial fixes will automatically be pushed to your PR.
+
+Don't hesitate to ask questions on the `aeon` Slack channel if you have any!
+    """  # noqa
+)


### PR DESCRIPTION
This PR adds a workflow and scripts to automatically label PRs based on the title and contents changed. This is similar to how `scikit-learn` does some of their labelling. 

[MNT] in the title should add the maintenance labels, [MNT,GOV] maintenance and governance lablels, etc.

Changes to the classification package should add classification, transformations the transformations label, examples the examples label etc. If this would add more than 3 labels, none are added to reduce bloat.

The actions will (should) post the changes made and a welcoming comment on the PR when it is opened.

I have made two uncontroversial (I hope) doc string changes to demonstrate this.