### PR TITLE
[MNT] Add `pytest` plugin to retry failed tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ dev = [
     "pytest-randomly",
     "pytest-timeout",
     "pytest-xdist",
+    "pytest-rerunfailures",
     "wheel",
     "boto3",  # mlflow related
     "botocore",  # mlflow related
@@ -173,6 +174,7 @@ addopts = '''
     --timeout 600
     --showlocals
     --numprocesses auto
+    --reruns 2
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ addopts = '''
     --showlocals
     --numprocesses auto
     --reruns 2
+    --only-rerun "crashed while running"
 '''
 filterwarnings = '''
     ignore::UserWarning


### PR DESCRIPTION
Somewhat of a reoccurring issue with our test suite is instability. Some of these are legitimate failures with sporadically failing tests, but a majority are just nodes crashing and causing the whole set to fail.

This would make the runs a lot more stable, but the downside of the above is it would rerun some of the legitimate failures, and they may get lost instead of being noticed and fixed. It's a bit hacky.

The main cause of these crashes from what I have gathered is `pytest-xdist` which runs the tests in parallel, and removing it would make everything a lot slower. One of the chosen plugins features is to be able to recover from hard crashed when `pytest-xdist` is installed.

One potential mitigator would be to automatically parse the output logs and create issues for re-runs which aren't crashes, but that's just an idea, and I'm not sure how much effort this would take or if it is possible.