### PR TITLE
[REF] Fixed the default use_mini_batch_size value in resnet

### DIFF
--- a/aeon/classification/deep_learning/_resnet.py
+++ b/aeon/classification/deep_learning/_resnet.py
@@ -126,7 +126,7 @@ class ResNetClassifier(BaseDeepClassifier):
         loss="categorical_crossentropy",
         metrics=None,
         batch_size=64,
-        use_mini_batch_size=True,
+        use_mini_batch_size=False,
         random_state=None,
         file_path="./",
         save_best_model=False,

--- a/aeon/regression/deep_learning/_resnet.py
+++ b/aeon/regression/deep_learning/_resnet.py
@@ -138,7 +138,7 @@ class ResNetRegressor(BaseDeepRegressor):
         output_activation="linear",
         metrics=None,
         batch_size=64,
-        use_mini_batch_size=True,
+        use_mini_batch_size=False,
         random_state=None,
         file_path="./",
         save_best_model=False,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Change to `False` the default value for use_mini_batch_size in resnet for both classification and regression (the docstring already used `False` as the default value)

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

