### PR TITLE
[DOC] Remove "Time series" from API titles

### DIFF
--- a/docs/api_reference/annotation.rst
+++ b/docs/api_reference/annotation.rst
@@ -1,7 +1,7 @@
 .. _annotation_ref:
 
-Time series annotation
-======================
+Annotation
+==========
 
 The :mod:`aeon.annotation` module contains algorithms and tools
 for time series annotation. This no longer includes anomaly/outlier

--- a/docs/api_reference/anomaly_detection.rst
+++ b/docs/api_reference/anomaly_detection.rst
@@ -1,7 +1,7 @@
 .. _annotation_ref:
 
-Time Series Anomaly Detection
-=============================
+Anomaly Detection
+=================
 
 Time Series Anomaly Detection aims at discovering regions of a time series that in
 some way not representative of the underlying generative process.

--- a/docs/api_reference/classification.rst
+++ b/docs/api_reference/classification.rst
@@ -1,7 +1,7 @@
 .. _classification_ref:
 
-Time series classification
-==========================
+Classification
+==============
 
 The :mod:`aeon.classification` module contains algorithms and composition tools for time series classification.
 

--- a/docs/api_reference/clustering.rst
+++ b/docs/api_reference/clustering.rst
@@ -1,8 +1,8 @@
 
 .. _clustering_ref:
 
-Time series clustering
-======================
+Clustering
+==========
 
 The :mod:`aeon.clustering` module contains algorithms for time series clustering.
 

--- a/docs/api_reference/distances.rst
+++ b/docs/api_reference/distances.rst
@@ -1,7 +1,7 @@
 .. _distances_ref:
 
-Time series distances
-=====================
+Distances
+=========
 
 The :mod:`aeon.distances` module contains time series specific distance functions
 that can be used in aeon and scikit learn estimators. It also contains tools for

--- a/docs/api_reference/regression.rst
+++ b/docs/api_reference/regression.rst
@@ -1,7 +1,7 @@
 .. _regression_ref:
 
-Time series regression
-======================
+Regression
+==========
 
 The :mod:`aeon.regression` module contains algorithms and composition tools for time series regression.
 

--- a/docs/api_reference/segmentation.rst
+++ b/docs/api_reference/segmentation.rst
@@ -1,7 +1,7 @@
 .. _annotation_ref:
 
-Time Series Segmentation
-========================
+Segmentation
+============
 
 Time Series Segmentation aims to discover regions of a time series that are
 semantically dissimilar to neighboring regions. The :mod:`aeon.segmentation` module

--- a/docs/api_reference/similarity_search.rst
+++ b/docs/api_reference/similarity_search.rst
@@ -1,7 +1,7 @@
 .. _similarity_search_ref:
 
-Time series similarity search
-=============================
+Similarity search
+=================
 
 The :mod:`aeon.similarity_search` module contains algorithms and tools for similarity search tasks.
 

--- a/docs/api_reference/transformations.rst
+++ b/docs/api_reference/transformations.rst
@@ -1,7 +1,7 @@
 .. _transformations_ref:
 
-Time series transformations
-===========================
+Transformations
+===============
 
 The :mod:`aeon.transformations` module contains classes for data
 transformations.


### PR DESCRIPTION
As discussed on slack, this removes Time series from title of API modules, as its redundant and not consistent