### PR TITLE
[MNT] Add upper bounds for main dependencies and replace `attrs`

### DIFF
--- a/aeon/segmentation/_ggs.py
+++ b/aeon/segmentation/_ggs.py
@@ -35,8 +35,8 @@ References
 
 import logging
 import math
-from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Tuple
+from dataclasses import dataclass, field
+from typing import List, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -510,58 +510,3 @@ class GreedyGaussianSegmenter(BaseSegmenter):
         ):
             labels[start:stop] = i
         return labels
-
-    def fit_predict(self, X, y=None):
-        """Perform segmentation.
-
-        Parameters
-        ----------
-        X: np.ndarray
-            Time series shape (n_timepoints, n_channels).
-        y: array_like
-            Placeholder for compatibility with sklearn-api, not used, default=None.
-
-        Returns
-        -------
-        y_pred : array_like
-            1D array with predicted segmentation of the same size as the first
-            dimension of X. The numerical values represent distinct segments
-            labels for each of the data points.
-        """
-        return self.fit(X, y).predict(X)
-
-    def get_params(self, deep: bool = True) -> Dict:
-        """Return initialization parameters.
-
-        Parameters
-        ----------
-        deep: bool
-            Dummy argument for compatibility with sklearn-api, not used.
-
-        Returns
-        -------
-        params: dict
-            Dictionary with the estimator's initialization parameters, with
-            keys being argument names and values being argument values.
-        """
-        return asdict(self.ggs, filter=lambda attr, value: attr.init is True)
-
-    def set_params(self, **parameters):
-        """Set the parameters of this object.
-
-        Parameters
-        ----------
-        parameters : dict
-            Initialization parameters for the estimator.
-
-        Returns
-        -------
-        self : reference to self (after parameters have been set)
-        """
-        for key, value in parameters.items():
-            setattr(self.ggs, key, value)
-        return self
-
-    def __repr__(self) -> str:
-        """Return a string representation of the estimator."""
-        return self.ggs.__repr__()

--- a/aeon/segmentation/_ggs.py
+++ b/aeon/segmentation/_ggs.py
@@ -35,11 +35,11 @@ References
 
 import logging
 import math
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Tuple
 
 import numpy as np
 import numpy.typing as npt
-from attrs import asdict, define, field
 from sklearn.utils.validation import check_random_state
 
 from aeon.segmentation.base import BaseSegmenter
@@ -47,7 +47,7 @@ from aeon.segmentation.base import BaseSegmenter
 logger = logging.getLogger(__name__)
 
 
-@define
+@dataclass
 class _GGS:
     """
     Greedy Gaussian Segmentation.
@@ -116,9 +116,11 @@ class _GGS:
     verbose: bool = False
     random_state: int = None
 
-    change_points_: npt.ArrayLike = field(init=False, default=[])
-    _intermediate_change_points: List[List[int]] = field(init=False, default=[])
-    _intermediate_ll: List[float] = field(init=False, default=[])
+    change_points_: npt.ArrayLike = field(init=False, default_factory=list)
+    _intermediate_change_points: List[List[int]] = field(
+        init=False, default_factory=list
+    )
+    _intermediate_ll: List[float] = field(init=False, default_factory=list)
 
     def initialize_intermediates(self) -> None:
         """Initialize the state fo the estimator."""

--- a/aeon/segmentation/_igts.py
+++ b/aeon/segmentation/_igts.py
@@ -17,13 +17,12 @@ References
 
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from attrs import asdict, define, field
 
 from aeon.segmentation.base import BaseSegmenter
 
@@ -103,7 +102,7 @@ def generate_segments_pandas(X: npt.ArrayLike, change_points: List) -> npt.Array
         yield X[interval.left : interval.right, :]
 
 
-@define
+@dataclass
 class _IGTS:
     """
     Information Gain based Temporal Segmentation (GTS).
@@ -174,7 +173,7 @@ class _IGTS:
     step: int = 5
 
     # computed attributes
-    intermediate_results_: List = field(init=False, default=[])
+    intermediate_results_: List = field(init=False, default_factory=list)
 
     def identity(self, X: npt.ArrayLike) -> List[int]:
         """Return identity segmentation, i.e. terminal indexes of the data."""

--- a/aeon/segmentation/_igts.py
+++ b/aeon/segmentation/_igts.py
@@ -17,8 +17,8 @@ References
 
 """
 
-from dataclasses import asdict, dataclass, field
-from typing import Dict, List
+from dataclasses import dataclass, field
+from typing import List
 
 import numpy as np
 import numpy.typing as npt
@@ -385,42 +385,6 @@ class InformationGainSegmenter(BaseSegmenter):
         self.change_points_ = self._igts.find_change_points(X)
         self.intermediate_results_ = self._igts.intermediate_results_
         return self.to_clusters(self.change_points_)
-
-    def get_params(self, deep: bool = True) -> Dict:
-        """Return initialization parameters.
-
-        Parameters
-        ----------
-        deep: bool
-            Dummy argument for compatibility with sklearn-api, not used.
-
-        Returns
-        -------
-        params: dict
-            Dictionary with the estimator's initialization parameters, with
-            keys being argument names and values being argument values.
-        """
-        return asdict(self._igts, filter=lambda attr, value: attr.init is True)
-
-    def set_params(self, **parameters):
-        """Set the parameters of this object.
-
-        Parameters
-        ----------
-        parameters : dict
-            Initialization parameters for th estimator.
-
-        Returns
-        -------
-        self : reference to self (after parameters have been set)
-        """
-        for key, value in parameters.items():
-            setattr(self._igts, key, value)
-        return self
-
-    def __repr__(self) -> str:
-        """Return a string representation of the estimator."""
-        return self._igts.__repr__()
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,12 @@ classifiers = [
 requires-python = ">=3.8,<3.12"
 dependencies = [
     "deprecated>=1.2.13",
-    "numba>=0.55",
-    "numpy>=1.21.0",
+    "numba>=0.55,<0.59.0",
+    "numpy>=1.21.0,<1.27.0",
     "packaging>=20.0",
     "pandas>=1.5.3,<2.1.0",
-    "scikit-learn>=1.0.0",
-    "scipy>=1.2.0",
+    "scikit-learn>=1.0.0,<1.5.0",
+    "scipy>=1.2.0,<1.13.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,13 @@ classifiers = [
 ]
 requires-python = ">=3.8,<3.12"
 dependencies = [
-    "attrs>=19.2.0", # see #282
     "deprecated>=1.2.13",
     "numba>=0.55",
-    "numpy>=1.21.0,<1.27.0",
+    "numpy>=1.21.0",
     "packaging>=20.0",
     "pandas>=1.5.3,<2.1.0",
-    "scikit-learn>=1.0.0,<1.5.0",
-    "scipy>=1.2.0,<2.0.0",
+    "scikit-learn>=1.0.0",
+    "scipy>=1.2.0",
 ]
 
 [project.optional-dependencies]
@@ -71,7 +70,6 @@ all_extras = [
     "scikit_posthocs>=0.6.5",
     "seaborn>=0.11.0",
     "statsforecast>=0.5.2",
-    "plotly-resampler>=0.9.0", # from statsforecast, needed for pandas2
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tbats>=1.1.0",


### PR DESCRIPTION
Resolves #282 

Adds upper bounds for `numba` and makes the one for `scipy` more aggressive. With dependabot and our current maintenance we should be able to respond to new releases in a suitable timeframe.

Replaces `attrs` with the `dataclass` module, which while not the same is similar in functionality and is one less core dependency.