### PR TITLE
[ENH] RIST classifier and regressor

### DIFF
--- a/aeon/base/estimator/hybrid/__init__.py
+++ b/aeon/base/estimator/hybrid/__init__.py
@@ -1,0 +1,5 @@
+"""Base classes for hybrid time series estimators."""
+
+__all__ = ["BaseRIST"]
+
+from aeon.base.estimator.hybrid.base_rist import BaseRIST

--- a/aeon/base/estimator/hybrid/base_rist.py
+++ b/aeon/base/estimator/hybrid/base_rist.py
@@ -130,11 +130,6 @@ class BaseRIST(metaclass=ABCMeta):
                 )
             elif is_regressor(self):
                 self._estimator = ExtraTreesRegressor(n_estimators=200)
-            else:
-                raise ValueError(
-                    f"{self} must be a scikit-learn compatible classifier or "
-                    "regressor."
-                )
         # base_estimator must be an sklearn estimator
         elif not isinstance(self.estimator, BaseEstimator):
             raise ValueError(
@@ -145,8 +140,8 @@ class BaseRIST(metaclass=ABCMeta):
         self._estimator = _clone_estimator(self._estimator, rng)
 
         n_jobs = check_n_jobs(self.n_jobs)
-        m = getattr(self._estimator, "n_jobs", None)
-        if m is not None:
+        m = getattr(self._estimator, "n_jobs", "missing")
+        if m != "missing":
             self._estimator.n_jobs = n_jobs
 
         if self.series_transformers == "default":
@@ -176,8 +171,8 @@ class BaseRIST(metaclass=ABCMeta):
         self._transformers = []
         for st in self._series_transformers:
             if st is not None:
-                m = getattr(st, "n_jobs", None)
-                if m is not None:
+                m = getattr(st, "n_jobs", "missing")
+                if m != "missing":
                     st.n_jobs = n_jobs
 
                 s = st.fit_transform(X, y)
@@ -249,7 +244,7 @@ class BaseRIST(metaclass=ABCMeta):
             dists = np.zeros((X.shape[0], self.n_classes_))
             preds = self._estimator.predict(self._transform_data(X))
             for i in range(0, X.shape[0]):
-                dists[i, self.class_dictionary_[preds[i]]] = 1
+                dists[i, self._class_dictionary[preds[i]]] = 1
             return dists
 
     def _transform_data(self, X):

--- a/aeon/base/estimator/hybrid/base_rist.py
+++ b/aeon/base/estimator/hybrid/base_rist.py
@@ -1,0 +1,270 @@
+"""Base class for the RIST pipeline."""
+
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+from sklearn.base import BaseEstimator, is_classifier, is_regressor
+from sklearn.ensemble import ExtraTreesClassifier, ExtraTreesRegressor
+from sklearn.ensemble._base import _set_random_states
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils import check_random_state
+
+from aeon.base._base import _clone_estimator
+from aeon.transformations.collection import (
+    ARCoefficientTransformer,
+    PeriodogramTransformer,
+)
+from aeon.transformations.collection.feature_based import Catch22
+from aeon.transformations.collection.interval_based import RandomIntervals
+from aeon.transformations.collection.shapelet_based import (
+    RandomDilatedShapeletTransform,
+)
+from aeon.utils.numba.general import first_order_differences_3d
+from aeon.utils.numba.stats import (
+    row_iqr,
+    row_mean,
+    row_median,
+    row_numba_max,
+    row_numba_min,
+    row_ppv,
+    row_slope,
+    row_std,
+)
+from aeon.utils.validation import check_n_jobs
+
+
+class BaseRIST(metaclass=ABCMeta):
+    """Randomised Interval-Shapelet Transformation (RIST) pipeline base.
+
+    RIST is a hybrid pipeline using the RandomIntervalTransformer using
+    Catch22 features and summary stats, and the RandomDilatedShapeletTransformer.
+    Both transforms extract features from different series transformations (1st Order
+    Differences, PeriodogramTransformer, and ARCoefficientTransformer).
+
+    Parameters
+    ----------
+    n_intervals : int, callable or None, default=None,
+        The number of intervals of random length, position and dimension to be
+        extracted for the interval portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of intervals per `series_transformer` output.
+        If None, extracts `int(np.sqrt(X.shape[2]) * np.sqrt(X.shape[1]) * 15 + 5)`
+        intervals where `Xt` is the series representation data.
+    n_shapelets : int, callable or None, default=None,
+        The number of shapelets of random dilation and position to be extracted for the
+        shapelet portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of shapelets per `series_transformer` output.
+        If None, extracts `int(np.sqrt(Xt.shape[2]) * 200 + 5)` shapelets where `Xt` is
+        the series representation data.
+    series_transformers : TransformerMixin, list, tuple, or None, default=None
+        The transformers to apply to the series before extracting intervals and
+        shapelets. If None, use the series as is. If "default", use [None, 1st Order
+        Differences, PeriodogramTransformer, and ARCoefficientTransformer].
+
+        A list or tuple of transformers will extract intervals from
+        all transformations concatenate the output. Including None in the list or tuple
+        will use the series as is for interval extraction.
+    use_pycatch22 : bool, optional, default=False
+        Wraps the C based pycatch22 implementation for aeon.
+        (https://github.com/DynamicsAndNeuralSystems/pycatch22). This requires the
+        ``pycatch22`` package to be installed if True.
+    use_pyfftw : bool, default=False
+        Whether to use the pyfftw library for FFT calculations. Requires the pyfftw
+        package to be installed.
+    estimator : sklearn estimator, default=None
+        An sklearn estimator to be built using the transformed data. Defaults to an
+        extra trees forest with 200 trees.
+    random_state : int, RandomState instance or None, default=None
+        If `int`, random_state is the seed used by the random number generator;
+        If `RandomState` instance, random_state is the random number generator;
+        If `None`, the random number generator is the `RandomState` instance used
+        by `np.random`.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        ``-1`` means using all processors.
+
+    Attributes
+    ----------
+    n_instances_ : int
+        The number of train cases in the training set.
+    n_channels_ : int
+        The number of dimensions per case in the training set.
+    n_timepoints_ : int
+        The length of each series in the training set.
+    """
+
+    @abstractmethod
+    def __init__(
+        self,
+        n_intervals=None,
+        n_shapelets=None,
+        series_transformers="default",
+        use_pycatch22=False,
+        use_pyfftw=False,
+        estimator=None,
+        n_jobs=1,
+        random_state=None,
+    ):
+        self.n_intervals = n_intervals
+        self.n_shapelets = n_shapelets
+        self.series_transformers = series_transformers
+        self.use_pycatch22 = use_pycatch22
+        self.use_pyfftw = use_pyfftw
+        self.estimator = estimator
+        self.random_state = random_state
+        self.n_jobs = n_jobs
+
+        super().__init__()
+
+    def _fit(self, X, y) -> object:
+        self.n_instances_, self.n_channels_, self.n_timepoints_ = X.shape
+
+        rng = check_random_state(self.random_state)
+
+        self._estimator = self.estimator
+        if self.estimator is None:
+            if is_classifier(self):
+                self._estimator = ExtraTreesClassifier(
+                    n_estimators=200, criterion="entropy"
+                )
+            elif is_regressor(self):
+                self._estimator = ExtraTreesRegressor(n_estimators=200)
+            else:
+                raise ValueError(
+                    f"{self} must be a scikit-learn compatible classifier or "
+                    "regressor."
+                )
+        # base_estimator must be an sklearn estimator
+        elif not isinstance(self.estimator, BaseEstimator):
+            raise ValueError(
+                "base_estimator must be a scikit-learn BaseEstimator or None. "
+                f"Found: {self.estimator}"
+            )
+
+        self._estimator = _clone_estimator(self._estimator, rng)
+
+        n_jobs = check_n_jobs(self.n_jobs)
+        m = getattr(self._estimator, "n_jobs", None)
+        if m is not None:
+            self._estimator.n_jobs = n_jobs
+
+        if self.series_transformers == "default":
+            self._series_transformers = [
+                None,
+                FunctionTransformer(func=first_order_differences_3d, validate=False),
+                PeriodogramTransformer(use_pyfftw=self.use_pyfftw),
+                ARCoefficientTransformer(
+                    replace_nan=True, order=int(12 * (X.shape[2] / 100.0) ** 0.25)
+                ),
+            ]
+        elif isinstance(self.series_transformers, (list, tuple)):
+            self._series_transformers = [
+                None if st is None else _clone_estimator(st, random_state=rng)
+                for st in self.series_transformers
+            ]
+        else:
+            self._series_transformers = [
+                (
+                    None
+                    if self.series_transformers is None
+                    else _clone_estimator(self.series_transformers, random_state=rng)
+                )
+            ]
+
+        Xt = np.empty((X.shape[0], 0))
+        self._transformers = []
+        for st in self._series_transformers:
+            if st is not None:
+                m = getattr(st, "n_jobs", None)
+                if m is not None:
+                    st.n_jobs = n_jobs
+
+                s = st.fit_transform(X, y)
+            else:
+                s = X
+
+            if self.n_intervals is None:
+                n_intervals = int(np.sqrt(X.shape[2]) * np.sqrt(X.shape[1]) * 15 + 5)
+            elif callable(self.n_intervals):
+                n_intervals = self.n_intervals(s)
+            else:
+                n_intervals = self.n_intervals
+
+            ct = RandomIntervals(
+                n_intervals=n_intervals,
+                features=[
+                    Catch22(
+                        outlier_norm=True,
+                        replace_nans=True,
+                        use_pycatch22=self.use_pycatch22,
+                    ),
+                    row_mean,
+                    row_std,
+                    row_slope,
+                    row_median,
+                    row_iqr,
+                    row_numba_min,
+                    row_numba_max,
+                    row_ppv,
+                ],
+                n_jobs=n_jobs,
+            )
+            _set_random_states(ct, rng)
+            self._transformers.append(ct)
+            t = ct.fit_transform(s, y)
+
+            Xt = np.hstack((Xt, t))
+
+            if self.n_shapelets is None:
+                n_shapelets = int(np.sqrt(X.shape[2]) * 200 + 5)
+            elif callable(self.n_shapelets):
+                n_shapelets = self.n_shapelets(s)
+            else:
+                n_shapelets = self.n_shapelets
+
+            st = RandomDilatedShapeletTransform(
+                max_shapelets=n_shapelets, n_jobs=n_jobs
+            )
+            _set_random_states(st, rng)
+            self._transformers.append(st)
+            t = st.fit_transform(s, y)
+
+            Xt = np.hstack((Xt, t))
+
+        Xt = np.nan_to_num(Xt, nan=0.0, posinf=0.0, neginf=0.0)
+
+        self._estimator.fit(Xt, y)
+
+        return self
+
+    def _predict(self, X) -> np.ndarray:
+        return self._estimator.predict(self._transform_data(X))
+
+    def _predict_proba(self, X) -> np.ndarray:
+        m = getattr(self._estimator, "predict_proba", None)
+        if callable(m):
+            return self._estimator.predict_proba(self._transform_data(X))
+        else:
+            dists = np.zeros((X.shape[0], self.n_classes_))
+            preds = self._estimator.predict(self._transform_data(X))
+            for i in range(0, X.shape[0]):
+                dists[i, self.class_dictionary_[preds[i]]] = 1
+            return dists
+
+    def _transform_data(self, X):
+        Xt = np.empty((X.shape[0], 0))
+        for i, st in enumerate(self._series_transformers):
+            if st is not None:
+                s = st.transform(X)
+            else:
+                s = X
+
+            t = self._transformers[i * 2].transform(s)
+            Xt = np.hstack((Xt, t))
+
+            t = self._transformers[i * 2 + 1].transform(s)
+            Xt = np.hstack((Xt, t))
+
+        Xt = np.nan_to_num(Xt, nan=0.0, posinf=0.0, neginf=0.0)
+        return Xt

--- a/aeon/base/estimator/hybrid/tests/__init__.py
+++ b/aeon/base/estimator/hybrid/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Testing for hybrid base classes."""

--- a/aeon/base/estimator/hybrid/tests/test_base_rist.py
+++ b/aeon/base/estimator/hybrid/tests/test_base_rist.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+from sklearn.ensemble import ExtraTreesClassifier, ExtraTreesRegressor
+from sklearn.linear_model import RidgeClassifierCV
+from sklearn.preprocessing import FunctionTransformer
+
+from aeon.classification.hybrid import RISTClassifier
+from aeon.regression.hybrid import RISTRegressor
+from aeon.testing.utils.data_gen import make_example_3d_numpy
+from aeon.transformations.collection import (
+    ARCoefficientTransformer,
+    PeriodogramTransformer,
+)
+from aeon.utils.numba.general import first_order_differences_3d
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(
+        ["statsmodels", "pycatch22", "pyfftw"], severity="none"
+    ),
+    reason="skip test if required soft dependency not available",
+)
+def test_rist_soft_dependencies():
+    rist = RISTClassifier()
+    assert rist.get_tag("python_dependencies") == "statsmodels"
+
+    rist = RISTClassifier(use_pycatch22=True, use_pyfftw=True)
+    assert rist.get_tag("python_dependencies") == ["statsmodels", "pycatch22", "pyfftw"]
+
+    X, y = make_example_3d_numpy()
+    rist.fit(X, y)
+    preds = rist.predict(X)
+
+    assert isinstance(preds, np.ndarray)
+    assert preds.shape[0] == 10
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["statsmodels"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_rist_estimator_input():
+    X, y = make_example_3d_numpy()
+
+    rist = RISTClassifier(n_intervals=3, n_shapelets=3, series_transformers=None)
+    rist.fit(X, y)
+    assert isinstance(rist._estimator, ExtraTreesClassifier)
+
+    rist = RISTRegressor(n_intervals=3, n_shapelets=3, series_transformers=None)
+    rist.fit(X, y)
+    assert isinstance(rist._estimator, ExtraTreesRegressor)
+
+    with pytest.raises(
+        ValueError, match="base_estimator must be a scikit-learn BaseEstimator"
+    ):
+        rist = RISTClassifier(estimator="invalid")
+        rist.fit(X, y)
+
+    rist = RISTClassifier(
+        estimator=RidgeClassifierCV(),
+        n_intervals=3,
+        n_shapelets=3,
+        series_transformers=None,
+    )
+    rist.fit(X, y)
+    proba = rist.predict_proba(X)
+
+    assert isinstance(proba, np.ndarray)
+    assert proba.shape == (10, 2)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["statsmodels"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_rist_series_transform_input():
+    X, y = make_example_3d_numpy()
+
+    rist = RISTClassifier(
+        n_intervals=3, n_shapelets=3, estimator=ExtraTreesClassifier(n_estimators=10)
+    )
+    rist.fit(X, y)
+
+    assert len(rist._series_transformers) == 4
+    assert rist._series_transformers[0] is None
+    assert isinstance(rist._series_transformers[1], FunctionTransformer)
+    assert isinstance(rist._series_transformers[2], PeriodogramTransformer)
+    assert isinstance(rist._series_transformers[3], ARCoefficientTransformer)
+
+    rist = RISTClassifier(
+        series_transformers=[
+            None,
+            FunctionTransformer(func=first_order_differences_3d, validate=False),
+        ],
+        n_intervals=3,
+        n_shapelets=3,
+        estimator=ExtraTreesClassifier(n_estimators=10),
+    )
+    rist.fit(X, y)
+
+    assert len(rist._series_transformers) == 2
+    assert rist._series_transformers[0] is None
+    assert isinstance(rist._series_transformers[1], FunctionTransformer)
+
+    rist = RISTClassifier(
+        series_transformers=None,
+        n_intervals=3,
+        n_shapelets=3,
+        estimator=ExtraTreesClassifier(n_estimators=10),
+    )
+    rist.fit(X, y)
+
+    assert rist._series_transformers == [None]
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["statsmodels"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_rist_n_interval_and_n_shapelet_lambda():
+    X, y = make_example_3d_numpy()
+
+    rist = RISTClassifier(
+        n_intervals=lambda X: len(X),
+        n_shapelets=lambda X: len(X),
+        series_transformers=[
+            None,
+            FunctionTransformer(func=first_order_differences_3d, validate=False),
+        ],
+        estimator=ExtraTreesClassifier(n_estimators=10),
+    )
+    rist.fit(X, y)
+    preds = rist.predict(X)
+
+    assert isinstance(preds, np.ndarray)
+    assert preds.shape[0] == 10

--- a/aeon/classification/hybrid/__init__.py
+++ b/aeon/classification/hybrid/__init__.py
@@ -3,7 +3,9 @@
 __all__ = [
     "HIVECOTEV1",
     "HIVECOTEV2",
+    "RISTClassifier",
 ]
 
 from aeon.classification.hybrid._hivecote_v1 import HIVECOTEV1
 from aeon.classification.hybrid._hivecote_v2 import HIVECOTEV2
+from aeon.classification.hybrid._rist import RISTClassifier

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -77,6 +77,18 @@ class RISTClassifier(BaseRIST, BaseClassifier):
     classes_ : ndarray of shape (n_classes_)
         Holds the label for each class.
 
+    See Also
+    --------
+    BaseRIST
+    RISTRegressor
+
+    References
+    ----------
+    .. [1] Middlehurst, M. and Bagnall, A., 2023, September. Extracting Features from
+        Random Subseries: A Hybrid Pipeline for Time Series Classification and Extrinsic
+        Regression. In International Workshop on Advanced Analytics and Learning on
+        Temporal Data (pp. 113-126). Cham: Springer Nature Switzerland.
+
     Examples
     --------
     >>> from aeon.classification.hybrid import RISTClassifier

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -76,8 +76,6 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : ndarray of shape (n_classes_)
         Holds the label for each class.
-    class_dictionary_ : dict
-        A dictionary mapping class labels to class indices in classes_.
 
     Examples
     --------
@@ -85,10 +83,10 @@ class RISTClassifier(BaseRIST, BaseClassifier):
     >>> from aeon.testing.utils.data_gen import make_example_3d_numpy
     >>> X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=12,
     ...                              return_y=True, random_state=0)
-    >>> clf = RISTClassifier(random_state=0)
-    >>> clf.fit(X, y)
+    >>> clf = RISTClassifier(random_state=0)  # doctest: +SKIP
+    >>> clf.fit(X, y)  # doctest: +SKIP
     RISTClassifier(...)
-    >>> clf.predict(X)
+    >>> clf.predict(X)  # doctest: +SKIP
     array([0, 1, 0, 1, 0, 0, 1, 1, 1, 0])
     """
 
@@ -111,8 +109,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         if use_pyfftw:
             d.append("pyfftw")
 
-        if d:
-            self.set_tags(**{"python_dependencies": d})
+        self.set_tags(**{"python_dependencies": d})
 
         super().__init__(
             n_intervals=n_intervals,

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -1,0 +1,157 @@
+"""Randomised Interval-Shapelet Transformation (RIST) pipeline estimators."""
+
+__author__ = ["MatthewMiddlehurst"]
+
+
+from sklearn.ensemble import ExtraTreesClassifier
+from sklearn.preprocessing import FunctionTransformer
+
+from aeon.base.estimator.hybrid import BaseRIST
+from aeon.classification import BaseClassifier
+from aeon.utils.numba.general import first_order_differences_3d
+
+
+class RISTClassifier(BaseRIST, BaseClassifier):
+    """Randomised Interval-Shapelet Transformation (RIST) pipeline classifier.
+
+    This classifier is a hybrid pipeline using the RandomIntervalTransformer using
+    Catch22 features and summary stats, and the RandomDilatedShapeletTransformer.
+    Both transforms extract features from different series transformations (1st Order
+    Differences, PeriodogramTransformer, and ARCoefficientTransformer).
+    An ExtraTreesClassifier with 200 trees is used as the estimator for the
+    concatenated feature vector output.
+
+    Parameters
+    ----------
+    n_intervals : int, callable or None, default=None,
+        The number of intervals of random length, position and dimension to be
+        extracted for the interval portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of intervals per `series_transformer` output.
+        If None, extracts `int(np.sqrt(X.shape[2]) * np.sqrt(X.shape[1]) * 15 + 5)`
+        intervals where `Xt` is the series representation data.
+    n_shapelets : int, callable or None, default=None,
+        The number of shapelets of random dilation and position to be extracted for the
+        shapelet portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of shapelets per `series_transformer` output.
+        If None, extracts `int(np.sqrt(Xt.shape[2]) * 200 + 5)` shapelets where `Xt` is
+        the series representation data.
+    series_transformers : TransformerMixin, list, tuple, or None, default=None
+        The transformers to apply to the series before extracting intervals and
+        shapelets. If None, use the series as is. If "default", use [None, 1st Order
+        Differences, PeriodogramTransformer, and ARCoefficientTransformer].
+
+        A list or tuple of transformers will extract intervals from
+        all transformations concatenate the output. Including None in the list or tuple
+        will use the series as is for interval extraction.
+    use_pycatch22 : bool, optional, default=False
+        Wraps the C based pycatch22 implementation for aeon.
+        (https://github.com/DynamicsAndNeuralSystems/pycatch22). This requires the
+        ``pycatch22`` package to be installed if True.
+    use_pyfftw : bool, default=False
+        Whether to use the pyfftw library for FFT calculations. Requires the pyfftw
+        package to be installed.
+    estimator : sklearn classifier, default=None
+        An sklearn estimator to be built using the transformed data. Defaults to an
+        ExtraTreesClassifier with 200 trees.
+    random_state : int, RandomState instance or None, default=None
+        If `int`, random_state is the seed used by the random number generator;
+        If `RandomState` instance, random_state is the random number generator;
+        If `None`, the random number generator is the `RandomState` instance used
+        by `np.random`.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        ``-1`` means using all processors.
+
+    Attributes
+    ----------
+    n_instances_ : int
+        The number of train cases in the training set.
+    n_channels_ : int
+        The number of dimensions per case in the training set.
+    n_timepoints_ : int
+        The length of each series in the training set.
+    n_classes_ : int
+        Number of classes. Extracted from the data.
+    classes_ : ndarray of shape (n_classes_)
+        Holds the label for each class.
+    class_dictionary_ : dict
+        A dictionary mapping class labels to class indices in classes_.
+
+    Examples
+    --------
+    >>> from aeon.classification.hybrid import RISTClassifier
+    >>> from aeon.testing.utils.data_gen import make_example_3d_numpy
+    >>> X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=12,
+    ...                              return_y=True, random_state=0)
+    >>> clf = RISTClassifier(random_state=0)
+    >>> clf.fit(X, y)
+    RISTClassifier(...)
+    >>> clf.predict(X)
+    array([0, 1, 1, 0, 0, 1, 0, 1])
+    """
+
+    def __init__(
+        self,
+        n_intervals=None,
+        n_shapelets=None,
+        series_transformers="default",
+        use_pycatch22=False,
+        use_pyfftw=False,
+        estimator=None,
+        n_jobs=1,
+        random_state=None,
+    ):
+        d = []
+        self.use_pycatch22 = use_pycatch22
+        if use_pycatch22:
+            d.append("pycatch22")
+        self.use_pyfftw = use_pyfftw
+        if use_pyfftw:
+            d.append("pyfftw")
+
+        if d:
+            self.set_tags(**{"python_dependencies": d})
+
+        super().__init__(
+            n_intervals=n_intervals,
+            n_shapelets=n_shapelets,
+            series_transformers=series_transformers,
+            use_pycatch22=use_pycatch22,
+            use_pyfftw=use_pyfftw,
+            estimator=estimator,
+            random_state=random_state,
+            n_jobs=n_jobs,
+        )
+
+    _tags = {
+        "capability:multivariate": True,
+        "capability:multithreading": True,
+        "algorithm_type": "hybrid",
+    }
+
+    @classmethod
+    def get_test_params(cls, parameter_set=None):
+        """Return unit test parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : None or str, default=None
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+        """
+        return {
+            "series_transformers": [
+                None,
+                FunctionTransformer(func=first_order_differences_3d, validate=False),
+            ],
+            "n_intervals": 1,
+            "n_shapelets": 2,
+            "estimator": ExtraTreesClassifier(n_estimators=2, criterion="entropy"),
+        }

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -89,7 +89,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
     >>> clf.fit(X, y)
     RISTClassifier(...)
     >>> clf.predict(X)
-    array([0, 1, 1, 0, 0, 1, 0, 1])
+    array([0, 1, 0, 1, 0, 0, 1, 1, 1, 0])
     """
 
     def __init__(
@@ -103,7 +103,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         n_jobs=1,
         random_state=None,
     ):
-        d = []
+        d = ["statsmodels"]
         self.use_pycatch22 = use_pycatch22
         if use_pycatch22:
             d.append("pycatch22")
@@ -129,6 +129,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         "capability:multivariate": True,
         "capability:multithreading": True,
         "algorithm_type": "hybrid",
+        "python_dependencies": "statsmodels",
     }
 
     @classmethod

--- a/aeon/regression/hybrid/__init__.py
+++ b/aeon/regression/hybrid/__init__.py
@@ -1,0 +1,7 @@
+"""Hybrid time series regressors."""
+
+__all__ = [
+    "RISTRegressor",
+]
+
+from aeon.regression.hybrid._rist import RISTRegressor

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -85,8 +85,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
     >>> from aeon.regression.hybrid import RISTRegressor
     >>> from aeon.testing.utils.data_gen import make_example_3d_numpy
     >>> X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=12,
-    ...                              return_y=True, regression_target=True,
-    ...                              random_state=0)
+    ...                              regression_target=True, random_state=0)
     >>> reg = RISTRegressor(random_state=0)  # doctest: +SKIP
     >>> reg.fit(X, y)  # doctest: +SKIP
     RISTRegressor(...)

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -40,11 +40,11 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         A list or tuple of transformers will extract intervals from
         all transformations concatenate the output. Including None in the list or tuple
         will use the series as is for interval extraction.
-    use_pycatch22 : bool, optional, default=True
+    use_pycatch22 : bool, optional, default=False
         Wraps the C based pycatch22 implementation for aeon.
         (https://github.com/DynamicsAndNeuralSystems/pycatch22). This requires the
         ``pycatch22`` package to be installed if True.
-    use_pyfftw : bool, default=True
+    use_pyfftw : bool, default=False
         Whether to use the pyfftw library for FFT calculations. Requires the pyfftw
         package to be installed.
     estimator : sklearn regressor, default=None

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -1,0 +1,148 @@
+from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.preprocessing import FunctionTransformer
+
+from aeon.base.estimator.hybrid import BaseRIST
+from aeon.regression import BaseRegressor
+from aeon.utils.numba.general import first_order_differences_3d
+
+
+class RISTRegressor(BaseRIST, BaseRegressor):
+    """Randomised Interval-Shapelet Transformation (RIST) pipeline regressor.
+
+    This regressor is a hybrid pipeline using the RandomIntervalTransformer using
+    Catch22 features and summary stats, and the RandomDilatedShapeletTransformer.
+    Both transforms extract features from different series transformations (1st Order
+    Differences, PeriodogramTransformer, and ARCoefficientTransformer).
+    An ExtraTreesRegressor with 200 trees is used as the estimator for the
+    concatenated feature vector output.
+
+    Parameters
+    ----------
+    n_intervals : int, callable or None, default=None,
+        The number of intervals of random length, position and dimension to be
+        extracted for the interval portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of intervals per `series_transformer` output.
+        If None, extracts `int(np.sqrt(X.shape[2]) * np.sqrt(X.shape[1]) * 15 + 5)`
+        intervals where `Xt` is the series representation data.
+    n_shapelets : int, callable or None, default=None,
+        The number of shapelets of random dilation and position to be extracted for the
+        shapelet portion of the pipeline. Input should be an int or
+        a function that takes a 3D np.ndarray input and returns an int. Functions may
+        extract a different number of shapelets per `series_transformer` output.
+        If None, extracts `int(np.sqrt(Xt.shape[2]) * 200 + 5)` shapelets where `Xt` is
+        the series representation data.
+    series_transformers : TransformerMixin, list, tuple, or None, default=None
+        The transformers to apply to the series before extracting intervals and
+        shapelets. If None, use the series as is. If "default", use [None, 1st Order
+        Differences, PeriodogramTransformer, and ARCoefficientTransformer].
+
+        A list or tuple of transformers will extract intervals from
+        all transformations concatenate the output. Including None in the list or tuple
+        will use the series as is for interval extraction.
+    use_pycatch22 : bool, optional, default=True
+        Wraps the C based pycatch22 implementation for aeon.
+        (https://github.com/DynamicsAndNeuralSystems/pycatch22). This requires the
+        ``pycatch22`` package to be installed if True.
+    use_pyfftw : bool, default=True
+        Whether to use the pyfftw library for FFT calculations. Requires the pyfftw
+        package to be installed.
+    estimator : sklearn regressor, default=None
+        An sklearn estimator to be built using the transformed data. Defaults to an
+        ExtraTreesRegressor with 200 trees.
+    random_state : int, RandomState instance or None, default=None
+        If `int`, random_state is the seed used by the random number generator;
+        If `RandomState` instance, random_state is the random number generator;
+        If `None`, the random number generator is the `RandomState` instance used
+        by `np.random`.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel for both `fit` and `predict`.
+        ``-1`` means using all processors.
+
+    Attributes
+    ----------
+    n_instances_ : int
+        The number of train cases in the training set.
+    n_channels_ : int
+        The number of dimensions per case in the training set.
+    n_timepoints_ : int
+        The length of each series in the training set.
+
+    Examples
+    --------
+    >>> from aeon.regression.hybrid import RISTRegressor
+    >>> from aeon.testing.utils.data_gen import make_example_3d_numpy
+    >>> X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=12,
+    ...                              return_y=True, regression_target=True,
+    ...                              random_state=0)
+    >>> reg = RISTRegressor(random_state=0)
+    >>> reg.fit(X, y)
+    RISTRegressor(...)
+    >>> reg.predict(X)
+    array([0.31798318, 1.41426301, 1.06414747, 0.6924721 , 0.56660146,
+           1.26538944, 0.52324808, 1.0939405 ])
+    """
+
+    def __init__(
+        self,
+        n_intervals=None,
+        n_shapelets=None,
+        series_transformers="default",
+        use_pycatch22=False,
+        use_pyfftw=False,
+        estimator=None,
+        n_jobs=1,
+        random_state=None,
+    ):
+        d = []
+        self.use_pycatch22 = use_pycatch22
+        if use_pycatch22:
+            d.append("pycatch22")
+        self.use_pyfftw = use_pyfftw
+        if use_pyfftw:
+            d.append("pyfftw")
+
+        if d:
+            self.set_tags(**{"python_dependencies": d})
+
+        super().__init__(
+            n_intervals=n_intervals,
+            n_shapelets=n_shapelets,
+            series_transformers=series_transformers,
+            use_pycatch22=use_pycatch22,
+            use_pyfftw=use_pyfftw,
+            estimator=estimator,
+            random_state=random_state,
+            n_jobs=n_jobs,
+        )
+
+    _tags = {
+        "capability:multivariate": True,
+        "capability:multithreading": True,
+        "algorithm_type": "hybrid",
+    }
+
+    @classmethod
+    def get_test_params(cls, parameter_set=None):
+        """Return unit test parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : None or str, default=None
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+        """
+        return {
+            "series_transformers": [
+                None,
+                FunctionTransformer(func=first_order_differences_3d, validate=False),
+            ],
+            "n_intervals": 1,
+            "n_shapelets": 2,
+            "estimator": ExtraTreesRegressor(n_estimators=2),
+        }

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -79,8 +79,8 @@ class RISTRegressor(BaseRIST, BaseRegressor):
     >>> reg.fit(X, y)
     RISTRegressor(...)
     >>> reg.predict(X)
-    array([0.31798318, 1.41426301, 1.06414747, 0.6924721 , 0.56660146,
-           1.26538944, 0.52324808, 1.0939405 ])
+    array([0.7252543 , 1.50132442, 0.95608366, 1.64399016, 0.42385504,
+           0.60639322, 1.01919317, 1.30157483, 1.66017354, 0.2900776 ])
     """
 
     def __init__(
@@ -94,7 +94,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         n_jobs=1,
         random_state=None,
     ):
-        d = []
+        d = ["statsmodels"]
         self.use_pycatch22 = use_pycatch22
         if use_pycatch22:
             d.append("pycatch22")
@@ -120,6 +120,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         "capability:multivariate": True,
         "capability:multithreading": True,
         "algorithm_type": "hybrid",
+        "python_dependencies": "statsmodels",
     }
 
     @classmethod

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -68,6 +68,18 @@ class RISTRegressor(BaseRIST, BaseRegressor):
     n_timepoints_ : int
         The length of each series in the training set.
 
+    See Also
+    --------
+    BaseRIST
+    RISTClassifier
+
+    References
+    ----------
+    .. [1] Middlehurst, M. and Bagnall, A., 2023, September. Extracting Features from
+        Random Subseries: A Hybrid Pipeline for Time Series Classification and Extrinsic
+        Regression. In International Workshop on Advanced Analytics and Learning on
+        Temporal Data (pp. 113-126). Cham: Springer Nature Switzerland.
+
     Examples
     --------
     >>> from aeon.regression.hybrid import RISTRegressor

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -75,10 +75,10 @@ class RISTRegressor(BaseRIST, BaseRegressor):
     >>> X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=12,
     ...                              return_y=True, regression_target=True,
     ...                              random_state=0)
