### PR TITLE
[DOC, REF] Add `TimeSeriesKernelKMeans` and `TimeSeriesKShapes` to `clustering/__init__.py` and also adds examples to dosctring

### DIFF
--- a/aeon/clustering/__init__.py
+++ b/aeon/clustering/__init__.py
@@ -5,6 +5,8 @@ __all__ = [
     "TimeSeriesCLARA",
     "TimeSeriesCLARANS",
     "TimeSeriesKMeans",
+    "TimeSeriesKShapes",
+    "TimeSeriesKernelKMeans",
 ]
 __author__ = ["chrisholder", "TonyBagnall"]
 
@@ -12,4 +14,6 @@ from aeon.clustering._clara import TimeSeriesCLARA
 from aeon.clustering._clarans import TimeSeriesCLARANS
 from aeon.clustering._k_means import TimeSeriesKMeans
 from aeon.clustering._k_medoids import TimeSeriesKMedoids
+from aeon.clustering._k_shapes import TimeSeriesKShapes
+from aeon.clustering._kernel_k_means import TimeSeriesKernelKMeans
 from aeon.clustering.base import BaseClusterer

--- a/aeon/clustering/_k_shapes.py
+++ b/aeon/clustering/_k_shapes.py
@@ -45,6 +45,19 @@ class TimeSeriesKShapes(BaseClusterer):
         the sample weights if provided.
     n_iter_: int
         Number of iterations run.
+
+    Examples
+    --------
+    >>> from aeon.clustering import TimeSeriesKShapes
+    >>> from aeon.datasets import load_basic_motions
+    >>> # Load data
+    >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
+    >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
+    >>> # Example of KShapes clustering
+    >>> ks = TimeSeriesKShapes(n_clusters=3, random_state=1)
+    >>> ks.fit(X_train)
+    TimeSeriesKShapes(n_clusters=3, random_state=1)
+    >>> preds = ks.predict(X_test)
     """
 
     _tags = {

--- a/aeon/clustering/_k_shapes.py
+++ b/aeon/clustering/_k_shapes.py
@@ -54,10 +54,10 @@ class TimeSeriesKShapes(BaseClusterer):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of KShapes clustering
-    >>> ks = TimeSeriesKShapes(n_clusters=3, random_state=1)
-    >>> ks.fit(X_train)
+    >>> ks = TimeSeriesKShapes(n_clusters=3, random_state=1)  # doctest: +SKIP
+    >>> ks.fit(X_train)  # doctest: +SKIP
     TimeSeriesKShapes(n_clusters=3, random_state=1)
-    >>> preds = ks.predict(X_test)
+    >>> preds = ks.predict(X_test)  # doctest: +SKIP
     """
 
     _tags = {

--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -77,9 +77,9 @@ class TimeSeriesKernelKMeans(BaseClusterer):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of KernelKMeans Clustering
-    >>> kkm = TimeSeriesKernelKMeans(n_clusters=3, kernel='rbf', random_state=1)  # doctest: +SKIP
+    >>> kkm = TimeSeriesKernelKMeans(n_clusters=3, kernel='rbf')  # doctest: +SKIP
     >>> kkm.fit(X_train)  # doctest: +SKIP
-    TimeSeriesKernelKMeans(kernel='rbf', n_clusters=3, random_state=1)
+    TimeSeriesKernelKMeans(kernel='rbf', n_clusters=3)
     >>> preds = kkm.predict(X_test)  # doctest: +SKIP
     """
 

--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -68,6 +68,19 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         .. [1] Kernel k-means, Spectral Clustering and Normalized Cuts. Inderjit S.
         Dhillon, Yuqiang Guan, Brian Kulis. KDD 2004.
         .. [2] Fast Global Alignment Kernels. Marco Cuturi. ICML 2011.
+
+    Examples
+    --------
+    >>> from aeon.clustering import TimeSeriesKernelKMeans
+    >>> from aeon.datasets import load_basic_motions
+    >>> # Load data
+    >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
+    >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
+    >>> # Example of KernelKMeans Clustering
+    >>> kkm = TimeSeriesKernelKMeans(n_clusters=3, kernel='rbf', random_state=1)
+    >>> kkm.fit(X_train)
+    TimeSeriesKernelKMeans(kernel='rbf', n_clusters=3, random_state=1)
+    >>> preds = kkm.predict(X_test)
     """
 
     _tags = {

--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -77,10 +77,10 @@ class TimeSeriesKernelKMeans(BaseClusterer):
     >>> X_train, y_train = load_basic_motions(split="TRAIN")[0:10]
     >>> X_test, y_test = load_basic_motions(split="TEST")[0:10]
     >>> # Example of KernelKMeans Clustering
-    >>> kkm = TimeSeriesKernelKMeans(n_clusters=3, kernel='rbf', random_state=1)
-    >>> kkm.fit(X_train)
+    >>> kkm = TimeSeriesKernelKMeans(n_clusters=3, kernel='rbf', random_state=1)  # doctest: +SKIP
+    >>> kkm.fit(X_train)  # doctest: +SKIP
     TimeSeriesKernelKMeans(kernel='rbf', n_clusters=3, random_state=1)
-    >>> preds = kkm.predict(X_test)
+    >>> preds = kkm.predict(X_test)  # doctest: +SKIP
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
Solves #942. See also #1091.

#### What does this implement/fix? Explain your changes.
Adds `TimeSeriesKernelKMeans` and `TimeSeriesKShapes` to `clustering/__init__.py`.

Adds doc string example for:
- `TimeSeriesKernelKMeans` in file `_kernel_k_means`
- `TimeSeriesKShapes` in file `_k_shapes`