### PR TITLE
[MNT] Use app token for other GitHub workflows

### DIFF
--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,10 +1,7 @@
 name: PR Opened
 on:
-#  pull_request_target:
-#    types: [opened]
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    types: [opened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -31,6 +31,12 @@ jobs:
         env:
           CONTEXT_GITHUB: ${{ toJson(github) }}
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_APP_ID }}
+          private-key: ${{ secrets.PR_APP_KEY }}
+
       - name: Write pull request comment
         run: python build_tools/pr_open_commenter.py ${{ steps.label-pr.outputs.title-labels }} ${{ steps.label-pr.outputs.title-labels-new }} ${{ steps.label-pr.outputs.content-labels }} ${{ steps.label-pr.outputs.content-labels-status }}
         env:

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,7 +1,10 @@
 name: PR Opened
 on:
-  pull_request_target:
-    types: [opened]
+#  pull_request_target:
+#    types: [opened]
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -38,6 +41,6 @@ jobs:
           private-key: ${{ secrets.PR_APP_KEY }}
 
       - name: Write pull request comment
-        run: python build_tools/pr_open_commenter.py ${{ steps.label-pr.outputs.title-labels }} ${{ steps.label-pr.outputs.title-labels-new }} ${{ steps.label-pr.outputs.content-labels }} ${{ steps.label-pr.outputs.content-labels-status }}
+        run: python build_tools/pr_open_commenter.py ${{ steps.app-token.outputs.token }} ${{ steps.label-pr.outputs.title-labels }} ${{ steps.label-pr.outputs.title-labels-new }} ${{ steps.label-pr.outputs.content-labels }} ${{ steps.label-pr.outputs.content-labels-status }}
         env:
           CONTEXT_GITHUB: ${{ toJson(github) }}

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -25,8 +25,15 @@ jobs:
         id: generate
         run: npx all-contributors generate
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_APP_ID }}
+          private-key: ${{ secrets.PR_APP_KEY }}
+
       - uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Automated `CONTRIBUTORS.md` update"
           branch: update_contributors
           title: "[MNT] Automated `CONTRIBUTORS.md` update"

--- a/build_tools/pr_open_commenter.py
+++ b/build_tools/pr_open_commenter.py
@@ -11,19 +11,17 @@ from github import Github
 
 context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
 
-print(context_dict)  # noqa
-
 repo = context_dict["repository"]
-g = Github(context_dict["token"])
+g = Github(sys.argv[1])
 repo = g.get_repo(repo)
 pr_number = context_dict["event"]["number"]
 pr = repo.get_pull(number=pr_number)
 
-print(sys.argv)  # noqa
-title_labels = sys.argv[1][1:-1].split(",")
-title_labels_new = sys.argv[2][1:-1].split(",")
-content_labels = sys.argv[3][1:-1].split(",")
-content_labels_status = sys.argv[4]
+print(sys.argv[2:])  # noqa
+title_labels = sys.argv[2][1:-1].split(",")
+title_labels_new = sys.argv[3][1:-1].split(",")
+content_labels = sys.argv[4][1:-1].split(",")
+content_labels_status = sys.argv[5]
 
 labels = [(label.name, label.color) for label in repo.get_labels()]
 title_labels = [

--- a/build_tools/pr_open_commenter.py
+++ b/build_tools/pr_open_commenter.py
@@ -11,6 +11,8 @@ from github import Github
 
 context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
 
+print(context_dict)  # noqa
+
 repo = context_dict["repository"]
 g = Github(context_dict["token"])
 repo = g.get_repo(repo)


### PR DESCRIPTION
Uses the `aeon` app access token from #881 in other GitHub workflows. This should cause the PR/Comment posted to be aeon rather than github-actions, and gives us a bit more control over permissions.