### PR TITLE
[DOC] Fix typos, misspellings & capitalizations in doctrings

### DIFF
--- a/aeon/transformations/collection/convolution_based/_minirocket.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket.py
@@ -14,18 +14,18 @@ from aeon.transformations.collection import BaseCollectionTransformer
 class MiniRocket(BaseCollectionTransformer):
     """MINImally RandOm Convolutional KErnel Transform (MiniRocket).
 
-    MiniRocket [1]_ is an almost deterministic version of Rocket. If creates
-    convolutions of length of 9 with weights restricted to two values, and uses 84 fixed
+    MiniRocket [1]_ is an almost deterministic version of Rocket. It creates
+    convolutions of length 9 with weights restricted to two values, and uses 84 fixed
     convolutions with six of one weight, three of the second weight to seed dilations.
-    MiniRocket is for unviariate time series only.  Use class MiniRocketMultivariate
+    MiniRocket is for unviariate time series only. Use class MiniRocketMultivariate
     for multivariate time series.
 
     Parameters
     ----------
     num_kernels : int, default=10,000
-       number of random convolutional kernels.
+       Number of random convolutional kernels.
     max_dilations_per_kernel : int, default=32
-        maximum number of dilations per kernel.
+        Maximum number of dilations per kernel.
     n_jobs : int, default=1
         The number of jobs to run in parallel for `transform`. ``-1`` means using all
         processors.

--- a/aeon/transformations/collection/convolution_based/_minirocket_multivariate.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket_multivariate.py
@@ -14,8 +14,8 @@ from aeon.transformations.collection import BaseCollectionTransformer
 class MiniRocketMultivariate(BaseCollectionTransformer):
     """MINImally RandOm Convolutional KErnel Transform (MiniRocket) multivariate.
 
-    MiniRocketMultivariate [1]_ is an almost deterministic version of Rocket. If creates
-    convolutions of length of 9 with weights restricted to two values, and uses 84 fixed
+    MiniRocketMultivariate [1]_ is an almost deterministic version of Rocket. It creates
+    convolutions of length 9 with weights restricted to two values, and uses 84 fixed
     convolutions with six of one weight, three of the second weight to seed dilations.
     MiniRocketMultivariate works with univariate and multivariate time series.
 

--- a/aeon/transformations/collection/convolution_based/_minirocket_mv.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket_mv.py
@@ -22,27 +22,29 @@ class MiniRocketMultivariateVariable(BaseCollectionTransformer):
     **Multivariate** and **unequal length**
 
     A provisional and naive extension of MINIROCKET to multivariate input
-    with unequal length provided by the authors [2]_ .  For better
+    with unequal length provided by the authors [2]_. For better
     performance, use the aeon class MiniRocket for univariate input,
-    and MiniRocketMultivariate to equal length multivariate input.
+    and MiniRocketMultivariate for equal-length multivariate input.
 
     Parameters
     ----------
     num_kernels : int, default=10,000
-       number of random convolutional kernels. The calculated number of features is the
-       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
-       (2*n_features_per_kernel(default 4)*num_kernels(default 10,000)).
+       Number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of ``n_features_per_kernel(default 4)*84=336 < 50,000``
+       (``2*n_features_per_kernel(default 4)*num_kernels(default 10,000)``).
     max_dilations_per_kernel : int, default=32
-        maximum number of dilations per kernel.
+        Maximum number of dilations per kernel.
     reference_length : int or str, default = `'max'`
-        series-length of reference, str defines how to infer from X during 'fit'.
-        options are `'max'`, `'mean'`, `'median'`, `'min'`.
+        Series-length of reference, str defines how to infer from `X` during `fit`.
+        Options are `'max'`, `'mean'`, `'median'`, `'min'`.
     pad_value_short_series : float or None, default=None
-        if padding series with len<9 to value. if None, not padding is performed.
+        Whether padding series with length less than 9 to value. If None, no
+        padding is performed.
     n_jobs : int, default=1
         The number of jobs to run in parallel for `transform`. ``-1`` means using all
         processors.
     random_state : None or int, default = None
+        Seed for random number generation.
 
     Examples
     --------

