### PR TITLE
[ENH] Support unequal length for rdst

### DIFF
--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -79,10 +79,6 @@ class RDSTClassifier(BaseClassifier):
         The number of unique classes in the training set.
     fit_time_  : int
         The time (in milliseconds) for ``fit`` to run.
-    n_instances_ : int
-        The number of train cases in the training set.
-    n_dims_ : int
-        The number of dimensions per case in the training set.
     series_length_ : int
         The length of each series in the training set.
     transformed_data_ : list of shape (n_estimators) of ndarray
@@ -151,9 +147,6 @@ class RDSTClassifier(BaseClassifier):
         self.save_transformed_data = save_transformed_data
         self.random_state = random_state
         self.n_jobs = n_jobs
-
-        self.n_instances_ = 0
-        self.n_dims_ = 0
         self.transformed_data_ = []
 
         self._transformer = None
@@ -181,9 +174,6 @@ class RDSTClassifier(BaseClassifier):
         Changes state by creating a fitted model that updates attributes
         ending in "_".
         """
-        self.n_instances_ = len(X)
-        self.n_dims_ = X[0].shape[0]
-
         self._transformer = RandomDilatedShapeletTransform(
             max_shapelets=self.max_shapelets,
             shapelet_lengths=self.shapelet_lengths,

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -120,8 +120,8 @@ class RDSTClassifier(BaseClassifier):
 
     _tags = {
         "capability:multivariate": True,
-        "capability:multithreading": True,
         "capability:unequal_length": True,
+        "capability:multithreading": True,
         "non-deterministic": True,  # due to random_state bug in MacOS #324
         "algorithm_type": "shapelet",
     }

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -152,7 +152,6 @@ class RDSTClassifier(BaseClassifier):
 
         self.n_instances_ = 0
         self.n_dims_ = 0
-        self.series_length_ = 0
         self.transformed_data_ = []
 
         self._transformer = None
@@ -180,7 +179,8 @@ class RDSTClassifier(BaseClassifier):
         Changes state by creating a fitted model that updates attributes
         ending in "_".
         """
-        self.n_instances_, self.n_dims_, self.series_length_ = X.shape
+        self.n_instances_ = len(X)
+        self.n_dims_ = X[0].shape[0]
 
         self._transformer = RandomDilatedShapeletTransform(
             max_shapelets=self.max_shapelets,

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -121,6 +121,7 @@ class RDSTClassifier(BaseClassifier):
     _tags = {
         "capability:multivariate": True,
         "capability:multithreading": True,
+        "capability:unequal_length": True,
         "non-deterministic": True,  # due to random_state bug in MacOS #324
         "algorithm_type": "shapelet",
     }

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -252,9 +252,9 @@ class RDSTClassifier(BaseClassifier):
         if callable(m):
             return self._estimator.predict_proba(X_t)
         else:
-            dists = np.zeros((X.shape[0], self.n_classes_))
+            dists = np.zeros((len(X), self.n_classes_))
             preds = self._estimator.predict(X_t)
-            for i in range(0, X.shape[0]):
+            for i in range(0, len(X)):
                 dists[i, np.where(self.classes_ == preds[i])] = 1
             return dists
 

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -122,6 +122,7 @@ class RDSTClassifier(BaseClassifier):
         "capability:multivariate": True,
         "capability:unequal_length": True,
         "capability:multithreading": True,
+        "X_inner_type": ["np-list", "numpy3D"],
         "non-deterministic": True,  # due to random_state bug in MacOS #324
         "algorithm_type": "shapelet",
     }

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -133,6 +133,8 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         "output_data_type": "Tabular",
         "capability:multivariate": True,
         "capability:unequal_length": True,
