### PR TITLE
[ENH] base deep classifier one hot encoder

### DIFF
--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -137,8 +137,18 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         self.classes_ = self.label_encoder.classes_
         self.n_classes_ = len(self.classes_)
         y = y.reshape(len(y), 1)
-        self.onehot_encoder = OneHotEncoder(sparse=False, categories="auto")
+        # Adjustment to allow deprecated attribute "sparse for older versions
+        import sklearn
+        from packaging import version
+
+        # Get the installed version of scikit-learn
+        installed_version = sklearn.__version__
+        # Compare the installed version with the target version
         # categories='auto' to get rid of FutureWarning
+        if version.parse(installed_version) < version.parse("1.1"):
+            self.onehot_encoder = OneHotEncoder(sparse=False)
+        else:
+            self.onehot_encoder = OneHotEncoder(sparse_output=False)
         y = self.onehot_encoder.fit_transform(y)
         return y
 


### PR DESCRIPTION
OneHotEncoder is generating a deprecation warning from sklearn : the parameter sparse is becoming sparse_output. This pr tests the sckit version and passes sparse_output as an argument. It also removes the argument auto, since that is the default value anyway.