### PR TITLE
[MNT] Set upper bound for `tensorflow`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all_extras = [
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tbats>=1.1.0",
-    "tensorflow",
+    "tensorflow<2.16.0",
     "tensorflow-probability",
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",
@@ -85,7 +85,7 @@ all_extras = [
 ]
 dl = [
     "keras-self-attention",
-    "tensorflow",
+    "tensorflow<2.16.0",
     "tensorflow-probability",
 ]
 unstable_extras = [


### PR DESCRIPTION
CI is currently failing with `tensorflow` related errors. Sets an upper bound for the dependency.