### PR TITLE
[BUG] Fixed missing z-normalisation for SFA in RED CoMETS

### DIFF
--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -17,6 +17,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state
+from sklearn.preprocessing import scale
 
 from aeon.classification.base import BaseClassifier
 from aeon.transformations.collection.dictionary_based import SAX, SFA
@@ -203,6 +204,8 @@ class REDCOMETS(BaseClassifier):
 
         from imblearn.over_sampling import SMOTE, RandomOverSampler
 
+        X = scale(X, axis=1)  # Z-normalise
+
         if self.variant in [1, 2, 3]:
             perc_length = self.perc_length / self._n_channels
         else:
@@ -279,7 +282,7 @@ class REDCOMETS(BaseClassifier):
             sfa_clfs.append((rf, weight))
 
         sax_transforms = [
-            SAX(n_segments=w, alphabet_size=a, znormalized=False) for w, a in sax_lenses
+            SAX(n_segments=w, alphabet_size=a, znormalized=True) for w, a in sax_lenses
         ]
 
         sax_clfs = []
@@ -397,7 +400,7 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 2D np.ndarray of shape = [n_instances, series_length]
             The data to make predict probabilities for.
 
         Returns
@@ -405,6 +408,7 @@ class REDCOMETS(BaseClassifier):
         y : array-like, shape = [n_instances, n_classes_]
             Predicted probabilities using the ordering in ``classes_``.
         """
+        X = scale(X, axis=1)  # Z-normalise
         pred_mat = np.zeros((X.shape[0], self.n_classes_))
 
         placeholder_y = np.zeros(X.shape[0])
@@ -459,6 +463,7 @@ class REDCOMETS(BaseClassifier):
             sax_clfs = self.sax_clfs[d]
 
             X_d = X[:, d, :]
+            X_d = scale(X_d, axis=1)  # Z-normalise
 
             if self.variant in [6, 7, 8, 9]:
                 dimension_pred_mats = None

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -134,9 +134,11 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray, shape = [n_instances, n_channels, n_timepoints]
+        X : np.ndarray
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The training data.
-        y : 1D np.ndarray, shape = [n_instances]
+        y : np.ndarray
+            1D np.ndarray of shape (n_instances)
             The class labels.
 
         Returns
@@ -177,9 +179,11 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 2D np.ndarray, shape = [n_instances, n_timepoints]
+        X : np.ndarray
+            2D np.ndarray of shape (n_instances, n_timepoints)
             The training data.
-        y : 1D np.ndarray, shape = [n_instances]
+        y : np.ndarray 
+            1D np.ndarray of shape (n_instances)
             The class labels.
 
         Returns
@@ -312,10 +316,12 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray, shape = [n_instances, n_channels, n_timepoints]
+        X : np.ndarray
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The training data.
             ``n_channels > 1``
-        y : 1D np.ndarray, shape = [n_instances]
+        y : np.ndarray
+            1D np.ndarray of shape (n_instances)
             The class labels.
 
         Returns
@@ -361,12 +367,14 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray, shape = [n_instances, n_channels, series_length]
+        X : np.ndarray
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The data to make predictions for.
 
         Returns
         -------
-        y : 1D np.ndarray, shape = [n_instances]
+        y : np.ndarray 
+            1D np.ndarray of shape (n_instances)
             Predicted class labels.
         """
         return np.array(
@@ -378,12 +386,14 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray, shape = [n_instances, n_channels, series_length]
+        X : np.ndarray
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The data to make predict probabilities for.
 
         Returns
         -------
-        y : 1D np.ndarray, shape = [n_instances, n_classes_]
+        y : np.ndarray
+            2D np.ndarray of shape (n_instances, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         if X.shape[1] == 1:  # Univariate
@@ -400,12 +410,14 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 2D np.ndarray of shape = [n_instances, series_length]
+        X : np.ndarray 
+            2D np.ndarray of shape (n_instances, n_timepoints)
             The data to make predict probabilities for.
 
         Returns
         -------
-        y : array-like, shape = [n_instances, n_classes_]
+        y : np.ndarray
+            2D np.ndarray of shape (n_instances, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         X = scale(X, axis=1)  # Z-normalise
@@ -443,13 +455,15 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : np.ndarray
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The data to make predict probabilities for.
             ``n_channels > 1``
 
         Returns
         -------
-        y : array-like, shape = [n_instances, n_classes_]
+        y : np.ndarray
+            2D np.ndarray of shape (n_instances, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         ensemble_pred_mats = None
@@ -545,7 +559,8 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray, shape = [n_instances, n_channels, n_timepoints]
+        X : np.ndarray 
+            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The training data.
         n_lenses : int
             Number of lenses to select.
@@ -585,7 +600,8 @@ class REDCOMETS(BaseClassifier):
         ----------
         sax_transforms : list
             List of ``SAX()`` instances
-        X : 2D np.ndarray, shape = [n_instances, n_timepoint]
+        X : np.ndarray
+            2D np.ndarray of shape (n_instances, n_timepoints)
             The data to transform.
         """
 

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -182,7 +182,7 @@ class REDCOMETS(BaseClassifier):
         X : np.ndarray
             2D np.ndarray of shape (n_instances, n_timepoints)
             The training data.
-        y : np.ndarray 
+        y : np.ndarray
             1D np.ndarray of shape (n_instances)
             The class labels.
 
@@ -373,7 +373,7 @@ class REDCOMETS(BaseClassifier):
 
         Returns
         -------
-        y : np.ndarray 
+        y : np.ndarray
             1D np.ndarray of shape (n_instances)
             Predicted class labels.
         """
@@ -410,7 +410,7 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : np.ndarray 
+        X : np.ndarray
             2D np.ndarray of shape (n_instances, n_timepoints)
             The data to make predict probabilities for.
 
@@ -559,7 +559,7 @@ class REDCOMETS(BaseClassifier):
 
         Parameters
         ----------
-        X : np.ndarray 
+        X : np.ndarray
             3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
             The training data.
         n_lenses : int

--- a/aeon/classification/dictionary_based/tests/test_redcomets.py
+++ b/aeon/classification/dictionary_based/tests/test_redcomets.py
@@ -30,7 +30,7 @@ def test_redcomets_train_estimate_univariate():
         score = redcomets.score(X_test, y_test)
 
         assert isinstance(score, np.float_)
-        np.testing.assert_almost_equal(score, 0.727272, decimal=4)
+        np.testing.assert_almost_equal(score, 0.818181, decimal=4)
 
     test_variant(1)
     test_variant(2)
@@ -61,15 +61,16 @@ def test_redcomets_train_estimate_multivariate():
         assert isinstance(score, np.float_)
         np.testing.assert_almost_equal(score, expected_result, decimal=4)
 
-    test_variant(1, 0.975)
-    test_variant(2, 0.925)
-    test_variant(3, 0.95)
-    test_variant(4, 0.875)
-    test_variant(5, 0.85)
-    test_variant(6, 0.875)
-    test_variant(7, 0.875)
-    test_variant(8, 0.85)
-    test_variant(9, 0.85)
+    test_variant(1, 0.95)
+    test_variant(2, 0.95)
+    test_variant(3, 0.925)
+    test_variant(3, 0.925)
+    test_variant(4, 0.775)
+    test_variant(5, 0.8)
+    test_variant(6, 0.775)
+    test_variant(7, 0.775)
+    test_variant(8, 0.8)
+    test_variant(9, 0.8)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
#### Reference Issues/PRs
Stops problem in #1052 affecting _REDCOMETS()_ but does not fix the root issue. 

#### What does this implement/fix? Explain your changes.
RED CoMETS should z-normalise before applying both SAX and SFA but the current implementation only normalises for SAX. This PR changes how the RED CoMETS implementation does z-normalisation so that it is correctly applied for both. 

#### Does your contribution introduce a new dependency? If yes, which one?
No

### PR checklist

##### For all contributions
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.