### PR TITLE
[MNT] Update `numba` bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 requires-python = ">=3.8,<3.12"
 dependencies = [
     "deprecated>=1.2.13",
-    "numba>=0.55,<0.59.0",
+    "numba>=0.55,<0.60.0",
     "numpy>=1.21.0,<1.27.0",
     "packaging>=20.0",
     "pandas>=1.5.3,<2.1.0",


### PR DESCRIPTION
Updates the bound for `numba`. This version is Python 3.12 compatible, allowing progress to be made on #861.