### PR TITLE
[DEP] Deprecate `MatrixProfileClassifier`

### DIFF
--- a/aeon/classification/feature_based/_matrix_profile_classifier.py
+++ b/aeon/classification/feature_based/_matrix_profile_classifier.py
@@ -7,6 +7,7 @@ __author__ = ["MatthewMiddlehurst"]
 __all__ = ["MatrixProfileClassifier"]
 
 import numpy as np
+from deprecated.sphinx import deprecated
 from sklearn.neighbors import KNeighborsClassifier
 
 from aeon.base._base import _clone_estimator
@@ -14,6 +15,12 @@ from aeon.classification.base import BaseClassifier
 from aeon.transformations.collection.matrix_profile import MatrixProfile
 
 
+# TODO: remove in v0.8.0
+@deprecated(
+    version="0.6.0",
+    reason="MatrixProfileClassifier will be removed in v0.8.0.",
+    category=FutureWarning,
+)
 class MatrixProfileClassifier(BaseClassifier):
     """
     Matrix Profile (MP) classifier.


### PR DESCRIPTION
Having an estimator for the matrix profile is probably not a bad idea, but it should not be this one or in the `feature_based`. Will keep if there are any objections.