### PR TITLE
[BUG] Correct imports for `visualisation` testing

### DIFF
--- a/aeon/visualisation/learning_task/tests/test_forecasting_plotting.py
+++ b/aeon/visualisation/learning_task/tests/test_forecasting_plotting.py
@@ -1,7 +1,7 @@
 import pytest
 
 from aeon.forecasting.model_selection import SlidingWindowSplitter
-from aeon.utils._testing.series import _make_series
+from aeon.testing.utils.series import _make_series
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 from aeon.visualisation import plot_series_windows
 

--- a/aeon/visualisation/learning_task/tests/test_segmentation_plotting.py
+++ b/aeon/visualisation/learning_task/tests/test_segmentation_plotting.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from aeon.utils._testing.series import _make_series
+from aeon.testing.utils.series import _make_series
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 from aeon.visualisation import plot_series_with_change_points
 

--- a/aeon/visualisation/series/tests/test_collection_plotting.py
+++ b/aeon/visualisation/series/tests/test_collection_plotting.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from aeon.utils._testing.collection import (
+from aeon.testing.utils.collection import (
     make_3d_test_data,
     make_unequal_length_test_data,
 )

--- a/aeon/visualisation/series/tests/test_series_plotting.py
+++ b/aeon/visualisation/series/tests/test_series_plotting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from aeon.datasets import load_airline
-from aeon.utils._testing.series import _make_series
+from aeon.testing.utils.series import _make_series
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 from aeon.utils.validation.series import VALID_DATA_TYPES
 from aeon.visualisation import plot_correlations, plot_lags, plot_series


### PR DESCRIPTION
Some of the tests use the old imports, this did not bring up a merge conflict before being merged into main. 

Fixes the broken imports.