### PR TITLE
[ENH] The Default value for use_mini_batch_size should be set to False

### DIFF
--- a/aeon/classification/deep_learning/_fcn.py
+++ b/aeon/classification/deep_learning/_fcn.py
@@ -42,7 +42,7 @@ class FCNClassifier(BaseDeepClassifier):
         The number of epochs to train the model.
     batch_size : int, default = 16
         The number of samples per gradient update.
-    use_mini_batch_size : bool, default = True
+    use_mini_batch_size : bool, default = False
         Whether or not to use the mini batch size formula.
     random_state : int or None, default = None
         Seed for random number generation.
@@ -117,7 +117,7 @@ class FCNClassifier(BaseDeepClassifier):
         last_file_name="last_model",
         n_epochs=2000,
         batch_size=16,
-        use_mini_batch_size=True,
+        use_mini_batch_size=False,
         callbacks=None,
         verbose=False,
         loss="categorical_crossentropy",

--- a/aeon/regression/deep_learning/_fcn.py
+++ b/aeon/regression/deep_learning/_fcn.py
@@ -42,7 +42,7 @@ class FCNRegressor(BaseDeepRegressor):
         the number of epochs to train the model
     batch_size      : int, default = 16
         the number of samples per gradient update.
-    use_mini_batch_size : bool, default = True,
+    use_mini_batch_size : bool, default = False,
         whether or not to use the mini batch size formula
     random_state    : int or None, default=None
         Seed for random number generation.
@@ -120,7 +120,7 @@ class FCNRegressor(BaseDeepRegressor):
         last_file_name="last_model",
         n_epochs=2000,
         batch_size=16,
-        use_mini_batch_size=True,
+        use_mini_batch_size=False,
         callbacks=None,
         verbose=False,
         output_activation="linear",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The default value of '''use_mini_batch_size''' should be set to '''False''' for FCN, most of the time FCN will not be used with mini_batch.

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.