### PR TITLE
[BUG] make metric precomputed in distances sklearn tests

### DIFF
--- a/aeon/distances/tests/test_sklearn_compatibility.py
+++ b/aeon/distances/tests/test_sklearn_compatibility.py
@@ -47,7 +47,9 @@ def test_support_vector_machine(dist):
     X, y = make_example_3d_numpy(n_cases=5, n_channels=1, n_timepoints=10)
     pairwise = dist["pairwise_distance"]
     ft = FunctionTransformer(pairwise)
-    pipe = Pipeline(steps=[("FunctionTransformer", ft), ("SVM", SVC())])
+    pipe = Pipeline(
+        steps=[("FunctionTransformer", ft), ("SVM", SVC(kernel="precomputed"))]
+    )
     pipe.fit(X, y)
     preds = pipe.predict(X)
     assert len(preds) == len(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
See #1189 (fixes it I think, @MatthewMiddlehurst)

Sets kernel to precomputed in SVM distance test for pairwise.