--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -10,10 +10,10 @@ from aeon.transformations.collection import BaseCollectionTransformer
 class MultiRocket(BaseCollectionTransformer):
     """Multi RandOm Convolutional KErnel Transform (MultiRocket).
 
-    MultiRocket [1]_ is uses the same set of kernels as MiniRocket on both the raw
+    MultiRocket [1]_ uses the same set of kernels as MiniRocket on both the raw
     series and the first order differenced series representation. It uses a different
     set of dilations and used for each representation. In addition to percentage of
-    positive values (PPV) MultiRocket adds 3 pooling operators: Mean of Positive
+    positive values (PPV), MultiRocket adds 3 pooling operators: Mean of Positive
     Values (MPV); Mean of Indices of Positive Values (MIPV); and Longest Stretch of
     Positive Values (LSPV). This version is for univariate time series only. Use class
     MultiRocketMultivariate for multivariate input.
@@ -21,14 +21,15 @@ class MultiRocket(BaseCollectionTransformer):
     Parameters
     ----------
     num_kernels : int, default = 6,250
-       number of random convolutional kernels. The calculated number of features is the
-       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
-       (2*n_features_per_kernel(default 4)*num_kernels(default 6,250)).
+       Number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of ``n_features_per_kernel(default 4)*84=336 < 50,000``
+       (``2*n_features_per_kernel(default 4)*num_kernels(default 6,250)``).
     max_dilations_per_kernel : int, default = 32
-        maximum number of dilations per kernel.
+        Maximum number of dilations per kernel.
     n_features_per_kernel : int, default = 4
-        number of features per kernel.
+        Number of features per kernel.
     normalise : bool, default False
+        Whether or not to normalise the input time series per instance.
     n_jobs : int, default=1
         The number of jobs to run in parallel for `transform`. ``-1`` means using all
         processors.
@@ -38,11 +39,11 @@ class MultiRocket(BaseCollectionTransformer):
     Attributes
     ----------
     parameter : tuple
-        parameter (dilations, num_features_per_dilation, biases) for
-        transformation of input X
+        Parameter (dilations, num_features_per_dilation, biases) for
+        transformation of input `X`.
     parameter1 : tuple
-        parameter (dilations, num_features_per_dilation, biases) for
-        transformation of input X1 = np.diff(X, 1)
+        Parameter (dilations, num_features_per_dilation, biases) for
+        transformation of input ``X1 = np.diff(X, 1)``.
 
 
     See Also

--- a/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
@@ -10,37 +10,39 @@ from aeon.transformations.collection import BaseCollectionTransformer
 class MultiRocketMultivariate(BaseCollectionTransformer):
     """Multi RandOm Convolutional KErnel Transform (MultiRocket).
 
-    MultiRocket [1]_ is uses the same set of kernels as MiniRocket on both the raw
+    MultiRocket [1]_ uses the same set of kernels as MiniRocket on both the raw
     series and the first order differenced series representation. It uses a different
     set of dilations and used for each representation. In addition to percentage of
-    positive values (PPV) MultiRocket adds 3 pooling operators: Mean of Positive
+    positive values (PPV), MultiRocket adds 3 pooling operators: Mean of Positive
     Values (MPV); Mean of Indices of Positive Values (MIPV); and Longest Stretch of
     Positive Values (LSPV). This version is the multivariate version.
 
     Parameters
     ----------
     num_kernels : int, default=6,250
-       number of random convolutional kernels. The calculated number of features is the
-       nearest multiple of n_features_per_kernel(default 4)*84=336 < 50,000
-       (2*n_features_per_kernel(default 4)*num_kernels(default 6,250)).
+       Number of random convolutional kernels. The calculated number of features is the
+       nearest multiple of ``n_features_per_kernel(default 4)*84=336 < 50,000``
+       (``2*n_features_per_kernel(default 4)*num_kernels(default 6,250)``).
     max_dilations_per_kernel : int, default=32
-        maximum number of dilations per kernel.
+        Maximum number of dilations per kernel.
     n_features_per_kernel : int, default =4
-        number of features per kernel.
+        Number of features per kernel.
     normalise : bool, default False
+        Whether or not to normalise the input time series per instance.
     n_jobs : int, default=1
         The number of jobs to run in parallel for `transform`. ``-1`` means using all
         processors.
     random_state : None or int, default = None
+        Seed for random number generation.
 
     Attributes
     ----------
     parameter : tuple
-        parameter (dilations, num_features_per_dilation, biases) for
-        transformation of input X
+        Parameter (dilations, num_features_per_dilation, biases) for
+        transformation of input `X`.
     parameter1 : tuple
-        parameter (dilations, num_features_per_dilation, biases) for
-        transformation of input X1 = np.diff(X, 1)
+        Parameter (dilations, num_features_per_dilation, biases) for
+        transformation of input ``X1 = np.diff(X, 1)``.
 
 
     See Also

--- a/aeon/transformations/collection/convolution_based/_rocket.py
+++ b/aeon/transformations/collection/convolution_based/_rocket.py
@@ -14,13 +14,14 @@ class Rocket(BaseCollectionTransformer):
     """RandOm Convolutional KErnel Transform (ROCKET).
 
     A kernel (or convolution) is a subseries used to create features that can be used
-    in machine learning tasks. ROCKET [1]_  generates a large number of random
+    in machine learning tasks. ROCKET [1]_ generates a large number of random
     convolutional kernels in the fit method. The length and dilation of each kernel
-    are also randomly generated. The kernels are use in the transform stage to
+    are also randomly generated. The kernels are used in the transform stage to
     generate a new set of features. A kernel is used to create an activation map for
     each series by running it across a time series, including random length and
     dilation. It transforms the time series with two features per kernel. The first
-    feature is global max pooling and the second is proportion of positive values.
+    feature is global max pooling and the second is proportion of positive values
+    (or PPV).
 
 
     Parameters
@@ -30,9 +31,10 @@ class Rocket(BaseCollectionTransformer):
     normalise : bool, default True
        Whether or not to normalise the input time series per instance.
     n_jobs : int, default=1
-       The number of jobs to run in parallel for `transform`. ``-1`` means use all
+       The number of jobs to run in parallel for `transform`. ``-1`` means using all
        processors.
     random_state : None or int, optional, default = None
+        Seed for random number generation.
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Typos, misspellings and sentence capitalization in the docstrings have been fixed. The docstring of the main classes in the `transformations/collection/convolution_based` module (e.g. `Rocket`, `MiniRocket`, ...) have been modified in this PR.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

<!--
Thanks for contributing!
-->