### PR TITLE
[MNT] Retry aeon install on failure for GitHub workflows

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -54,7 +54,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: python -m pip install .[all_extras,binder,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,binder,dev]
 
       - name: Run example notebooks
         run: build_tools/run_examples.sh
@@ -71,7 +75,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -93,7 +101,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -118,7 +130,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[all_extras,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -140,7 +156,11 @@ jobs:
         run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[all_extras,unstable_extras,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,unstable_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -29,7 +29,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[all_extras,binder,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,binder,dev]
 
       - name: Run example notebooks
         run: build_tools/run_examples.sh

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -28,7 +28,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -51,7 +55,11 @@ jobs:
           python-version: "3.10"
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -77,7 +85,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[all_extras,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -104,7 +116,11 @@ jobs:
         run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
       - name: Install aeon and dependencies
-        run: python -m pip install .[all_extras,unstable_extras,dev]
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,unstable_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,18 @@ jobs:
 
       - if: runner.os == 'Windows'
         name: Windows install
-        run: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
       - if: runner.os != 'Windows'
         name: Unix install
-        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Tests
         run: python -m pytest


### PR DESCRIPTION
Currently, the installation will occasionally fail with an SHA error when too many things are installed at once on the workflows.

I'm not quite sure what is causing this, or if there is anything on our side that can change to fix it (other than reducing the amount of dependencies).

The error is sporadic, so this PR just adds a workflow to retry the installation if it fails. Consistent failures should still be caught, as there is a limit to the amount of retries.