### PR TITLE
[ENH] Remove upper bounds for `tslearn` and `pmdarima`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ all_extras = [
     "kotsu>=0.3.1",
     "matplotlib>=3.3.2",
     "mne",
-    "pmdarima>=1.8.0,<3.0.0",
+    "pmdarima>=1.8.0",
     "prophet>=1.1.0",
     "pyod>=0.8.0",
     "scikit_posthocs>=0.6.5",
@@ -79,7 +79,7 @@ all_extras = [
     "tensorflow<2.13.0",
     "tensorflow-probability<0.21.0",
     "tsfresh>=0.20.0",
-    "tslearn>=0.5.2,<0.6.0",
+    "tslearn>=0.5.2",
     "xarray",
     "mlflow<2.4.0", # see https://github.com/mlflow/mlflow/issues/8629
     "imbalanced-learn",


### PR DESCRIPTION
Removes some version upper bounds for soft dependencies.