### PR TITLE
[MNT] Always create a pull request on `pre-commit` update even if full run fails

### DIFF
--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
 
-      - uses: peter-evans/create-pull-request@v5
+      - if: always()
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "Automated `pre-commit` hook update"
           branch: pre-commit-hooks-update

--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -18,11 +18,18 @@ jobs:
 
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.PR_APP_ID }}
+          private_key: ${{ secrets.PR_APP_KEY }}
+
       - if: always()
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: "Automated `pre-commit` hook update"
           branch: pre-commit-hooks-update
           title: "[MNT] Automated `pre-commit` hook update"
           body: "Automated weekly update to `.pre-commit-config.yaml` hook versions."
-          labels: maintenance, no changelog
+          labels: maintenance, full pre-commit, no changelog


### PR DESCRIPTION
Updating sometimes comes with some errors, but it shouldn't stop creating a PR.

See https://github.com/aeon-toolkit/aeon/actions/runs/6607280135

Creates a new token for the PR, which should allow it to run CI as well.