+        "X_inner_type": ["np-list", "numpy3D"],
+        "y_inner_type": "numpy1D",
     }
 
     def __init__(
@@ -195,7 +197,7 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         else:
             y = LabelEncoder().fit_transform(y)
 
-        if any(self.shapelet_lengths_ > self.series_length):
+        if any(self.shapelet_lengths_ > self.min_series_length_fit):
             raise ValueError(
                 "Shapelets lengths can't be superior to input length,",
                 "but got shapelets_lengths = {} ".format(self.shapelet_lengths_),
@@ -448,7 +450,6 @@ def _init_random_shapelet_params(
 def random_dilated_shapelet_extraction(
     X,
     y,
-    min_series_length_fit,
     max_shapelets,
     shapelet_lengths,
     proba_normalization,

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -181,11 +181,8 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         else:
             self._random_state = np.int32(np.random.randint(0, 2**31))
 
-        self.n_instances = len(X)
-        self.n_channels = X[0].shape[0]
-        self.min_series_length_fit = min(
-            [X[i].shape[1] for i in range(self.n_instances)]
-        )
+        n_instances_ = len(X)
+        self.min_series_length_fit = min([X[i].shape[1] for i in range(n_instances_)])
 
         self._check_input_params()
 
@@ -193,7 +190,7 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         set_num_threads(self._n_jobs)
 
         if y is None:
-            y = np.zeros(self.n_instances)
+            y = np.zeros(n_instances_)
         else:
             y = LabelEncoder().fit_transform(y)
 

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -223,6 +223,12 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
                 "you have NaN values in your data. We do not currently support NaN "
                 "values for shapelet transformation."
             )
+
+        # Shapelet "length" is length-1 times dilation
+        self.max_fitted_shapelet_length_ = np.max(
+            (self.shapelets_[1] - 1) * self.shapelets_[2]
+        )
+
         return self
 
     def _transform(self, X, y=None):
@@ -238,6 +244,14 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         X_new : 2D np.array of shape = (n_instances, 3*n_shapelets)
             The transformed data.
         """
+        for i in range(0, len(X)):
+            if X[i].shape[1] < self.max_fitted_shapelet_length_:
+                raise ValueError(
+                    "The shortest series in transform is smaller than "
+                    "the min shapelet length, pad to min length prior to "
+                    "calling transform."
+                )
+
         X_new = dilated_shapelet_transform(X, self.shapelets_)
         if np.isinf(X_new).any() or np.isnan(X_new).any():
             warnings.warn(

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -90,7 +90,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
         The number of train cases.
     n_channels_ : int
         The number of dimensions per case.
-    max_fitted_shapelet_length_ : int
+    max_shapelet_length_ : int
         The maximum actual shapelet length fitted to train data.
     min_series_length_ : int
         The minimum length of series in train data.
@@ -351,7 +351,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
                 )
             )
         # find max shapelet length
-        self.max_fitted_shapelet_length_ = max(self.shapelets, key=lambda x: x[1])[1]
+        self.max_shapelet_length_ = max(self.shapelets, key=lambda x: x[1])[1]
 
     def _transform(self, X, y=None):
         """Transform X according to the extracted shapelets.
@@ -369,7 +369,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
         output = np.zeros((len(X), len(self.shapelets)))
 
         for i in range(0, len(X)):
-            if X[i].shape[1] < self.max_fitted_shapelet_length_:
+            if X[i].shape[1] < self.max_shapelet_length_:
                 raise ValueError(
                     "The shortest series in transform is smaller than "
                     "the min shapelet length, pad to min length prior to "

--- a/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
@@ -14,7 +14,7 @@ def test_shapelet_transform():
     # Assert at least one shapelet per class when max_shapelets < n_labels
     assert len(rst.shapelets) == 4
     X, y = make_3d_test_data(
-        n_cases=3, n_timepoints=rst.max_fitted_shapelet_length_ - 1, n_labels=4
+        n_cases=3, n_timepoints=rst.max_shapelet_length_ - 1, n_labels=4
     )
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Add unequal length support for RDST transformer and classifier

#### Reference Issues/PRs

Fixes #872 

#### What does this implement/fix? Explain your changes.

For the non-numba code, use len(X) instead of shape[0] to be compatible with lists, and check for minimum length requirements in the input (i.e. all inputs must be longer than shapelets).

For the numba code, use the minimum length in fit to initialize dilations, and create a boolean mask of the size of the longer series for alpha similarity sampling. The mask is then set to false after each series length so we cannot sample points that do not exist.

#### Does your contribution introduce a new dependency? If yes, which one?

No additional dependency.