### PR TITLE
[DOC] Kmeans updated default for averaging method

### DIFF
--- a/aeon/clustering/k_means.py
+++ b/aeon/clustering/k_means.py
@@ -77,7 +77,8 @@ class TimeSeriesKMeans(BaseClusterer):
         If you specify 'ba' then by default the distance measure used will be the same
         as the distance measure used for clustering. If you wish to use a different
         distance measure you can specify it by passing {"distance": "dtw"} as
-        averaging_params.
+        averaging_params. BA is very computationally expensive so you may want to
+        consider setting a bounding window or using a different averaging method.
     average_params : dict, default=None
         Dictionary containing kwargs for averaging_method. See documentation of
         aeon.clustering.averaging and aeon.distances for more details. NOTE: if you

--- a/aeon/clustering/k_means.py
+++ b/aeon/clustering/k_means.py
@@ -70,7 +70,7 @@ class TimeSeriesKMeans(BaseClusterer):
         Verbosity mode.
     random_state : int or np.random.RandomState instance or None, default=None
         Determines random number generation for centroid initialization.
-    averaging_method : str or Callable, default='mean'
+    averaging_method : str or Callable, default='ba'
         Averaging method to compute the average of a cluster. Any of the following
         strings are valid: ['mean', 'ba']. If a Callable is provided must take the form
         Callable[[np.ndarray], np.ndarray].

--- a/aeon/clustering/k_means.py
+++ b/aeon/clustering/k_means.py
@@ -77,8 +77,9 @@ class TimeSeriesKMeans(BaseClusterer):
         If you specify 'ba' then by default the distance measure used will be the same
         as the distance measure used for clustering. If you wish to use a different
         distance measure you can specify it by passing {"distance": "dtw"} as
-        averaging_params. BA is very computationally expensive so you may want to
-        consider setting a bounding window or using a different averaging method.
+        averaging_params. BA yields 'better' clustering results but is very
+        computationally expensive so you may want to consider setting a bounding window
+        or using a different averaging method if time complexity is a concern.
     average_params : dict, default=None
         Dictionary containing kwargs for averaging_method. See documentation of
         aeon.clustering.averaging and aeon.distances for more details. NOTE: if you


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://github.com/aeon-toolkit/aeon/blob/main/CONTRIBUTING.md

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
The default for the averaging_method was documented incorrectly. Changed default in docstring from 'mean' to 'ba'.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).

##### For developers with write access
- [x] Optionally, I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
