### PR TITLE
[BUG] Wrong bound on sklearn for sparse argument

### DIFF
--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -145,7 +145,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         installed_version = sklearn.__version__
         # Compare the installed version with the target version
         # categories='auto' to get rid of FutureWarning
-        if version.parse(installed_version) < version.parse("1.1"):
+        if version.parse(installed_version) < version.parse("1.2"):
             self.onehot_encoder = OneHotEncoder(sparse=False)
         else:
             self.onehot_encoder = OneHotEncoder(sparse_output=False)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Fixes #1109 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Corrected threshold for change of sparse argument name from sklearn version 1.1 to 1.2
<!--
A clear and concise description of what you have implemented.
-->


### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.



<!--
Thanks for contributing!
-->
