### PR TITLE
[ENH] Refactored series_length and n_instances to n_timepoints and n_cases in dictionary based classifiers #1151

### DIFF
--- a/aeon/classification/dictionary_based/_boss.py
+++ b/aeon/classification/dictionary_based/_boss.py
@@ -82,9 +82,9 @@ class BOSSEnsemble(BaseClassifier):
 
     Attributes
     ----------
-    n_instances_ : int
+    n_cases_ : int
         Number of train instances in data passed to fit.
-    series_length_ : int
+    n_timepoints_ : int
         Length of all series (assumed equal).
     n_estimators_ : int
         The final number of classifiers used. Will be <= `max_ensemble_size` if
@@ -151,8 +151,8 @@ class BOSSEnsemble(BaseClassifier):
 
         self.estimators_ = []
         self.n_estimators_ = 0
-        self.series_length_ = 0
-        self.n_instances_ = 0
+        self.n_timepoints_ = 0
+        self.n_cases_ = 0
         self.feature_selection = feature_selection
 
         self._word_lengths = [16, 14, 12, 10, 8]
@@ -180,9 +180,9 @@ class BOSSEnsemble(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The training data shape = (n_instances, n_channels, n_timepoints).
+            The training data shape = (n_cases, n_channels, n_timepoints).
         y : 1D np.ndarray
-            The training labels, shape = (n_instances).
+            The training labels, shape = (n_cases).
 
         Returns
         -------
@@ -194,13 +194,13 @@ class BOSSEnsemble(BaseClassifier):
         Changes state by creating a fitted model that updates attributes
         ending in "_" and sets is_fitted flag to True.
         """
-        self.n_instances_, _, self.series_length_ = X.shape
+        self.n_cases_, _, self.n_timepoints_ = X.shape
 
         self.estimators_ = []
 
         # Window length parameter space dependent on series length
-        max_window_searches = self.series_length_ / 4
-        max_window = int(self.series_length_ * self.max_win_len_prop)
+        max_window_searches = self.n_timepoints_ / 4
+        max_window = int(self.n_timepoints_ * self.max_win_len_prop)
         win_inc = max(1, int((max_window - self.min_window) / max_window_searches))
 
         if self.min_window > max_window + 1:
@@ -244,7 +244,7 @@ class BOSSEnsemble(BaseClassifier):
                     boss._accuracy = self._individual_train_acc(
                         boss,
                         y,
-                        self.n_instances_,
+                        self.n_cases_,
                         best_acc_for_win_size,
                         keep_train_preds,
                     )
@@ -295,13 +295,13 @@ class BOSSEnsemble(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         y : 1D np.ndarray
-            The predicted class labels, shape = (n_instances).
+            The predicted class labels, shape = (n_cases).
         """
         rng = check_random_state(self.random_state)
         return np.array(
@@ -317,14 +317,14 @@ class BOSSEnsemble(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         y : 2D np.ndarray
             Predicted probabilities using the ordering in classes_ shape = (
-            n_instances, n_classes_).
+            n_cases, n_classes_).
         """
         sums = np.zeros((X.shape[0], self.n_classes_))
 
@@ -346,8 +346,8 @@ class BOSSEnsemble(BaseClassifier):
     def _fit_predict_proba(self, X, y) -> np.ndarray:
         self._fit(X, y, keep_train_preds=True)
 
-        results = np.zeros((self.n_instances_, self.n_classes_))
-        divisors = np.zeros(self.n_instances_)
+        results = np.zeros((self.n_cases_, self.n_classes_))
+        divisors = np.zeros(self.n_cases_)
 
         for clf in self.estimators_:
             preds = clf._train_predictions
@@ -355,7 +355,7 @@ class BOSSEnsemble(BaseClassifier):
                 results[n][self._class_dictionary[pred]] += 1
                 divisors[n] += 1
 
-        for i in range(self.n_instances_):
+        for i in range(self.n_cases_):
             results[i] = (
                 np.ones(self.n_classes_) * (1 / self.n_classes_)
                 if divisors[i] == 0
@@ -572,13 +572,13 @@ class IndividualBOSS(BaseClassifier):
         super().__init__()
 
     def _fit(self, X, y):
-        """Fit a single boss classifier on n_instances cases (X,y).
+        """Fit a single boss classifier on n_cases cases (X,y).
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
             The training data.
-        y : array-like, shape = [n_instances]
+        y : array-like, shape = [n_cases]
             The class labels.
 
         Returns
@@ -614,12 +614,12 @@ class IndividualBOSS(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
             The data to make predictions for.
 
         Returns
         -------
-        y : array-like, shape = [n_instances]
+        y : array-like, shape = [n_cases]
             Predicted class labels.
         """
         test_bags = self._transformer.transform(X)

--- a/aeon/classification/dictionary_based/_cboss.py
+++ b/aeon/classification/dictionary_based/_cboss.py
@@ -85,9 +85,9 @@ class ContractableBOSS(BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : list
         The classes labels.
-    n_instances_ : int
+    n_cases_ : int
         Number of instances. Extracted from the data.
-    series_length_ : int
+    n_timepoints_ : int
         Length of all series (assumed equal).
     estimators_ : list
        List of DecisionTree classifiers.
@@ -165,8 +165,8 @@ class ContractableBOSS(BaseClassifier):
         self.estimators_ = []
         self.weights_ = []
         self.n_estimators_ = 0
-        self.series_length_ = 0
-        self.n_instances_ = 0
+        self.n_timepoints_ = 0
+        self.n_cases_ = 0
 
         self._weight_sum = 0
         self._word_lengths = [16, 14, 12, 10, 8]
@@ -194,9 +194,9 @@ class ContractableBOSS(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The training data shape = (n_instances, n_channels, n_timepoints).
+            The training data shape = (n_cases, n_channels, n_timepoints).
         y : 1D np.ndarray
-            The training labels, shape = (n_instances).
+            The training labels, shape = (n_cases).
 
         Returns
         -------
@@ -209,14 +209,14 @@ class ContractableBOSS(BaseClassifier):
         ending in "_" and sets is_fitted flag to True.
         """
         time_limit = self.time_limit_in_minutes * 60
-        self.n_instances_, _, self.series_length_ = X.shape
+        self.n_cases_, _, self.n_timepoints_ = X.shape
 
         self.estimators_ = []
         self.weights_ = []
 
         # Window length parameter space dependent on series length
-        max_window_searches = self.series_length_ / 4
-        max_window = int(self.series_length_ * self.max_win_len_prop)
+        max_window_searches = self.n_timepoints_ / 4
+        max_window = int(self.n_timepoints_ * self.max_win_len_prop)
         win_inc = int((max_window - self.min_window) / max_window_searches)
         win_inc = max(win_inc, 1)
         if self.min_window > max_window + 1:
@@ -232,7 +232,7 @@ class ContractableBOSS(BaseClassifier):
         num_classifiers = 0
         start_time = time.time()
         train_time = 0
-        subsample_size = int(self.n_instances_ * 0.7)
+        subsample_size = int(self.n_cases_ * 0.7)
         lowest_acc = 1
         lowest_acc_idx = 0
 
@@ -256,9 +256,7 @@ class ContractableBOSS(BaseClassifier):
                 rng.randint(0, len(possible_parameters))
             )
 
-            subsample = rng.choice(
-                self.n_instances_, size=subsample_size, replace=False
-            )
+            subsample = rng.choice(self.n_cases_, size=subsample_size, replace=False)
             X_subsample = X[subsample]
             y_subsample = y[subsample]
 
@@ -313,13 +311,13 @@ class ContractableBOSS(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         1D np.ndarray
-            Predicted class labels shape = (n_instances).
+            Predicted class labels shape = (n_cases).
 
         """
         rng = check_random_state(self.random_state)
@@ -336,13 +334,13 @@ class ContractableBOSS(BaseClassifier):
         Parameters
         ----------
          X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         2D np.ndarray
-            Predicted class labels shape = (n_instances).
+            Predicted class labels shape = (n_cases).
         """
         sums = np.zeros((X.shape[0], self.n_classes_))
 
@@ -368,8 +366,8 @@ class ContractableBOSS(BaseClassifier):
     def _fit_predict_proba(self, X, y) -> np.ndarray:
         self._fit(X, y, keep_train_preds=True)
 
-        results = np.zeros((self.n_instances_, self.n_classes_))
-        divisors = np.zeros(self.n_instances_)
+        results = np.zeros((self.n_cases_, self.n_classes_))
+        divisors = np.zeros(self.n_cases_)
 
         for i, clf in enumerate(self.estimators_):
             subsample = clf._subsample
@@ -379,7 +377,7 @@ class ContractableBOSS(BaseClassifier):
                 results[subsample[n]][self._class_dictionary[pred]] += self.weights_[i]
                 divisors[subsample[n]] += self.weights_[i]
 
-        for i in range(self.n_instances_):
+        for i in range(self.n_cases_):
             results[i] = (
                 np.ones(self.n_classes_) * (1 / self.n_classes_)
                 if divisors[i] == 0

--- a/aeon/classification/dictionary_based/_muse.py
+++ b/aeon/classification/dictionary_based/_muse.py
@@ -168,9 +168,9 @@ class MUSE(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The training data shape = (n_instances, n_channels, n_timepoints).
+            The training data shape = (n_cases, n_channels, n_timepoints).
         y : 1D np.ndarray
-            The training labels, shape = (n_instances).
+            The training labels, shape = (n_cases).
 
         Returns
         -------
@@ -262,13 +262,13 @@ class MUSE(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         1D np.ndarray
-            The predicted class labels shape = (n_instances).
+            The predicted class labels shape = (n_cases).
         """
         bag = self._transform_words(X)
         return self.clf.predict(bag)
@@ -279,14 +279,14 @@ class MUSE(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         2D np.ndarray
             Predicted probabilities using the ordering in classes_, shape = (
-            n_instances, n_classes_).
+            n_cases, n_classes_).
         """
         bag = self._transform_words(X)
         if self.support_probabilities:
@@ -353,9 +353,9 @@ class MUSE(BaseClassifier):
         }
 
 
-def _compute_window_inc(series_length, window_inc):
+def _compute_window_inc(n_timepoints, window_inc):
     win_inc = window_inc
-    if series_length < 100:
+    if n_timepoints < 100:
         win_inc = 1  # less than 100 is ok time-wise
 
     return win_inc
@@ -401,11 +401,11 @@ def _parallel_fit(
 
     # On each dimension, perform SFA
     X_dim = X[:, ind]
-    series_length = X_dim.shape[-1]
+    n_timepoints = X_dim.shape[-1]
 
     # increment window size in steps of 'win_inc'
-    win_inc = _compute_window_inc(series_length, window_inc)
-    max_window = int(min(series_length, max_window))
+    win_inc = _compute_window_inc(n_timepoints, window_inc)
+    max_window = int(min(n_timepoints, max_window))
 
     if min_window > max_window:
         raise ValueError(

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -135,10 +135,10 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The training data.
         y : np.ndarray
-            1D np.ndarray of shape (n_instances)
+            1D np.ndarray of shape (n_cases)
             The class labels.
 
         Returns
@@ -180,10 +180,10 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            2D np.ndarray of shape (n_instances, n_timepoints)
+            2D np.ndarray of shape (n_cases, n_timepoints)
             The training data.
         y : np.ndarray
-            1D np.ndarray of shape (n_instances)
+            1D np.ndarray of shape (n_cases)
             The class labels.
 
         Returns
@@ -317,11 +317,11 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The training data.
             ``n_channels > 1``
         y : np.ndarray
-            1D np.ndarray of shape (n_instances)
+            1D np.ndarray of shape (n_cases)
             The class labels.
 
         Returns
@@ -368,13 +368,13 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The data to make predictions for.
 
         Returns
         -------
         y : np.ndarray
-            1D np.ndarray of shape (n_instances)
+            1D np.ndarray of shape (n_cases)
             Predicted class labels.
         """
         return np.array(
@@ -387,13 +387,13 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The data to make predict probabilities for.
 
         Returns
         -------
         y : np.ndarray
-            2D np.ndarray of shape (n_instances, n_classes_)
+            2D np.ndarray of shape (n_cases, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         if X.shape[1] == 1:  # Univariate
@@ -411,13 +411,13 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            2D np.ndarray of shape (n_instances, n_timepoints)
+            2D np.ndarray of shape (n_cases, n_timepoints)
             The data to make predict probabilities for.
 
         Returns
         -------
         y : np.ndarray
-            2D np.ndarray of shape (n_instances, n_classes_)
+            2D np.ndarray of shape (n_cases, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         X = scale(X, axis=1)  # Z-normalise
@@ -456,14 +456,14 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The data to make predict probabilities for.
             ``n_channels > 1``
 
         Returns
         -------
         y : np.ndarray
-            2D np.ndarray of shape (n_instances, n_classes_)
+            2D np.ndarray of shape (n_cases, n_classes_)
             Predicted probabilities using the ordering in ``classes_``.
         """
         ensemble_pred_mats = None
@@ -560,7 +560,7 @@ class REDCOMETS(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D np.ndarray of shape (n_instances, n_channels, n_timepoints)
+            3D np.ndarray of shape (n_cases, n_channels, n_timepoints)
             The training data.
         n_lenses : int
             Number of lenses to select.
@@ -601,7 +601,7 @@ class REDCOMETS(BaseClassifier):
         sax_transforms : list
             List of ``SAX()`` instances
         X : np.ndarray
-            2D np.ndarray of shape (n_instances, n_timepoints)
+            2D np.ndarray of shape (n_cases, n_timepoints)
             The data to transform.
         """
 

--- a/aeon/classification/dictionary_based/_weasel.py
+++ b/aeon/classification/dictionary_based/_weasel.py
@@ -150,8 +150,8 @@ class WEASEL(BaseClassifier):
         self.window_inc = window_inc
         self.highest_bit = -1
         self.window_sizes = []
-        self.series_length = 0
-        self.n_instances = 0
+        self.n_timepoints = 0
+        self.n_cases = 0
         self.SFA_transformers = []
         self.clf = None
         self.n_jobs = n_jobs
@@ -165,9 +165,9 @@ class WEASEL(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The training data shape = (n_instances, n_channels, n_timepoints).
+            The training data shape = (n_cases, n_channels, n_timepoints).
         y : 1D np.ndarray
-            The class labels shape = (n_instances).
+            The class labels shape = (n_cases).
 
         Returns
         -------
@@ -175,16 +175,16 @@ class WEASEL(BaseClassifier):
             Reference to self.
         """
         # Window length parameter space dependent on series length
-        self.n_instances, self.series_length = X.shape[0], X.shape[-1]
+        self.n_cases, self.n_timepoints = X.shape[0], X.shape[-1]
 
         win_inc = self._compute_window_inc()
-        self.max_window = int(min(self.series_length, self.max_window))
+        self.max_window = int(min(self.n_timepoints, self.max_window))
         if self.min_window > self.max_window:
             raise ValueError(
                 f"Error in WEASEL, min_window ="
                 f"{self.min_window} is bigger"
                 f" than max_window ={self.max_window},"
-                f" series length is {self.series_length}"
+                f" series length is {self.n_timepoints}"
                 f" try set min_window to be smaller than series length in "
                 f"the constructor, but the classifier may not work at "
                 f"all with very short series"
@@ -246,13 +246,13 @@ class WEASEL(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         1D np.ndarray
-            Predicted class labels shape = (n_instances).
+            Predicted class labels shape = (n_cases).
         """
         bag = self._transform_words(X)
         return self.clf.predict(bag)
@@ -263,13 +263,13 @@ class WEASEL(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         2D np.ndarray
-            Predicted class labels shape = (n_instances).
+            Predicted class labels shape = (n_cases).
         """
         bag = self._transform_words(X)
         if self.support_probabilities:
@@ -292,7 +292,7 @@ class WEASEL(BaseClassifier):
         )
 
     def _compute_window_inc(self):
-        return 1 if self.series_length < 100 else self.window_inc
+        return 1 if self.n_timepoints < 100 else self.window_inc
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/aeon/classification/dictionary_based/_weasel_v2.py
+++ b/aeon/classification/dictionary_based/_weasel_v2.py
@@ -173,9 +173,9 @@ class WEASEL_V2(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The training data shape = (n_instances, n_channels, n_timepoints).
+            The training data shape = (n_cases, n_channels, n_timepoints).
         y : 1D np.ndarray
-            The class labels shape = (n_instances).
+            The class labels shape = (n_cases).
 
         Returns
         -------
@@ -229,13 +229,13 @@ class WEASEL_V2(BaseClassifier):
         Parameters
         ----------
         X : 3D np.ndarray
-            The data to make predictions for, shape = (n_instances, n_channels,
+            The data to make predictions for, shape = (n_cases, n_channels,
             n_timepoints).
 
         Returns
         -------
         1D np.ndarray
-            Predicted class labels shape = (n_instances).
+            Predicted class labels shape = (n_cases).
         """
         bag = self.transform.transform(X)
         return self.clf.predict(bag)
@@ -245,12 +245,12 @@ class WEASEL_V2(BaseClassifier):
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
             The data to make predict probabilities for.
 
         Returns
         -------
-        y : array-like, shape = [n_instances, n_classes_]
+        y : array-like, shape = [n_cases, n_classes_]
             Predicted probabilities using the ordering in classes_.
         """
         m = getattr(self.clf, "predict_proba", None)
@@ -360,8 +360,8 @@ class WEASELTransformerV2:
         self.max_window = MAX_WINDOW_LARGE
         self.ensemble_size = ENSEMBLE_SIZE_LARGE
         self.window_sizes = []
-        self.series_length_ = 0
-        self.n_instances_ = 0
+        self.n_timepoints_ = 0
+        self.n_cases_ = 0
 
         self.SFA_transformers = []
 
@@ -370,9 +370,9 @@ class WEASELTransformerV2:
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
             The training data.
-        y : array-like, shape = [n_instances]
+        y : array-like, shape = [n_cases]
             The class labels.
 
         Returns
@@ -380,27 +380,27 @@ class WEASELTransformerV2:
         scipy csr_matrix, transformed features
         """
         # Window length parameter space dependent on series length
-        self.n_instances_, self.series_length_ = X.shape[0], X.shape[-1]
+        self.n_cases_, self.n_timepoints_ = X.shape[0], X.shape[-1]
         XX = X.squeeze(1)
 
         # avoid overfitting with too many features
-        if self.n_instances_ < SWITCH_SMALL_INSTANCES:
+        if self.n_cases_ < SWITCH_SMALL_INSTANCES:
             self.max_window = MAX_WINDOW_SMALL
             self.ensemble_size = ENSEMBLE_SIZE_SMALL
-        elif self.series_length_ < SWITCH_MEDIUM_LENGTH:
+        elif self.n_timepoints_ < SWITCH_MEDIUM_LENGTH:
             self.max_window = MAX_WINDOW_MEDIUM
             self.ensemble_size = ENSEMBLE_SIZE_MEDIUM
         else:
             self.max_window = MAX_WINDOW_LARGE
             self.ensemble_size = ENSEMBLE_SIZE_LARGE
 
-        self.max_window = int(min(self.series_length_, self.max_window))
+        self.max_window = int(min(self.n_timepoints_, self.max_window))
         if self.min_window > self.max_window:
             raise ValueError(
                 f"Error in WEASEL, min_window ="
                 f"{self.min_window} is bigger"
                 f" than max_window ={self.max_window},"
-                f" series length is {self.series_length_}"
+                f" series length is {self.n_timepoints_}"
                 f" try set min_window to be smaller than series length in "
                 f"the constructor, but the classifier may not work at "
                 f"all with very short series"
@@ -417,7 +417,7 @@ class WEASELTransformerV2:
                 self.window_sizes,
                 self.alphabet_sizes,
                 self.word_lengths,
-                self.series_length_,
+                self.n_timepoints_,
                 self.norm_options,
                 self.use_first_differences,
                 self.binning_strategies,
@@ -455,7 +455,7 @@ class WEASELTransformerV2:
 
         Parameters
         ----------
-        X : 3D np.ndarray of shape = [n_instances, n_channels, series_length]
+        X : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
            The data to make predictions for.
         y : ignored argument for interface compatibility
 
@@ -487,7 +487,7 @@ def _parallel_fit(
     window_sizes,
     alphabet_sizes,
     word_lengths,
-    series_length,
+    n_timepoints,
     norm_options,
     use_first_differences,
     binning_strategies,
@@ -510,7 +510,7 @@ def _parallel_fit(
     window_size = rng.choice(window_sizes)
     dilation = np.maximum(
         1,
-        np.int32(2 ** rng.uniform(0, np.log2((series_length - 1) / (window_size - 1)))),
+        np.int32(2 ** rng.uniform(0, np.log2((n_timepoints - 1) / (window_size - 1)))),
     )
 
     alphabet_size = rng.choice(alphabet_sizes)


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes [#1151](https://github.com/aeon-toolkit/aeon/issues/1151).  I also extended these changes to the ```_redcomets.py``` file as well , after confirming it with @baraline. 
PS : Ran the pre-commit tests as well, which passed.

**Description** : Replaced usage of  `n_instances` with `n_cases` and  `series_length`  with `n_timepoints` in dictionary classifiers' files.

- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

