### PR TITLE
[DOC] Add warning to installation guide for some shells

### DIFF
--- a/build_tools/pr_open_commenter.py
+++ b/build_tools/pr_open_commenter.py
@@ -40,6 +40,15 @@ content_labels = [
     if label in content_labels
 ]
 
+replacement_labels = [
+    ("anomalydetection", "anomaly detection"),
+    ("similaritysearch", "similarity search"),
+]
+for i, label in enumerate(content_labels):
+    for cur_label, new_label in replacement_labels:
+        if label == cur_label:
+            content_labels[i] = new_label
+
 title_labels_str = ""
 if len(title_labels) == 0:
     title_labels_str = (

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,10 +53,17 @@ required.
 pip install -U aeon[all_extras]
 ```
 
+```{note}
+    If this results in a "no matches found" error, it may be due to how your shell
+    handles special characters. Try surrounding the dependency portion with quotes i.e.
+
+    pip install -U aeon"[all_extras]"
+```
+
 ```{warning}
-Some of the dependencies included in `all_extras` do not work on Mac ARM-based
-processors, such as M1, M2, M1Pro, M1Max or M1Ultra. This may cause an error during
-installation. Mode details can be found in the troubleshooting section below.
+    Some of the dependencies included in `all_extras` do not work on Mac ARM-based
+    processors, such as M1, M2, M1Pro, M1Max or M1Ultra. This may cause an error during
+    installation. Mode details can be found in the troubleshooting section below.
 ```
 
 After installation, you can verify that `aeon` has been installed correctly by
@@ -203,3 +210,14 @@ Also, ARM-based processors have issues when installing packages distributed as s
 distributions instead of Python wheels. To avoid this issue when installing a package,
 you can try installing it through `conda` or use a prior version of the package that
 was distributed as a wheel.
+
+### `no matches found` when installing `all_extras`
+
+Some shells (i.e. the commonly used [Zsh](https://en.wikipedia.org/wiki/Z_shell)) use
+square brackets as a special character. If you are using such a shell, you may
+encounter an error when installing `aeon[all_extras]`. This can be resolved by
+surrounding the dependency portion with quotes i.e.
+
+```{code-block} powershell
+pip install -U aeon"[all_extras]"
+```


### PR DESCRIPTION
There have been multiple people on the slack unable to install `all_extras` due the the command line/shell used. This is not really a problem specific to `aeon`, but does impact us.

This PR adds a warning to the installation guide for certain shells which require a different input for dependency groups i.e. `all_extras` and `dev`.