### PR TITLE
[MNT] Give more time for codecov workflow tests

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -146,6 +146,6 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --cov=aeon --cov-report=xml
+        run: python -m pytest --cov=aeon --cov-report=xml --timeout 1800
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -110,6 +110,6 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --cov=aeon --cov-report=xml
+        run: python -m pytest --cov=aeon --cov-report=xml  --timeout 1800
 
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Give codecov tests 30 minutes instead of 10 maximum runtime. Ideally it shouldnt need this much, but this gives a bit more flexibility. These can only be run manually or periodically in the night, so it should not have a massive impact to resource usage overall.