### PR TITLE
[ENH] BaseCollectionTransformers fit_is_empty tag

### DIFF
--- a/aeon/transformations/collection/ar_coefficient.py
+++ b/aeon/transformations/collection/ar_coefficient.py
@@ -45,6 +45,7 @@ class ARCoefficientTransformer(BaseCollectionTransformer):
     _tags = {
         "capability:multivariate": True,
         "python_dependencies": "statsmodels",
+        "fit_is_empty": False
     }
 
     def __init__(

--- a/aeon/transformations/collection/ar_coefficient.py
+++ b/aeon/transformations/collection/ar_coefficient.py
@@ -45,7 +45,7 @@ class ARCoefficientTransformer(BaseCollectionTransformer):
     _tags = {
         "capability:multivariate": True,
         "python_dependencies": "statsmodels",
-        "fit_is_empty": False
+        "fit_is_empty": False,
     }
 
     def __init__(

--- a/aeon/transformations/collection/channel_selection.py
+++ b/aeon/transformations/collection/channel_selection.py
@@ -292,7 +292,7 @@ class ElbowClassSum(BaseCollectionTransformer):
         "skip-inverse-transform": True,
         "y_inner_type": "numpy1D",
         "requires_y": True,
-        "fit_is_empty": False
+        "fit_is_empty": False,
     }
 
     def __init__(

--- a/aeon/transformations/collection/channel_selection.py
+++ b/aeon/transformations/collection/channel_selection.py
@@ -292,6 +292,7 @@ class ElbowClassSum(BaseCollectionTransformer):
         "skip-inverse-transform": True,
         "y_inner_type": "numpy1D",
         "requires_y": True,
+        "fit_is_empty": False
     }
 
     def __init__(

--- a/aeon/transformations/collection/periodogram.py
+++ b/aeon/transformations/collection/periodogram.py
@@ -51,10 +51,7 @@ class PeriodogramTransformer(BaseCollectionTransformer):
        3.36395549  2.69146494  2.27041859  3.9023142 ]]
     """
 
-    _tags = {
-        "capability:multivariate": True,
-        "fit_is_empty": False
-    }
+    _tags = {"capability:multivariate": True, "fit_is_empty": False}
 
     def __init__(
         self,

--- a/aeon/transformations/collection/periodogram.py
+++ b/aeon/transformations/collection/periodogram.py
@@ -53,6 +53,7 @@ class PeriodogramTransformer(BaseCollectionTransformer):
 
     _tags = {
         "capability:multivariate": True,
+        "fit_is_empty": False
     }
 
     def __init__(

--- a/aeon/transformations/collection/scaler.py
+++ b/aeon/transformations/collection/scaler.py
@@ -72,6 +72,7 @@ class TimeSeriesScaler(BaseCollectionTransformer):
         "X_inner_type": ["np-list", "numpy3D"],
         "capability:multivariate": True,
         "capability:unequal_length": True,
+        "fit_is_empty": False
     }
 
     def __init__(self, copy=True, with_mean=True, with_std=True):

--- a/aeon/transformations/collection/scaler.py
+++ b/aeon/transformations/collection/scaler.py
@@ -72,7 +72,7 @@ class TimeSeriesScaler(BaseCollectionTransformer):
         "X_inner_type": ["np-list", "numpy3D"],
         "capability:multivariate": True,
         "capability:unequal_length": True,
-        "fit_is_empty": False
+        "fit_is_empty": False,
     }
 
     def __init__(self, copy=True, with_mean=True, with_std=True):

--- a/aeon/transformations/collection/segment.py
+++ b/aeon/transformations/collection/segment.py
@@ -60,10 +60,7 @@ class IntervalSegmenter(BaseCollectionTransformer):
         and the second column giving end points of intervals
     """
 
-    _tags = {
-        "capability:unequal_length:removes": True,
-        "fit_is_empty": False
-    }
+    _tags = {"capability:unequal_length:removes": True, "fit_is_empty": False}
 
     def __init__(self, intervals=10):
         self.intervals = intervals

--- a/aeon/transformations/collection/segment.py
+++ b/aeon/transformations/collection/segment.py
@@ -62,6 +62,7 @@ class IntervalSegmenter(BaseCollectionTransformer):
 
     _tags = {
         "capability:unequal_length:removes": True,
+        "fit_is_empty": False
     }
 
     def __init__(self, intervals=10):

--- a/aeon/transformations/collection/truncate.py
+++ b/aeon/transformations/collection/truncate.py
@@ -39,7 +39,7 @@ class TruncationTransformer(BaseCollectionTransformer):
         "capability:multivariate": True,
         "capability:unequal_length": True,
         "capability:unequal_length:removes": True,
-        "fit_is_empty": False
+        "fit_is_empty": False,
     }
 
     def __init__(self, truncated_length=None):

--- a/aeon/transformations/collection/truncate.py
+++ b/aeon/transformations/collection/truncate.py
@@ -39,6 +39,7 @@ class TruncationTransformer(BaseCollectionTransformer):
         "capability:multivariate": True,
         "capability:unequal_length": True,
         "capability:unequal_length:removes": True,
+        "fit_is_empty": False
     }
 
     def __init__(self, truncated_length=None):


### PR DESCRIPTION
Fixes #1172 

I have set the tag

```
_tags = {
      "fit_is_empty": False,
}
```
to any base collection transformers that do not implement _fit

Please let me know if any changes are required.
Thanks

- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
