### PR TITLE
[MNT] Allow manual run of certain workflows

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # every day at 1:30 AM UTC
     - cron:  "30 1 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
 
-      - uses: peter-evans/create-pull-request@v5
+      - if: always()
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "Automated `pre-commit` hook update"
           branch: pre-commit-hooks-update

--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # every Monday at 12:30 AM UTC
     - cron:  "30 0 * * 1"
+  workflow_dispatch:
 
 jobs:
   pre-commit-auto-update:

--- a/.github/workflows/precommit_autoupdate.yml
+++ b/.github/workflows/precommit_autoupdate.yml
@@ -18,11 +18,18 @@ jobs:
 
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.PR_APP_ID }}
+          private_key: ${{ secrets.PR_APP_KEY }}
+
       - if: always()
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: "Automated `pre-commit` hook update"
           branch: pre-commit-hooks-update
           title: "[MNT] Automated `pre-commit` hook update"
           body: "Automated weekly update to `.pre-commit-config.yaml` hook versions."
-          labels: maintenance, no changelog
+          labels: maintenance, full pre-commit, no changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   check-manifest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dl = [
     "tensorflow-probability<0.21.0",
 ]
 unstable_extras = [
-    "pycatch22<=4.3",  # known to fail installation on some setups
+    "pycatch22<=0.4.3",  # known to fail installation on some setups
     "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'",  # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
 ]
 dev = [


### PR DESCRIPTION
Allows devs to manually run certain workflows from the actions tab. Fixes weird version bound for `pycatch22`.