-    >>> reg = RISTRegressor(random_state=0)
-    >>> reg.fit(X, y)
+    >>> reg = RISTRegressor(random_state=0)  # doctest: +SKIP
+    >>> reg.fit(X, y)  # doctest: +SKIP
     RISTRegressor(...)
-    >>> reg.predict(X)
+    >>> reg.predict(X)  # doctest: +SKIP
     array([0.7252543 , 1.50132442, 0.95608366, 1.64399016, 0.42385504,
            0.60639322, 1.01919317, 1.30157483, 1.66017354, 0.2900776 ])
     """
@@ -102,8 +102,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         if use_pyfftw:
             d.append("pyfftw")
 
-        if d:
-            self.set_tags(**{"python_dependencies": d})
+        self.set_tags(**{"python_dependencies": d})
 
         super().__init__(
             n_intervals=n_intervals,

--- a/docs/api_reference/base.rst
+++ b/docs/api_reference/base.rst
@@ -24,9 +24,9 @@ Base classes
     BaseSeriesEstimator
 
 Estimator base classes
-------------
+---------------------
 
-.. currentmodule:: aeon.base
+.. currentmodule:: aeon.base.estimator
 
 .. autosummary::
     :toctree: auto_generated/

--- a/docs/api_reference/base.rst
+++ b/docs/api_reference/base.rst
@@ -22,3 +22,15 @@ Base classes
     BaseEstimator
     BaseCollectionEstimator
     BaseSeriesEstimator
+
+Estimator base classes
+------------
+
+.. currentmodule:: aeon.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    hybrid.BaseRIST
+    interval_based.BaseIntervalForest

--- a/docs/api_reference/base.rst
+++ b/docs/api_reference/base.rst
@@ -24,7 +24,7 @@ Base classes
     BaseSeriesEstimator
 
 Estimator base classes
----------------------
+----------------------
 
 .. currentmodule:: aeon.base.estimator
 

--- a/docs/api_reference/classification.rst
+++ b/docs/api_reference/classification.rst
@@ -98,6 +98,7 @@ Hybrid
 
     HIVECOTEV1
     HIVECOTEV2
+    RISTClassifier
 
 Interval-based
 --------------

--- a/docs/api_reference/regression.rst
+++ b/docs/api_reference/regression.rst
@@ -69,6 +69,17 @@ Feature-based
 
     FreshPRINCERegressor
 
+Hybrid
+------
+
+.. currentmodule:: aeon.regression.hybrid
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    RISTRegression
+
 
 Interval-based
 --------------


### PR DESCRIPTION
Implements `RISTClassifier` and `RISTRegressor`, inheriting from a `BaseRIST` class which holds the shared functionality. From [this publication](https://link.springer.com/chapter/10.1007/978-3-031-49896-1_8) of mine.