### PR TITLE
[MNT,DOC] Remove `__author__` lines for `__maintainer__`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,9 +52,10 @@ Please go through the checklist below. Please feel free to remove points if they
 
 ##### For new estimators and functions
 - [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
+- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed.
 
 ##### For developers with write access
-- [ ] Optionally, I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
+- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
 
 
 <!--

--- a/aeon/annotation/base/_base.py
+++ b/aeon/annotation/base/_base.py
@@ -18,7 +18,7 @@ State:
     fitted state flag       - check_is_fitted()
 """
 
-__author__ = ["satya-pattnaik ", "fkiraly"]
+__maintainer__ = []
 __all__ = ["BaseSeriesAnnotator"]
 
 from aeon.base import BaseEstimator

--- a/aeon/annotation/eagglo.py
+++ b/aeon/annotation/eagglo.py
@@ -9,7 +9,7 @@ from numba import njit
 
 from aeon.transformations.base import BaseTransformer
 
-__author__ = ["KatieBuc", "patrickzib"]
+__maintainer__ = []
 __all__ = ["EAgglo"]
 from deprecated.sphinx import deprecated
 

--- a/aeon/annotation/hmm.py
+++ b/aeon/annotation/hmm.py
@@ -15,7 +15,7 @@ from scipy.stats import norm
 
 from aeon.annotation.base._base import BaseSeriesAnnotator
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["HMM"]
 
 

--- a/aeon/annotation/hmm_learn/base.py
+++ b/aeon/annotation/hmm_learn/base.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from aeon.annotation.base import BaseSeriesAnnotator
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["BaseHMMLearn"]
 
 

--- a/aeon/annotation/hmm_learn/gaussian.py
+++ b/aeon/annotation/hmm_learn/gaussian.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["GaussianHMM"]
 
 

--- a/aeon/annotation/hmm_learn/gmm.py
+++ b/aeon/annotation/hmm_learn/gmm.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["GMMHMM"]
 
 

--- a/aeon/annotation/hmm_learn/poisson.py
+++ b/aeon/annotation/hmm_learn/poisson.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from aeon.annotation.hmm_learn import BaseHMMLearn
 
-__author__ = ["klam-data", "pyyim", "mgorlin"]
+__maintainer__ = []
 __all__ = ["PoissonHMM"]
 
 

--- a/aeon/annotation/tests/test_all_annotators.py
+++ b/aeon/annotation/tests/test_all_annotators.py
@@ -1,6 +1,6 @@
 """Tests for aeon annotators."""
 
-__author__ = ["miraep8", "fkiraly", "klam-data", "pyyim", "mgorlin"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/annotation/tests/test_hmm_learn.py
+++ b/aeon/annotation/tests/test_hmm_learn.py
@@ -1,6 +1,6 @@
 """Tests for hmmlearn wrapper annotation estimator."""
 
-__author__ = ["miraep8", "klam-data", "pyyim", "mgorlin"]
+__maintainer__ = []
 
 import pytest
 from numpy import array_equal

--- a/aeon/anomaly_detection/_stray.py
+++ b/aeon/anomaly_detection/_stray.py
@@ -9,7 +9,7 @@ from sklearn.neighbors import NearestNeighbors
 
 from aeon.transformations.base import BaseTransformer
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 __all__ = ["STRAY"]
 
 

--- a/aeon/anomaly_detection/tests/test_stray.py
+++ b/aeon/anomaly_detection/tests/test_stray.py
@@ -1,6 +1,6 @@
 """Tests for STRAY outlier estimator."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler, RobustScaler

--- a/aeon/base/__init__.py
+++ b/aeon/base/__init__.py
@@ -1,6 +1,5 @@
 """Base classes for defining estimators and other objects in aeon."""
 
-__author__ = ["mloning", "RNKuhns", "fkiraly", "TonyBagnall"]
 __all__ = [
     "BaseObject",
     "BaseEstimator",

--- a/aeon/base/_base.py
+++ b/aeon/base/_base.py
@@ -49,7 +49,7 @@ State:
     fitted state check      - check_is_fitted (raises error if not is_fitted)
 """
 
-__author__ = ["mloning", "RNKuhns", "fkiraly"]
+__maintainer__ = []
 __all__ = ["BaseEstimator", "BaseObject"]
 
 import inspect

--- a/aeon/base/_meta.py
+++ b/aeon/base/_meta.py
@@ -1,6 +1,6 @@
 """Implements meta estimator for estimators composed of other estimators."""
 
-__author__ = ["mloning, fkiraly"]
+__maintainer__ = []
 __all__ = ["_HeterogenousMetaEstimator"]
 
 from inspect import isclass

--- a/aeon/base/_serialize.py
+++ b/aeon/base/_serialize.py
@@ -6,7 +6,7 @@ All estimator specific functionality should be in
 the class methods `load_from_serial` and `load_from_path`.
 """
 
-__author__ = ["fkiraly", "achieveordie"]
+__maintainer__ = []
 
 
 def load(serial):

--- a/aeon/base/estimator/interval_based/base_interval_forest.py
+++ b/aeon/base/estimator/interval_based/base_interval_forest.py
@@ -1,6 +1,6 @@
 """A base class for interval extracting forest estimators."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["BaseIntervalForest"]
 
 import inspect

--- a/aeon/base/tests/test_base.py
+++ b/aeon/base/tests/test_base.py
@@ -18,7 +18,7 @@ tests in this module:
     test_eq_dunder       - tests __eq__ dunder to compare parameter definition
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "test_get_class_tags",

--- a/aeon/base/tests/test_base_aeon.py
+++ b/aeon/base/tests/test_base_aeon.py
@@ -1,6 +1,6 @@
 """Tests for BaseObject universal base class that require aeon or sklearn imports."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 
 def test_get_fitted_params_sklearn():

--- a/aeon/benchmarking/experiments.py
+++ b/aeon/benchmarking/experiments.py
@@ -3,7 +3,7 @@
 Results are saved a standardised format used by both tsml and aeon.
 """
 
-__author__ = ["TonyBagnall"]
+__maintainer__ = []
 __all__ = [
     "run_clustering_experiment",
     "load_and_run_clustering_experiment",

--- a/aeon/benchmarking/results_loaders.py
+++ b/aeon/benchmarking/results_loaders.py
@@ -5,7 +5,7 @@ __all__ = [
     "get_estimator_results_as_array",
     "get_available_estimators",
 ]
-__author__ = ["TonyBagnall"]
+__maintainer__ = []
 
 
 import numpy as np

--- a/aeon/classification/_dummy.py
+++ b/aeon/classification/_dummy.py
@@ -1,6 +1,6 @@
 """Dummy time series classifier."""
 
-__author__ = ["ZiyaoWei"]
+__maintainer__ = []
 __all__ = ["DummyClassifier"]
 
 import numpy as np

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -21,7 +21,7 @@ State:
 __all__ = [
     "BaseClassifier",
 ]
-__author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 import time
 from abc import ABC, abstractmethod

--- a/aeon/classification/compose/__init__.py
+++ b/aeon/classification/compose/__init__.py
@@ -1,6 +1,5 @@
 """Compositions for classifiers."""
 
-__author__ = ["mloning", "fkiraly"]
 __all__ = [
     "ChannelEnsembleClassifier",
     "WeightedEnsembleClassifier",

--- a/aeon/classification/compose/_channel_ensemble.py
+++ b/aeon/classification/compose/_channel_ensemble.py
@@ -3,7 +3,7 @@
 Builds classifiers on each channel (dimension) independently.
 """
 
-__author__ = ["abostrom", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["ChannelEnsembleClassifier"]
 
 from itertools import chain

--- a/aeon/classification/compose/_ensemble.py
+++ b/aeon/classification/compose/_ensemble.py
@@ -1,6 +1,6 @@
 """Configurable time series ensembles."""
 
-__author__ = ["mloning", "AyushmaanSeth", "fkiraly"]
+__maintainer__ = []
 __all__ = ["WeightedEnsembleClassifier"]
 
 

--- a/aeon/classification/compose/_pipeline.py
+++ b/aeon/classification/compose/_pipeline.py
@@ -1,6 +1,6 @@
 """Pipeline with a classifier."""
 
-__author__ = ["fkiraly", "MatthewMiddlehurst", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["ClassifierPipeline", "SklearnClassifierPipeline"]
 
 

--- a/aeon/classification/compose/tests/test_pipeline.py
+++ b/aeon/classification/compose/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 """Unit tests for (dunder) composition functionality attached to the base class."""
 
-__author__ = ["fkiraly", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/classification/convolution_based/_arsenal.py
+++ b/aeon/classification/convolution_based/_arsenal.py
@@ -3,7 +3,7 @@
 kernel based ensemble of ROCKET classifiers.
 """
 
-__author__ = ["MatthewMiddlehurst", "kachayev"]
+__maintainer__ = []
 __all__ = ["Arsenal"]
 
 import time

--- a/aeon/classification/convolution_based/_rocket_classifier.py
+++ b/aeon/classification/convolution_based/_rocket_classifier.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the ROCKET transformer and an sklearn classifier.
 """
 
-__author__ = ["MatthewMiddlehurst", "victordremov", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["RocketClassifier"]
 
 import numpy as np

--- a/aeon/classification/deep_learning/_cnn.py
+++ b/aeon/classification/deep_learning/_cnn.py
@@ -1,6 +1,6 @@
 """Time Convolutional Neural Network (CNN) for classification."""
 
-__author__ = ["James-Large", "TonyBagnall", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["CNNClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_encoder.py
+++ b/aeon/classification/deep_learning/_encoder.py
@@ -1,6 +1,6 @@
 """Encoder Classifier."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["EncoderClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_fcn.py
+++ b/aeon/classification/deep_learning/_fcn.py
@@ -1,6 +1,6 @@
 """Fully Convolutional Network (FCN) for classification."""
 
-__author__ = ["James-Large", "AurumnPegasus", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["FCNClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_inception_time.py
+++ b/aeon/classification/deep_learning/_inception_time.py
@@ -1,6 +1,6 @@
 """InceptionTime classifier."""
 
-__author__ = ["James-Large", "TonyBagnall", "MatthewMiddlehurst", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["InceptionTimeClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_lite_time.py
+++ b/aeon/classification/deep_learning/_lite_time.py
@@ -1,6 +1,6 @@
 """LITETime classifier."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["LITETimeClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_mlp.py
+++ b/aeon/classification/deep_learning/_mlp.py
@@ -1,6 +1,6 @@
 """Multi Layer Perceptron Network (MLP) for classification."""
 
-__author__ = ["James-Large", "AurumnPegasus"]
+__maintainer__ = []
 __all__ = ["MLPClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_resnet.py
+++ b/aeon/classification/deep_learning/_resnet.py
@@ -1,6 +1,6 @@
 """Residual Network (ResNet) for classification."""
 
-__author__ = ["James-Large", "AurumnPegasus", "nilesh05apr", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["ResNetClassifier"]
 
 import gc

--- a/aeon/classification/deep_learning/_tapnet.py
+++ b/aeon/classification/deep_learning/_tapnet.py
@@ -1,10 +1,6 @@
 """Time Convolutional Neural Network (CNN) for classification."""
 
-__author__ = [
-    "Jack Russon",
-    "TonyBagnall",
-    "achieveordie",
-]
+__maintainer__ = []
 __all__ = [
     "TapNetClassifier",
 ]

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -5,14 +5,7 @@ The reason for this class between BaseClassifier and deep_learning classifiers i
 because we can generalise tags, _predict and _predict_proba
 """
 
-__author__ = [
-    "James-Large",
-    "ABostrom",
-    "TonyBagnall",
-    "aurunmpegasus",
-    "achieveordie",
-    "hadifawaz1999",
-]
+__maintainer__ = []
 __all__ = ["BaseDeepClassifier"]
 
 from abc import ABC, abstractmethod

--- a/aeon/classification/deep_learning/tests/test_deep_classifier_base.py
+++ b/aeon/classification/deep_learning/tests/test_deep_classifier_base.py
@@ -10,7 +10,7 @@ from aeon.classification.deep_learning.base import BaseDeepClassifier
 from aeon.testing.utils.data_gen import make_example_2d_numpy
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-__author__ = ["achieveordie", "hadifawaz1999"]
+__maintainer__ = []
 
 
 class _DummyDeepClassifier(BaseDeepClassifier):

--- a/aeon/classification/dictionary_based/_boss.py
+++ b/aeon/classification/dictionary_based/_boss.py
@@ -4,7 +4,7 @@ Dictionary based BOSS classifiers based on SFA transform.
 Contains a single BOSS and a BOSS ensemble.
 """
 
-__author__ = ["patrickzib", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["BOSSEnsemble", "IndividualBOSS", "pairwise_distances"]
 
 import warnings

--- a/aeon/classification/dictionary_based/_cboss.py
+++ b/aeon/classification/dictionary_based/_cboss.py
@@ -4,7 +4,7 @@ Dictionary based cBOSS classifier based on SFA transform. Improves the ensemble
 structure of the original BOSS algorithm.
 """
 
-__author__ = ["MatthewMiddlehurst", "BINAYKUMAR943"]
+__maintainer__ = []
 
 __all__ = ["ContractableBOSS", "pairwise_distances"]
 

--- a/aeon/classification/dictionary_based/_muse.py
+++ b/aeon/classification/dictionary_based/_muse.py
@@ -4,7 +4,7 @@ multivariate dictionary based classifier based on SFA transform, dictionaries
 and logistic regression.
 """
 
-__author__ = ["patrickzib", "BINAYKUMAR943"]
+__maintainer__ = []
 __all__ = ["MUSE"]
 
 import math

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -6,7 +6,7 @@ Ensemble of symbolically represented time series using random forests as the bas
 classifier.
 """
 
-__author__ = ["zy18811"]
+__maintainer__ = []
 __all__ = ["REDCOMETS"]
 
 from collections import Counter

--- a/aeon/classification/dictionary_based/_tde.py
+++ b/aeon/classification/dictionary_based/_tde.py
@@ -4,7 +4,7 @@ Dictionary based TDE classifiers based on SFA transform. Contains a single
 IndividualTDE and TDE.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["TemporalDictionaryEnsemble", "IndividualTDE", "histogram_intersection"]
 
 import math

--- a/aeon/classification/dictionary_based/_weasel.py
+++ b/aeon/classification/dictionary_based/_weasel.py
@@ -3,7 +3,7 @@
 Dictionary based classifier based on SFA transform, BOSS and linear regression.
 """
 
-__author__ = ["patrickzib", "Arik Ermshaus"]
+__maintainer__ = []
 __all__ = ["WEASEL"]
 
 import math

--- a/aeon/classification/dictionary_based/_weasel_v2.py
+++ b/aeon/classification/dictionary_based/_weasel_v2.py
@@ -5,7 +5,7 @@ Time Series Classification.
 
 """
 
-__author__ = ["patrickzib"]
+__maintainer__ = []
 __all__ = ["WEASEL_V2", "WEASELTransformerV2"]
 
 import warnings

--- a/aeon/classification/distance_based/_elastic_ensemble.py
+++ b/aeon/classification/distance_based/_elastic_ensemble.py
@@ -3,7 +3,7 @@
 An ensemble of elastic nearest neighbour classifiers.
 """
 
-__author__ = ["jasonlines", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["ElasticEnsemble"]
 
 import math

--- a/aeon/classification/distance_based/_shape_dtw.py
+++ b/aeon/classification/distance_based/_shape_dtw.py
@@ -23,7 +23,7 @@ from aeon.transformations.collection.segment import SlidingWindowSegmenter
 from aeon.transformations.collection.slope import SlopeTransformer
 from aeon.utils.numba.general import slope_derivative_3d
 
-__author__ = ["vincent-nich12"]
+__maintainer__ = []
 
 
 class ShapeDTW(BaseClassifier):

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -5,7 +5,7 @@ The class can take callables or uses string references to utilise the numba base
 distances in aeon.distances.
 """
 
-__author__ = ["TonyBagnall", "GuiArcencio"]
+__maintainer__ = []
 __all__ = ["KNeighborsTimeSeriesClassifier"]
 
 import numpy as np

--- a/aeon/classification/early_classification/_probability_threshold.py
+++ b/aeon/classification/early_classification/_probability_threshold.py
@@ -4,7 +4,7 @@ An early classifier using a prediction probability threshold with a time series
 classifier.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["ProbabilityThresholdEarlyClassifier"]
 
 import copy

--- a/aeon/classification/early_classification/_teaser.py
+++ b/aeon/classification/early_classification/_teaser.py
@@ -4,7 +4,7 @@ An early classifier using a one class SVM's to determine decision safety with a
 time series classifier.
 """
 
-__author__ = ["MatthewMiddlehurst", "patrickzib"]
+__maintainer__ = []
 __all__ = ["TEASER"]
 
 import copy

--- a/aeon/classification/early_classification/base.py
+++ b/aeon/classification/early_classification/base.py
@@ -24,7 +24,7 @@ State:
 __all__ = [
     "BaseEarlyClassifier",
 ]
-__author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 import time
 from abc import ABC, abstractmethod

--- a/aeon/classification/early_classification/tests/test_all_early_classifiers.py
+++ b/aeon/classification/early_classification/tests/test_all_early_classifiers.py
@@ -1,6 +1,6 @@
 """Unit tests for early classifier input output."""
 
-__author__ = ["mloning", "TonyBagnall", "fkiraly", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 import numpy as np
 from sklearn.utils._testing import set_random_state

--- a/aeon/classification/feature_based/_catch22.py
+++ b/aeon/classification/feature_based/_catch22.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the Catch22 transformer and an estimator.
 """
 
-__author__ = ["MatthewMiddlehurst", "RavenRudi", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["Catch22Classifier"]
 
 import numpy as np

--- a/aeon/classification/feature_based/_fresh_prince.py
+++ b/aeon/classification/feature_based/_fresh_prince.py
@@ -4,7 +4,7 @@ Pipeline classifier using the full set of TSFresh features and a
 RotationForestClassifier.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["FreshPRINCEClassifier"]
 
 import warnings

--- a/aeon/classification/feature_based/_matrix_profile_classifier.py
+++ b/aeon/classification/feature_based/_matrix_profile_classifier.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the Matrix Profile transformer and an estimator.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["MatrixProfileClassifier"]
 
 import numpy as np

--- a/aeon/classification/feature_based/_summary_classifier.py
+++ b/aeon/classification/feature_based/_summary_classifier.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the basic summary statistics and an estimator.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["SummaryClassifier"]
 
 import numpy as np

--- a/aeon/classification/feature_based/_tsfresh_classifier.py
+++ b/aeon/classification/feature_based/_tsfresh_classifier.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the TSFresh transformer and an estimator.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["TSFreshClassifier"]
 
 import warnings

--- a/aeon/classification/hybrid/_hivecote_v1.py
+++ b/aeon/classification/hybrid/_hivecote_v1.py
@@ -4,7 +4,7 @@ Hybrid ensemble of classifiers from 4 separate time series classification
 representations, using the weighted probabilistic CAWPE as an ensemble controller.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["HIVECOTEV1"]
 
 from datetime import datetime

--- a/aeon/classification/hybrid/_hivecote_v2.py
+++ b/aeon/classification/hybrid/_hivecote_v2.py
@@ -4,7 +4,7 @@ Upgraded hybrid ensemble of classifiers from 4 separate time series classificati
 representations, using the weighted probabilistic CAWPE as an ensemble controller.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["HIVECOTEV2"]
 
 from datetime import datetime

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -1,6 +1,6 @@
 """Randomised Interval-Shapelet Transformation (RIST) pipeline estimators."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 
 
 from sklearn.ensemble import ExtraTreesClassifier

--- a/aeon/classification/interval_based/_cif.py
+++ b/aeon/classification/interval_based/_cif.py
@@ -3,7 +3,7 @@
 Interval based CIF classifier extracting catch22 features from random intervals.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["CanonicalIntervalForestClassifier"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_drcif.py
+++ b/aeon/classification/interval_based/_drcif.py
@@ -4,7 +4,7 @@ Interval-based DrCIF classifier extracting catch22 features from random interval
 periodogram and differences representations as well as the base series.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["DrCIFClassifier"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_interval_forest.py
+++ b/aeon/classification/interval_based/_interval_forest.py
@@ -1,6 +1,6 @@
 """Interval forest classifier."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["IntervalForestClassifier"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_interval_pipelines.py
+++ b/aeon/classification/interval_based/_interval_pipelines.py
@@ -3,7 +3,7 @@
 Pipeline classifiers which extract interval features then build a base estimator.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RandomIntervalClassifier", "SupervisedIntervalClassifier"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_rise.py
+++ b/aeon/classification/interval_based/_rise.py
@@ -1,6 +1,6 @@
 """Random Interval Spectral Ensemble (RISE) classifier."""
 
-__author__ = ["TonyBagnall", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RandomIntervalSpectralEnsembleClassifier"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_rstsf.py
+++ b/aeon/classification/interval_based/_rstsf.py
@@ -1,6 +1,6 @@
 """Random Supervised Time Series Forest (RSTSF) Classifier."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RSTSF"]
 
 import numpy as np

--- a/aeon/classification/interval_based/_stsf.py
+++ b/aeon/classification/interval_based/_stsf.py
@@ -4,7 +4,7 @@ Interval-based STSF classifier extracting summary features from intervals select
 through a supervised process.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["SupervisedTimeSeriesForest"]
 
 

--- a/aeon/classification/interval_based/_tsf.py
+++ b/aeon/classification/interval_based/_tsf.py
@@ -3,7 +3,7 @@
 Interval-based TSF classifier, extracts basic summary features from random intervals.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["TimeSeriesForestClassifier"]
 
 import numpy as np

--- a/aeon/classification/ordinal_classification/_ordinal_tde.py
+++ b/aeon/classification/ordinal_classification/_ordinal_tde.py
@@ -4,7 +4,7 @@ Dictionary based Ordinal TDE classifiers based on SFA transform. Contains a sing
 IndividualOrdinalTDE and Ordinal TDE.
 """
 
-__author__ = ["RafaelAyllon"]
+__maintainer__ = []
 __all__ = [
     "OrdinalTDE",
     "IndividualOrdinalTDE",

--- a/aeon/classification/shapelet_based/_mrsqm.py
+++ b/aeon/classification/shapelet_based/_mrsqm.py
@@ -1,6 +1,6 @@
 """Multiple Representations Sequence Miner (MrSQM) Classifier."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["MrSQMClassifier"]
 
 import numpy as np

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -4,7 +4,7 @@ A Random Dilated Shapelet Transform classifier pipeline that simply performs a r
 shapelet dilated transform and build (by default) a ridge classifier on the output.
 """
 
-__author__ = ["baraline"]
+__maintainer__ = []
 __all__ = ["RDSTClassifier"]
 
 import numpy as np

--- a/aeon/classification/shapelet_based/_sast_classifier.py
+++ b/aeon/classification/shapelet_based/_sast_classifier.py
@@ -3,7 +3,7 @@
 Pipeline classifier using the SAST transformer and an sklearn classifier.
 """
 
-__author__ = ["MichaelMbouopda"]
+__maintainer__ = []
 __all__ = ["SASTClassifier"]
 
 from operator import itemgetter

--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -4,7 +4,7 @@ Shapelet transform classifier pipeline that simply performs a (configurable) sha
 transform then builds (by default) a rotation forest classifier on the output.
 """
 
-__author__ = ["TonyBagnall", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["ShapeletTransformClassifier"]
 
 import warnings

--- a/aeon/classification/sklearn/_continuous_interval_tree.py
+++ b/aeon/classification/sklearn/_continuous_interval_tree.py
@@ -5,7 +5,7 @@ in the time series forest interval based classification algorithm. Fits sklearn
 conventions.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["ContinuousIntervalTree"]
 
 import math

--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -4,7 +4,7 @@ A Rotation Forest aeon implementation for continuous values only. Fits sklearn
 conventions.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RotationForestClassifier"]
 
 import time

--- a/aeon/classification/sklearn/tests/test_all_classifiers.py
+++ b/aeon/classification/sklearn/tests/test_all_classifiers.py
@@ -1,6 +1,6 @@
 """Unit tests for sklearn classifiers."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 
 from sklearn.utils.estimator_checks import parametrize_with_checks
 

--- a/aeon/classification/tests/test_all_classifiers.py
+++ b/aeon/classification/tests/test_all_classifiers.py
@@ -1,6 +1,6 @@
 """Unit tests for classifier/regressor input output."""
 
-__author__ = ["mloning", "TonyBagnall", "fkiraly"]
+__maintainer__ = []
 
 import inspect
 

--- a/aeon/classification/tests/test_base.py
+++ b/aeon/classification/tests/test_base.py
@@ -17,7 +17,7 @@ from aeon.testing.utils.data_gen._collection import (
 )
 from aeon.utils.conversion._convert_collection import COLLECTIONS_DATA_TYPES
 
-__author__ = ["mloning", "fkiraly", "TonyBagnall", "MatthewMiddlehurst", "achieveordie"]
+__maintainer__ = []
 
 
 multivariate_message = r"multivariate series"

--- a/aeon/classification/tests/test_sklearn_compatability.py
+++ b/aeon/classification/tests/test_sklearn_compatability.py
@@ -1,6 +1,6 @@
 """Unit tests for aeon classifier compatability with sklearn interfaces."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = [
     "test_sklearn_cross_validation",
     "test_sklearn_cross_validation_iterators",

--- a/aeon/clustering/__init__.py
+++ b/aeon/clustering/__init__.py
@@ -9,7 +9,6 @@ __all__ = [
     "TimeSeriesKShapes",
     "TimeSeriesKernelKMeans",
 ]
-__author__ = ["chrisholder", "TonyBagnall"]
 
 from aeon.clustering._clara import TimeSeriesCLARA
 from aeon.clustering._clarans import TimeSeriesCLARANS

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -1,6 +1,6 @@
 """Time series kmedoids."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import Callable, Union
 

--- a/aeon/clustering/_clarans.py
+++ b/aeon/clustering/_clarans.py
@@ -1,6 +1,6 @@
 """Time series kmedoids."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 import math
 from typing import Callable, Union

--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -1,6 +1,6 @@
 """Time series kmeans."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import Callable, Union
 

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -1,6 +1,6 @@
 """Time series kmedoids."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 import warnings
 from typing import Callable, Tuple, Union

--- a/aeon/clustering/averaging/_averaging.py
+++ b/aeon/clustering/averaging/_averaging.py
@@ -1,6 +1,6 @@
 """Clustering averaging metrics."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import Callable, Dict
 

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder"]
+__maintainer__ = []
 
 from typing import Tuple
 

--- a/aeon/clustering/base.py
+++ b/aeon/clustering/base.py
@@ -1,6 +1,6 @@
 """Base class for clustering."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["BaseClusterer"]
 
 import time

--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -1,6 +1,6 @@
 """Deep Learning Auto-Encoder using FCN Network."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["AEFCNClusterer"]
 
 import gc

--- a/aeon/clustering/deep_learning/_ae_resnet.py
+++ b/aeon/clustering/deep_learning/_ae_resnet.py
@@ -1,6 +1,6 @@
 """Residual Network (ResNet) for clustering."""
 
-__author__ = ["xiaopu222"]
+__maintainer__ = []
 __all__ = ["AEResNetClusterer"]
 
 import gc

--- a/aeon/clustering/deep_learning/base.py
+++ b/aeon/clustering/deep_learning/base.py
@@ -1,6 +1,6 @@
 """Base class for deep clustering."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 from abc import ABC, abstractmethod
 

--- a/aeon/clustering/deep_learning/tests/test_deep_clusterer_base.py
+++ b/aeon/clustering/deep_learning/tests/test_deep_clusterer_base.py
@@ -9,7 +9,7 @@ from aeon.testing.mock_estimators import MockDeepClusterer
 from aeon.testing.utils.data_gen import make_example_2d_numpy
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 
 @pytest.mark.skipif(

--- a/aeon/datasets/_dataframe_loaders.py
+++ b/aeon/datasets/_dataframe_loaders.py
@@ -1,12 +1,6 @@
 """Legacy functions that load collections of time series into nested dataframes."""
 
-__author__ = [
-    "Emiliathewolf",
-    "TonyBagnall",
-    "jasonlines",
-    "achieveordie",
-]
-
+__maintainer__ = []
 __all__ = [
     "load_from_tsfile_to_dataframe",
     "load_from_arff_to_dataframe",

--- a/aeon/datasets/_single_problem_loaders.py
+++ b/aeon/datasets/_single_problem_loaders.py
@@ -1,20 +1,6 @@
 """Utilities for loading datasets."""
 
-__author__ = [
-    "mloning",
-    "sajaysurya",
-    "big-o",
-    "SebasKoel",
-    "Emiliathewolf",
-    "TonyBagnall",
-    "yairbeer",
-    "patrickZIB",
-    "aiwalter",
-    "jasonlines",
-    "achieveordie",
-    "ciaran-g",
-]
-
+__maintainer__ = []
 __all__ = [
     "load_airline",
     "load_plaid",

--- a/aeon/datasets/dataset_collections.py
+++ b/aeon/datasets/dataset_collections.py
@@ -26,7 +26,7 @@ Forecasting
 
 """
 
-__author__ = ["Tony Bagnall"]
+__maintainer__ = []
 __all__ = [
     "get_downloaded_tsc_tsr_datasets",
     "get_downloaded_tsf_datasets",

--- a/aeon/datasets/tests/test_data_loaders.py
+++ b/aeon/datasets/tests/test_data_loaders.py
@@ -1,6 +1,6 @@
 """Test functions for data input and output."""
 
-__author__ = ["SebasKoel", "Emiliathewolf", "TonyBagnall", "jasonlines", "achieveordie"]
+__maintainer__ = []
 
 __all__ = []
 

--- a/aeon/datatypes/__init__.py
+++ b/aeon/datatypes/__init__.py
@@ -1,7 +1,5 @@
 """Module exports: data type definitions, checks, validation, fixtures, converters."""
 
-__author__ = ["fkiraly"]
-
 from aeon.datatypes._check import (
     check_is_mtype,
     check_is_scitype,

--- a/aeon/datatypes/_check.py
+++ b/aeon/datatypes/_check.py
@@ -14,7 +14,7 @@ mtype(obj, as_scitype: str = None)
     infer the mtype of obj, considering it as as_scitype
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "check_is_mtype",

--- a/aeon/datatypes/_convert.py
+++ b/aeon/datatypes/_convert.py
@@ -56,7 +56,7 @@ str - the type to convert "obj" to, a valid mtype string
     or None, if obj is None
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "convert",

--- a/aeon/datatypes/_convert_utils/_convert.py
+++ b/aeon/datatypes/_convert_utils/_convert.py
@@ -1,6 +1,6 @@
 """Conversion utilities for mtypes."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 
 def _concat(fun1, fun2):

--- a/aeon/datatypes/_examples.py
+++ b/aeon/datatypes/_examples.py
@@ -14,7 +14,7 @@ the representation is considered "lossy" if the representation is incomplete
 
 from aeon.datatypes._registry import mtype_to_scitype
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "get_examples",

--- a/aeon/datatypes/_hierarchical/_check.py
+++ b/aeon/datatypes/_hierarchical/_check.py
@@ -37,7 +37,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "n_panels": int, number of flat panels in the hierarchical panel
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["check_dict"]
 

--- a/aeon/datatypes/_panel/_check.py
+++ b/aeon/datatypes/_panel/_check.py
@@ -35,7 +35,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "n_instances": int, number of instances in the panel
 """
 
-__author__ = ["fkiraly", "tonybagnall"]
+__maintainer__ = []
 
 __all__ = ["check_dict"]
 

--- a/aeon/datatypes/_proba/_check.py
+++ b/aeon/datatypes/_proba/_check.py
@@ -31,7 +31,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "has_nans": bool, True iff the series contains NaN values
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["check_dict"]
 

--- a/aeon/datatypes/_proba/_convert.py
+++ b/aeon/datatypes/_proba/_convert.py
@@ -26,7 +26,7 @@ ValueError and TypeError, if requested conversion is not possible
                             (depending on conversion logic)
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["convert_dict"]
 

--- a/aeon/datatypes/_series/_check.py
+++ b/aeon/datatypes/_series/_check.py
@@ -32,7 +32,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "has_nans": bool, True iff the series contains NaN values
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["check_dict"]
 

--- a/aeon/datatypes/_series/_convert.py
+++ b/aeon/datatypes/_series/_convert.py
@@ -26,7 +26,7 @@ ValueError and TypeError, if requested conversion is not possible
                             (depending on conversion logic)
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["convert_dict"]
 

--- a/aeon/datatypes/_series/_mtypes.py
+++ b/aeon/datatypes/_series/_mtypes.py
@@ -21,7 +21,7 @@ Raises
 TypeError, if scitype cannot be inferred
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["infer_mtype_dict"]
 

--- a/aeon/datatypes/_series_as_panel/_convert.py
+++ b/aeon/datatypes/_series_as_panel/_convert.py
@@ -13,7 +13,7 @@ convert_Hierarchical_to_Panel(obj, store=None)
     converts to pd.DataFrame based data container in the target scitype
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/datatypes/_table/_check.py
+++ b/aeon/datatypes/_table/_check.py
@@ -32,7 +32,7 @@ metadata: dict - metadata about obj if valid, otherwise None
         "n_instances": int, number of instances/rows in the table
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["check_dict"]
 

--- a/aeon/datatypes/_table/_convert.py
+++ b/aeon/datatypes/_table/_convert.py
@@ -26,7 +26,7 @@ ValueError and TypeError, if requested conversion is not possible
                             (depending on conversion logic)
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["convert_dict"]
 

--- a/aeon/datatypes/tests/test_check.py
+++ b/aeon/datatypes/tests/test_check.py
@@ -1,6 +1,6 @@
 """Testing machine type checkers for scitypes."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/datatypes/tests/test_convert.py
+++ b/aeon/datatypes/tests/test_convert.py
@@ -1,6 +1,6 @@
 """Testing machine type converters for scitypes."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 from aeon.datatypes import DATATYPE_REGISTER, scitype_to_mtype
 from aeon.datatypes._convert import _conversions_defined, convert

--- a/aeon/datatypes/tests/test_convert_to.py
+++ b/aeon/datatypes/tests/test_convert_to.py
@@ -1,6 +1,6 @@
 """Testing machine type converters for scitypes - covert_to utility."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 from aeon.datatypes._convert import convert_to
 from aeon.datatypes._examples import get_examples

--- a/aeon/datatypes/tests/test_lookup.py
+++ b/aeon/datatypes/tests/test_lookup.py
@@ -1,6 +1,6 @@
 """Testing mtype/scitypes lookup."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pytest
 

--- a/aeon/datatypes/tests/test_vectorize.py
+++ b/aeon/datatypes/tests/test_vectorize.py
@@ -1,6 +1,6 @@
 """Testing vectorization via VectorizedDF."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/distances/__init__.py
+++ b/aeon/distances/__init__.py
@@ -1,7 +1,5 @@
 """Distance computation."""
 
-__author__ = ["chrisholder", "TonyBagnall", "baraline", "akshatvishu"]
-
 __all__ = [
     "create_bounding_matrix",
     "squared_distance",

--- a/aeon/distances/_adtw.py
+++ b/aeon/distances/_adtw.py
@@ -1,6 +1,6 @@
 r"""Amercing dynamic time warping (ADTW) between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_alignment_paths.py
+++ b/aeon/distances/_alignment_paths.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_bounding_matrix.py
+++ b/aeon/distances/_bounding_matrix.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder"]
+__maintainer__ = []
 
 import math
 

--- a/aeon/distances/_ddtw.py
+++ b/aeon/distances/_ddtw.py
@@ -1,6 +1,6 @@
 """Derivative Dynamic Time Warping (DDTW) distance."""
 
-__author__ = ["chrisholder", "tonybagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_distance.py
+++ b/aeon/distances/_distance.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "TonyBagnall", "akshatvishu"]
+__maintainer__ = []
 
 from typing import Any, Callable, List, Tuple, Union
 

--- a/aeon/distances/_dtw.py
+++ b/aeon/distances/_dtw.py
@@ -1,6 +1,6 @@
 r"""Dynamic time warping (DTW) between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_edr.py
+++ b/aeon/distances/_edr.py
@@ -1,6 +1,6 @@
 """Edit distance for real sequences (EDR) between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_erp.py
+++ b/aeon/distances/_erp.py
@@ -1,6 +1,6 @@
 r"""Edit real penalty (erp) distance between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple, Union
 

--- a/aeon/distances/_euclidean.py
+++ b/aeon/distances/_euclidean.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "tonybagnall"]
+__maintainer__ = []
 
 import numpy as np
 from numba import njit

--- a/aeon/distances/_lcss.py
+++ b/aeon/distances/_lcss.py
@@ -1,6 +1,6 @@
 r"""Longest common subsequence (LCSS) between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_manhattan.py
+++ b/aeon/distances/_manhattan.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "TonyBagnall", "baraline"]
+__maintainer__ = []
 
 import numpy as np
 from numba import njit

--- a/aeon/distances/_minkowski.py
+++ b/aeon/distances/_minkowski.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "TonyBagnall", "akshatvishu"]
+__maintainer__ = []
 
 import numpy as np
 from numba import njit

--- a/aeon/distances/_msm.py
+++ b/aeon/distances/_msm.py
@@ -1,6 +1,6 @@
 """Move-split-merge (MSM) distance between two time series."""
 
-__author__ = ["chrisholder", "jlines", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -1,6 +1,6 @@
 r"""Shape Dynamic time warping (ShapeDTW) between two time series."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_squared.py
+++ b/aeon/distances/_squared.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder", "tonybagnall"]
+__maintainer__ = []
 
 import numpy as np
 from numba import njit

--- a/aeon/distances/_twe.py
+++ b/aeon/distances/_twe.py
@@ -1,6 +1,6 @@
 """Time Warp Edit (TWE) distance between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_wddtw.py
+++ b/aeon/distances/_wddtw.py
@@ -1,6 +1,6 @@
 """Weighted derivative dynamic time warping (wddtw) distance between two series."""
 
-__author__ = ["chrisholder", "tonybagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/_wdtw.py
+++ b/aeon/distances/_wdtw.py
@@ -1,6 +1,6 @@
 r"""Weighted dynamic time warping (WDTW) distance between two time series."""
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import List, Tuple
 

--- a/aeon/distances/tests/test_bounding.py
+++ b/aeon/distances/tests/test_bounding.py
@@ -1,4 +1,4 @@
-__author__ = ["chrisholder"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/distances/tests/test_distance_correctness.py
+++ b/aeon/distances/tests/test_distance_correctness.py
@@ -4,7 +4,7 @@ Compare the distance calculations on the 1D and 2D (d,m) format input against th
 results generated with tsml, in distances.tests.TestDistances.
 """
 
-__author__ = ["chrisholder", "TonyBagnall"]
+__maintainer__ = []
 
 from numpy.testing import assert_almost_equal
 

--- a/aeon/exceptions.py
+++ b/aeon/exceptions.py
@@ -1,6 +1,5 @@
 """Custom exceptions and warnings."""
 
-__author__ = "mloning"
 __all__ = ["NotEvaluatedError", "NotFittedError", "FitFailedWarning"]
 
 

--- a/aeon/forecasting/ardl.py
+++ b/aeon/forecasting/ardl.py
@@ -10,7 +10,7 @@ from aeon.forecasting.base.adapters import _StatsModelsAdapter
 from aeon.forecasting.base.adapters._statsmodels import _coerce_int_to_range_index
 
 _all_ = ["ARDL"]
-__author__ = ["kcc-lion"]
+__maintainer__ = []
 
 
 class ARDL(_StatsModelsAdapter):

--- a/aeon/forecasting/arima.py
+++ b/aeon/forecasting/arima.py
@@ -1,6 +1,6 @@
 """Implements autoregressive integrated moving average (ARIMA) models."""
 
-__author__ = ["mloning", "hyang1996", "fkiraly", "ilkersigirci"]
+__maintainer__ = []
 __all__ = ["AutoARIMA", "ARIMA"]
 
 from aeon.forecasting.base.adapters._pmdarima import _PmdArimaAdapter

--- a/aeon/forecasting/base/_aeon.py
+++ b/aeon/forecasting/base/_aeon.py
@@ -1,6 +1,6 @@
 """aeon window forecaster base class."""
 
-__author__ = ["@mloning", "@big-o", "fkiraly"]
+__maintainer__ = []
 __all__ = ["_BaseWindowForecaster"]
 
 import numpy as np

--- a/aeon/forecasting/base/_base.py
+++ b/aeon/forecasting/base/_base.py
@@ -32,7 +32,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["mloning", "big-o", "fkiraly", "sveameyer13", "miraep8"]
+__maintainer__ = []
 
 __all__ = ["BaseForecaster"]
 

--- a/aeon/forecasting/base/_delegate.py
+++ b/aeon/forecasting/base/_delegate.py
@@ -5,7 +5,7 @@ For that purpose, inherit from this estimator and then override only the methods
     that are not delegated.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["_DelegatedForecaster"]
 
 from aeon.forecasting.base import BaseForecaster

--- a/aeon/forecasting/base/_fh.py
+++ b/aeon/forecasting/base/_fh.py
@@ -1,6 +1,6 @@
 """Implements functionality for specifying forecast horizons in aeon."""
 
-__author__ = ["mloning", "fkiraly", "eenticott-shell", "khrapovs"]
+__maintainer__ = []
 __all__ = ["ForecastingHorizon"]
 
 from functools import lru_cache

--- a/aeon/forecasting/base/_meta.py
+++ b/aeon/forecasting/base/_meta.py
@@ -1,6 +1,6 @@
 """Implements meta forecaster for forecasters composed of other estimators."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["_HeterogenousEnsembleForecaster"]
 
 from joblib import Parallel, delayed

--- a/aeon/forecasting/base/adapters/_fbprophet.py
+++ b/aeon/forecasting/base/adapters/_fbprophet.py
@@ -1,6 +1,6 @@
 """Implements adapter for Facebook prophet to be used in aeon framework."""
 
-__author__ = ["mloning", "aiwalter", "fkiraly"]
+__maintainer__ = []
 __all__ = ["_ProphetAdapter"]
 
 import os

--- a/aeon/forecasting/base/adapters/_pmdarima.py
+++ b/aeon/forecasting/base/adapters/_pmdarima.py
@@ -1,6 +1,6 @@
 """Implements adapter for pmdarima forecasters to be used in aeon framework."""
 
-__author__ = ["mloning", "hyang1996", "kejsitake", "fkiraly"]
+__maintainer__ = []
 __all__ = ["_PmdArimaAdapter"]
 
 import pandas as pd

--- a/aeon/forecasting/base/adapters/_statsforecast.py
+++ b/aeon/forecasting/base/adapters/_statsforecast.py
@@ -1,6 +1,6 @@
 """Implements adapter for StatsForecast forecasters to be used in aeon framework."""
 
-__author__ = ["FedericoGarza"]
+__maintainer__ = []
 __all__ = ["_StatsForecastAdapter"]
 
 

--- a/aeon/forecasting/base/adapters/_statsmodels.py
+++ b/aeon/forecasting/base/adapters/_statsmodels.py
@@ -1,6 +1,6 @@
 """Implements adapter for statsmodels forecasters to be used in aeon framework."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["_StatsModelsAdapter"]
 
 import inspect

--- a/aeon/forecasting/base/adapters/_tbats.py
+++ b/aeon/forecasting/base/adapters/_tbats.py
@@ -1,6 +1,6 @@
 """Implements adapter for using tbats forecasters in aeon framework."""
 
-__author__ = ["mloning", "aiwalter", "k1m190r"]
+__maintainer__ = []
 __all__ = ["_TbatsAdapter"]
 
 import numpy as np

--- a/aeon/forecasting/base/tests/__init__.py
+++ b/aeon/forecasting/base/tests/__init__.py
@@ -1,4 +1,1 @@
 """Tests for the forecaster base module."""
-
-__author__ = ["mloning"]
-__all__ = []

--- a/aeon/forecasting/base/tests/test_base.py
+++ b/aeon/forecasting/base/tests/test_base.py
@@ -1,6 +1,6 @@
 """Testing advanced functionality of the base class."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/forecasting/base/tests/test_fh.py
+++ b/aeon/forecasting/base/tests/test_fh.py
@@ -1,6 +1,6 @@
 """Tests for ForecastingHorizon object."""
 
-__author__ = ["mloning", "khrapovs"]
+__maintainer__ = []
 
 from datetime import timedelta
 

--- a/aeon/forecasting/bats.py
+++ b/aeon/forecasting/bats.py
@@ -6,7 +6,7 @@ transformation, ARMA errors, Trend and Seasonal components.
 Wrapping implementation in [1]_ of method proposed in [2]_.
 """
 
-__author__ = ["Martin Walter"]
+__maintainer__ = []
 __all__ = ["BATS"]
 
 from aeon.forecasting.base.adapters import _TbatsAdapter

--- a/aeon/forecasting/compose/__init__.py
+++ b/aeon/forecasting/compose/__init__.py
@@ -1,7 +1,5 @@
 """Implements composite forecasters."""
 
-__author__ = ["mloning"]
-
 __all__ = [
     "HierarchyEnsembleForecaster",
     "ColumnEnsembleForecaster",

--- a/aeon/forecasting/compose/_bagging.py
+++ b/aeon/forecasting/compose/_bagging.py
@@ -1,6 +1,6 @@
 """Implements Bagging Forecaster."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 from typing import List, Union
 

--- a/aeon/forecasting/compose/_column_ensemble.py
+++ b/aeon/forecasting/compose/_column_ensemble.py
@@ -1,6 +1,6 @@
 """Implements forecaster for applying different univariates by column."""
 
-__author__ = ["GuzalBulatova", "mloning", "fkiraly"]
+__maintainer__ = []
 __all__ = ["ColumnEnsembleForecaster"]
 
 import numpy as np

--- a/aeon/forecasting/compose/_ensemble.py
+++ b/aeon/forecasting/compose/_ensemble.py
@@ -4,7 +4,7 @@ Creates univariate (optionally weighted)
 combination of the predictions from underlying forecasts.
 """
 
-__author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]
+__maintainer__ = []
 __all__ = ["EnsembleForecaster", "AutoEnsembleForecaster"]
 
 import numpy as np

--- a/aeon/forecasting/compose/_grouped.py
+++ b/aeon/forecasting/compose/_grouped.py
@@ -4,7 +4,7 @@ from aeon.base import ALL_TIME_SERIES_TYPES
 from aeon.datatypes import mtype_to_scitype
 from aeon.forecasting.base._delegate import _DelegatedForecaster
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["ForecastByLevel"]
 
 

--- a/aeon/forecasting/compose/_hierarchy_ensemble.py
+++ b/aeon/forecasting/compose/_hierarchy_ensemble.py
@@ -1,6 +1,6 @@
 """Implements forecaster for applying different univariates on hierarchical data."""
 
-__author__ = ["VyomkeshVyas"]
+__maintainer__ = []
 __all__ = ["HierarchyEnsembleForecaster"]
 
 

--- a/aeon/forecasting/compose/_multiplexer.py
+++ b/aeon/forecasting/compose/_multiplexer.py
@@ -4,7 +4,7 @@ from aeon.base import ALL_TIME_SERIES_TYPES, _HeterogenousMetaEstimator
 from aeon.forecasting.base._base import BaseForecaster
 from aeon.forecasting.base._delegate import _DelegatedForecaster
 
-__author__ = ["kkoralturk", "aiwalter", "fkiraly", "miraep8"]
+__maintainer__ = []
 __all__ = ["MultiplexForecaster"]
 
 

--- a/aeon/forecasting/compose/_pipeline.py
+++ b/aeon/forecasting/compose/_pipeline.py
@@ -1,6 +1,6 @@
 """Implements pipelines for forecasting."""
 
-__author__ = ["mloning", "aiwalter"]
+__maintainer__ = []
 __all__ = ["TransformedTargetForecaster", "ForecastingPipeline", "ForecastX"]
 
 import pandas as pd

--- a/aeon/forecasting/compose/_reduce.py
+++ b/aeon/forecasting/compose/_reduce.py
@@ -1,14 +1,6 @@
 """Composition functionality for reduction approaches to forecasting."""
 
-__author__ = [
-    "mloning",
-    "AyushmaanSeth",
-    "kAnand77",
-    "LuisZugasti",
-    "Lovkush-A",
-    "fkiraly",
-]
-
+__maintainer__ = []
 __all__ = [
     "make_reduction",
     "DirectTimeSeriesRegressionForecaster",

--- a/aeon/forecasting/compose/_stack.py
+++ b/aeon/forecasting/compose/_stack.py
@@ -1,6 +1,6 @@
 """Implements forecasters for combining forecasts via stacking."""
 
-__author__ = ["mloning", "fkiraly", "indinewton"]
+__maintainer__ = []
 __all__ = ["StackingForecaster"]
 
 from warnings import warn

--- a/aeon/forecasting/compose/tests/test_autoensemble.py
+++ b/aeon/forecasting/compose/tests/test_autoensemble.py
@@ -1,6 +1,6 @@
 """Unit tests of AutoEnsembleForecaster functionality."""
 
-__author__ = ["mloning", "GuzalBulatova", "aiwalter", "RNKuhns", "AnH0ang"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/forecasting/compose/tests/test_column_ensemble.py
+++ b/aeon/forecasting/compose/tests/test_column_ensemble.py
@@ -1,6 +1,6 @@
 """Unit tests of ColumnEnsembleForecaster functionality."""
 
-__author__ = ["GuzalBulatova", "canbooo", "fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/compose/tests/test_ensemble.py
+++ b/aeon/forecasting/compose/tests/test_ensemble.py
@@ -1,6 +1,6 @@
 """Unit tests of EnsembleForecaster functionality."""
 
-__author__ = ["GuzalBulatova", "RNKuhns"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/compose/tests/test_hierarchy_ensemble.py
+++ b/aeon/forecasting/compose/tests/test_hierarchy_ensemble.py
@@ -1,6 +1,6 @@
 """Unit tests of HierarchyEnsembleForecaster functionality."""
 
-__author__ = ["VyomkeshVyas"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/forecasting/compose/tests/test_multiplex.py
+++ b/aeon/forecasting/compose/tests/test_multiplex.py
@@ -1,6 +1,6 @@
 """Tests for MultiplexForecaster and associated dunders."""
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 
 import pytest
 

--- a/aeon/forecasting/compose/tests/test_pipeline.py
+++ b/aeon/forecasting/compose/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 """Tests for forecasting pipelines."""
 
-__author__ = ["mloning", "fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/forecasting/compose/tests/test_reduce.py
+++ b/aeon/forecasting/compose/tests/test_reduce.py
@@ -1,6 +1,6 @@
 """Test reduce."""
 
-__author__ = ["Lovkush-A", "mloning", "LuisZugasti", "AyushmaanSeth"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/compose/tests/test_reduce_global.py
+++ b/aeon/forecasting/compose/tests/test_reduce_global.py
@@ -1,6 +1,6 @@
 """Test extraction of features across (shifted) windows."""
 
-__author__ = ["danbartl"]
+__maintainer__ = []
 
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 

--- a/aeon/forecasting/conformal.py
+++ b/aeon/forecasting/conformal.py
@@ -4,7 +4,7 @@ Code based partially on NaiveVariance by ilyasmoutawwakil.
 """
 
 __all__ = ["ConformalIntervals"]
-__author__ = ["fkiraly", "bethrice44"]
+__maintainer__ = []
 
 from math import floor
 from warnings import warn

--- a/aeon/forecasting/dynamic_factor.py
+++ b/aeon/forecasting/dynamic_factor.py
@@ -8,7 +8,7 @@ import pandas as pd
 from aeon.forecasting.base.adapters import _StatsModelsAdapter
 
 _all_ = ["DynamicFactor"]
-__author__ = ["Ris-Bali", "lbventura"]
+__maintainer__ = []
 
 
 class DynamicFactor(_StatsModelsAdapter):

--- a/aeon/forecasting/ets.py
+++ b/aeon/forecasting/ets.py
@@ -1,6 +1,6 @@
 """Implements automatic and manually exponential time series smoothing models."""
 
-__author__ = ["hyang1996"]
+__maintainer__ = []
 __all__ = ["AutoETS"]
 
 import warnings

--- a/aeon/forecasting/exp_smoothing.py
+++ b/aeon/forecasting/exp_smoothing.py
@@ -1,7 +1,7 @@
 """Implements Holt-Winters exponential smoothing."""
 
 __all__ = ["ExponentialSmoothing"]
-__author__ = ["mloning", "big-o"]
+__maintainer__ = []
 
 from aeon.forecasting.base.adapters import _StatsModelsAdapter
 

--- a/aeon/forecasting/fbprophet.py
+++ b/aeon/forecasting/fbprophet.py
@@ -1,6 +1,6 @@
 """Implements Prophet forecaster by wrapping fbprophet."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = ["Prophet"]
 
 

--- a/aeon/forecasting/model_evaluation/__init__.py
+++ b/aeon/forecasting/model_evaluation/__init__.py
@@ -1,6 +1,5 @@
 """Implements functionality to evaluate forecasting models."""
 
-__author__ = ["Martin Walter"]
 __all__ = ["evaluate"]
 
 from aeon.forecasting.model_evaluation._functions import evaluate

--- a/aeon/forecasting/model_evaluation/_functions.py
+++ b/aeon/forecasting/model_evaluation/_functions.py
@@ -1,6 +1,6 @@
 """Implements functions to be used in evaluating forecasting models."""
 
-__author__ = ["aiwalter", "mloning", "fkiraly", "topher-lo"]
+__maintainer__ = []
 __all__ = ["evaluate"]
 
 import time

--- a/aeon/forecasting/model_evaluation/tests/test_evaluate.py
+++ b/aeon/forecasting/model_evaluation/tests/test_evaluate.py
@@ -4,7 +4,7 @@ In particular, function `evaluate`, that performs time series
 cross-validation, is tested with various configurations for correct output.
 """
 
-__author__ = ["aiwalter", "mloning", "fkiraly"]
+__maintainer__ = []
 __all__ = [
     "test_evaluate_common_configs",
     "test_evaluate_initial_window",

--- a/aeon/forecasting/model_selection/__init__.py
+++ b/aeon/forecasting/model_selection/__init__.py
@@ -1,6 +1,5 @@
 """Implements functionality for selecting forecasting models."""
 
-__author__ = ["mloning", "kkoralturk"]
 __all__ = [
     "CutoffSplitter",
     "SingleWindowSplitter",

--- a/aeon/forecasting/model_selection/_split.py
+++ b/aeon/forecasting/model_selection/_split.py
@@ -7,7 +7,7 @@ __all__ = [
     "SingleWindowSplitter",
     "temporal_train_test_split",
 ]
-__author__ = ["mloning", "kkoralturk", "khrapovs", "chillerobscuro"]
+__maintainer__ = []
 
 from typing import Iterator, Optional, Tuple, Union
 

--- a/aeon/forecasting/model_selection/_tune.py
+++ b/aeon/forecasting/model_selection/_tune.py
@@ -1,6 +1,6 @@
 """Implements grid search functionality to tune forecasters."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["ForecastingGridSearchCV", "ForecastingRandomizedSearchCV"]
 
 from collections.abc import Sequence

--- a/aeon/forecasting/model_selection/tests/test_split.py
+++ b/aeon/forecasting/model_selection/tests/test_split.py
@@ -1,6 +1,6 @@
 """Tests for splitters."""
 
-__author__ = ["mloning", "kkoralturk", "khrapovs", "fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/model_selection/tests/test_tune.py
+++ b/aeon/forecasting/model_selection/tests/test_tune.py
@@ -1,6 +1,6 @@
 """Test grid search CV."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["test_gscv", "test_rscv"]
 
 import numpy as np

--- a/aeon/forecasting/naive.py
+++ b/aeon/forecasting/naive.py
@@ -1,16 +1,8 @@
 """Implements simple forecasts based on naive assumptions."""
 
+__maintainer__ = []
 __all__ = ["NaiveForecaster", "NaiveVariance"]
-__author__ = [
-    "mloning",
-    "piyush1729",
-    "sri1419",
-    "Flix6x",
-    "aiwalter",
-    "IlyasMoutawwakil",
-    "fkiraly",
-    "bethrice44",
-]
+
 
 import math
 from warnings import warn

--- a/aeon/forecasting/online_learning/__init__.py
+++ b/aeon/forecasting/online_learning/__init__.py
@@ -1,7 +1,5 @@
 """Implments algorithms for creating online ensembles of forecasters."""
 
-__author__ = ["William Zheng"]
-
 __all__ = [
     "NormalHedgeEnsemble",
     "NNLSEnsemble",

--- a/aeon/forecasting/online_learning/_online_ensemble.py
+++ b/aeon/forecasting/online_learning/_online_ensemble.py
@@ -1,6 +1,6 @@
 """Implements framework for applying online ensembling algorithms to forecasters."""
 
-__author__ = ["magittan, mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/online_learning/tests/test_online_learning.py
+++ b/aeon/forecasting/online_learning/tests/test_online_learning.py
@@ -1,6 +1,6 @@
 """Test OnlineEnsembleForecaster."""
 
-__author__ = ["magittan"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/forecasting/reconcile.py
+++ b/aeon/forecasting/reconcile.py
@@ -1,9 +1,7 @@
 """Implements reconciled forecasters for hierarchical data."""
 
+__maintainer__ = []
 __all__ = ["ReconcilerForecaster"]
-__author__ = [
-    "ciaran-g",
-]
 
 
 from warnings import warn

--- a/aeon/forecasting/sarimax.py
+++ b/aeon/forecasting/sarimax.py
@@ -1,7 +1,7 @@
 """Implements SARIMAX."""
 
 __all__ = ["SARIMAX"]
-__author__ = ["TNTran92"]
+__maintainer__ = []
 
 from aeon.forecasting.base.adapters import _StatsModelsAdapter
 

--- a/aeon/forecasting/squaring_residuals.py
+++ b/aeon/forecasting/squaring_residuals.py
@@ -1,7 +1,7 @@
 """Implements the probabilistic Squaring Residuals forecaster."""
 
 __all__ = ["SquaringResiduals"]
-__author__ = ["kcc-lion"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/forecasting/statsforecast.py
+++ b/aeon/forecasting/statsforecast.py
@@ -1,6 +1,6 @@
 """Implements AutoARIMA model from statsforecast by Nixtla."""
 
-__author__ = ["FedericoGarza"]
+__maintainer__ = []
 __all__ = ["StatsForecastAutoARIMA"]
 
 

--- a/aeon/forecasting/stream/_update.py
+++ b/aeon/forecasting/stream/_update.py
@@ -1,6 +1,6 @@
 """Compositors that control stream and refitting behaviour of update."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 

--- a/aeon/forecasting/structural.py
+++ b/aeon/forecasting/structural.py
@@ -1,7 +1,7 @@
 """Wraps the UnobservedComponents (state space) model from statsmodels."""
 
 __all__ = ["UnobservedComponents"]
-__author__ = ["juanitorduz"]
+__maintainer__ = []
 
 import pandas as pd
 

--- a/aeon/forecasting/tbats.py
+++ b/aeon/forecasting/tbats.py
@@ -6,7 +6,7 @@ Seasonality, Box-Cox transformation, ARMA errors, Trend and Seasonal components.
 Wrapping implementation in [1]_ of method proposed in [2]_.
 """
 
-__author__ = ["Martin Walter"]
+__maintainer__ = []
 __all__ = ["TBATS"]
 
 from aeon.forecasting.base.adapters import _TbatsAdapter

--- a/aeon/forecasting/tests/test_all_forecasters.py
+++ b/aeon/forecasting/tests/test_all_forecasters.py
@@ -2,7 +2,7 @@
 
 """
 
-__author__ = ["mloning", "kejsitake", "fkiraly"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_ardl.py
+++ b/aeon/forecasting/tests/test_ardl.py
@@ -1,6 +1,6 @@
 """Tests the ARDL model."""
 
-__author__ = ["kcc-lion"]
+__maintainer__ = []
 
 import pytest
 from numpy.testing import assert_allclose

--- a/aeon/forecasting/tests/test_config.py
+++ b/aeon/forecasting/tests/test_config.py
@@ -1,4 +1,4 @@
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_config_full.py
+++ b/aeon/forecasting/tests/test_config_full.py
@@ -1,4 +1,4 @@
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_ets.py
+++ b/aeon/forecasting/tests/test_ets.py
@@ -1,6 +1,6 @@
 """ETS tests."""
 
-__author__ = ["Hongyi Yang"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_exp_smoothing.py
+++ b/aeon/forecasting/tests/test_exp_smoothing.py
@@ -1,6 +1,6 @@
 """Test exponential smoothing forecasters."""
 
-__author__ = ["mloning", "@big-o"]
+__maintainer__ = []
 __all__ = ["test_set_params"]
 
 import pytest

--- a/aeon/forecasting/tests/test_interval_wrappers.py
+++ b/aeon/forecasting/tests/test_interval_wrappers.py
@@ -1,6 +1,6 @@
 """Tests the conformal interval wrapper."""
 
-__author__ = ["fkiraly", "bethrice44"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_naive.py
+++ b/aeon/forecasting/tests/test_naive.py
@@ -1,6 +1,6 @@
 """Tests simple forecasts based on naive assumptions."""
 
-__author__ = ["mloning", "Piyush Gade", "Flix6x"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_prophet.py
+++ b/aeon/forecasting/tests/test_prophet.py
@@ -2,7 +2,7 @@
 
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/forecasting/tests/test_reconcile.py
+++ b/aeon/forecasting/tests/test_reconcile.py
@@ -1,6 +1,6 @@
 """Tests for hierarchical reconciler forecasters."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/forecasting/tests/test_sarimax.py
+++ b/aeon/forecasting/tests/test_sarimax.py
@@ -1,6 +1,6 @@
 """Tests the SARIMAX model."""
 
-__author__ = ["TNTran92"]
+__maintainer__ = []
 
 import pytest
 from numpy.testing import assert_allclose

--- a/aeon/forecasting/tests/test_structural.py
+++ b/aeon/forecasting/tests/test_structural.py
@@ -1,6 +1,6 @@
 """UnobservedComponents Tests."""
 
-__author__ = ["juanitorduz"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_theta.py
+++ b/aeon/forecasting/tests/test_theta.py
@@ -2,7 +2,7 @@
 
 """
 
-__author__ = ["@big-o", "kejsitake"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/forecasting/tests/test_trend.py
+++ b/aeon/forecasting/tests/test_trend.py
@@ -1,6 +1,6 @@
 """Test trend forecasters."""
 
-__author__ = ["mloning", "fkiraly"]
+__maintainer__ = []
 __all__ = ["get_expected_polynomial_coefs"]
 
 import numpy as np

--- a/aeon/forecasting/tests/test_var.py
+++ b/aeon/forecasting/tests/test_var.py
@@ -1,6 +1,6 @@
 """Tests the VAR model."""
 
-__author__ = ["thayeylolu"]
+__maintainer__ = []
 import numpy as np
 import pandas as pd
 import pytest

--- a/aeon/forecasting/tests/test_varmax.py
+++ b/aeon/forecasting/tests/test_varmax.py
@@ -1,6 +1,6 @@
 """Tests the VARMAX model."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/forecasting/tests/test_vecm.py
+++ b/aeon/forecasting/tests/test_vecm.py
@@ -1,6 +1,6 @@
 """Tests the VAR model."""
 
-__author__ = ["thayeylolu", "AurumnPegasus"]
+__maintainer__ = []
 import numpy as np
 import pandas as pd
 import pytest

--- a/aeon/forecasting/tests/test_window_forecasters.py
+++ b/aeon/forecasting/tests/test_window_forecasters.py
@@ -1,6 +1,6 @@
 """Tests for window forecasters."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/forecasting/theta.py
+++ b/aeon/forecasting/theta.py
@@ -1,7 +1,7 @@
 """Theta forecasters."""
 
 __all__ = ["ThetaForecaster", "ThetaModularForecaster"]
-__author__ = ["big-o", "mloning", "kejsitake", "fkiraly", "GuzalBulatova"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/forecasting/trend.py
+++ b/aeon/forecasting/trend.py
@@ -1,6 +1,6 @@
 """Implements trend based forecasters."""
 
-__author__ = ["tensorflow-as-tf", "mloning", "aiwalter", "fkiraly"]
+__maintainer__ = []
 __all__ = ["TrendForecaster", "PolynomialTrendForecaster", "STLForecaster"]
 
 import pandas as pd

--- a/aeon/forecasting/var.py
+++ b/aeon/forecasting/var.py
@@ -1,7 +1,7 @@
 """Implements VAR Model as interface to statsmodels."""
 
 __all__ = ["VAR"]
-__author__ = ["thayeylolu", "aiwalter", "lbventura"]
+__maintainer__ = []
 
 import itertools
 from collections import OrderedDict

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -1,7 +1,7 @@
 """Vector Autoregressive Moving Average with eXogenous regressors model (VARMAX)."""
 
 __all__ = ["VARMAX"]
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 
 import warnings
 

--- a/aeon/forecasting/vecm.py
+++ b/aeon/forecasting/vecm.py
@@ -1,7 +1,7 @@
 """VECM Forecaster."""
 
 __all__ = ["VECM"]
-__author__ = ["thayeylolu", "AurumnPegasus"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/networks/_ae_fcn.py
+++ b/aeon/networks/_ae_fcn.py
@@ -1,6 +1,6 @@
 """Auto-Encoder using Fully Convolutional Network (FCN)."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/networks/_cnn.py
+++ b/aeon/networks/_cnn.py
@@ -1,6 +1,6 @@
 """Time Convolutional Neural Network (CNN) (minus the final output layer)."""
 
-__author__ = ["James-Large", "Withington", "TonyBagnall", "hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_encoder.py
+++ b/aeon/networks/_encoder.py
@@ -1,6 +1,6 @@
 """Encoder Classifier."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_fcn.py
+++ b/aeon/networks/_fcn.py
@@ -1,6 +1,6 @@
 """Fully Convolutional Network (FCN) (minus the final output layer)."""
 
-__author__ = ["James-Large", "AurumnPegasus", "hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_inception.py
+++ b/aeon/networks/_inception.py
@@ -1,6 +1,6 @@
 """Inception Network."""
 
-__author__ = ["James-Large", "Withington", "TonyBagnall", "hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_lite.py
+++ b/aeon/networks/_lite.py
@@ -1,6 +1,6 @@
 """LITE Network."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_mlp.py
+++ b/aeon/networks/_mlp.py
@@ -1,6 +1,6 @@
 """Multi Layer Perceptron (MLP) (minus the final output layer)."""
 
-__author__ = ["James-Large", "Withington", "AurumnPegasus"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_resnet.py
+++ b/aeon/networks/_resnet.py
@@ -1,6 +1,6 @@
 """Residual Network (ResNet) (minus the final output layer)."""
 
-__author__ = ["James Large", "Withington", "nilesh05apr", "hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.networks.base import BaseDeepNetwork
 

--- a/aeon/networks/_tapnet.py
+++ b/aeon/networks/_tapnet.py
@@ -1,8 +1,7 @@
 """Time Convolutional Neural Network (CNN) (minus the final output layer)."""
 
-__author__ = [
-    "Jack Russon",
-]
+__maintainer__ = []
+
 
 import math
 

--- a/aeon/networks/base.py
+++ b/aeon/networks/base.py
@@ -1,6 +1,6 @@
 """Abstract base class for deep learning networks."""
 
-__author__ = ["hadifawaz1999", "Withington", "TonyBagnall"]
+__maintainer__ = []
 
 from abc import ABC, abstractmethod
 

--- a/aeon/networks/tests/test_all_networks.py
+++ b/aeon/networks/tests/test_all_networks.py
@@ -5,7 +5,7 @@ import pytest
 from aeon import networks
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 
 @pytest.mark.skipif(

--- a/aeon/networks/tests/test_network_base.py
+++ b/aeon/networks/tests/test_network_base.py
@@ -4,7 +4,7 @@ from aeon.networks.base import BaseDeepNetwork
 from aeon.testing.utils.data_gen import make_example_3d_numpy
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 
 class DummyDeepNetwork(BaseDeepNetwork):

--- a/aeon/performance_metrics/base/__init__.py
+++ b/aeon/performance_metrics/base/__init__.py
@@ -1,6 +1,5 @@
 """Base class for defining performance metrics."""
 
-__author__ = ["Ryan Kuhns"]
 __all__ = ["BaseMetric"]
 
 from aeon.performance_metrics.base._base import BaseMetric

--- a/aeon/performance_metrics/base/_base.py
+++ b/aeon/performance_metrics/base/_base.py
@@ -1,6 +1,6 @@
 """Implements base class for defining performance metric in aeon."""
 
-__author__ = ["rnkuhns", "fkiraly"]
+__maintainer__ = []
 __all__ = ["BaseMetric"]
 
 from aeon.base import BaseObject

--- a/aeon/performance_metrics/clustering.py
+++ b/aeon/performance_metrics/clustering.py
@@ -1,6 +1,6 @@
 """Clustering performance metric functions."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 
 __all__ = ["clustering_accuracy_score"]
 

--- a/aeon/performance_metrics/forecasting/__init__.py
+++ b/aeon/performance_metrics/forecasting/__init__.py
@@ -6,7 +6,6 @@ Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
 the lower the better.
 """
 
-__author__ = ["mloning", "Tomasz Chodakowski", "aiwalter", "RNKuhns"]
 __all__ = [
     "make_forecasting_scorer",
     "MeanAbsoluteScaledError",

--- a/aeon/performance_metrics/forecasting/_classes.py
+++ b/aeon/performance_metrics/forecasting/_classes.py
@@ -40,7 +40,7 @@ from aeon.performance_metrics.forecasting._functions import (
     relative_loss,
 )
 
-__author__ = ["mloning", "Tomasz Chodakowski", "RNKuhns", "fkiraly"]
+__maintainer__ = []
 __all__ = [
     "make_forecasting_scorer",
     "MeanAbsoluteScaledError",

--- a/aeon/performance_metrics/forecasting/_functions.py
+++ b/aeon/performance_metrics/forecasting/_functions.py
@@ -17,7 +17,7 @@ from sklearn.utils.validation import check_consistent_length
 from aeon.utils.stats import _weighted_geometric_mean
 from aeon.utils.validation.series import check_series
 
-__author__ = ["mloning", "Tomasz Chodakowski", "RNKuhns"]
+__maintainer__ = []
 __all__ = [
     "relative_loss",
     "mean_linex_error",

--- a/aeon/performance_metrics/forecasting/probabilistic/__init__.py
+++ b/aeon/performance_metrics/forecasting/probabilistic/__init__.py
@@ -6,8 +6,6 @@ Function named as ``*_error`` or ``*_loss`` return a scalar value to minimize:
 the lower the better.
 """
 
-__author__ = ["euanenticott-shell"]
-
 __all__ = [
     "_BaseProbaForecastingErrorMetric",
     "PinballLoss",

--- a/aeon/performance_metrics/segmentation/__init__.py
+++ b/aeon/performance_metrics/segmentation/__init__.py
@@ -5,5 +5,3 @@ from aeon.performance_metrics.segmentation.metrics import (  # noqa
     hausdorff_error,
     prediction_ratio,
 )
-
-__author__ = ["lmmentel"]

--- a/aeon/performance_metrics/segmentation/metrics.py
+++ b/aeon/performance_metrics/segmentation/metrics.py
@@ -10,7 +10,7 @@ import numpy.typing as npt
 from scipy.spatial.distance import directed_hausdorff
 from sklearn.utils import check_array
 
-__author__ = ["lmmentel"]
+__maintainer__ = []
 
 
 def count_error(

--- a/aeon/performance_metrics/stats.py
+++ b/aeon/performance_metrics/stats.py
@@ -1,6 +1,6 @@
 """Functions to compute stats and get p-values."""
 
-__author__ = ["SveaMeyer13", "dguijo", "TonyBagnall"]
+__maintainer__ = []
 
 __all__ = ["check_friedman", "nemenyi_test", "wilcoxon_test"]
 

--- a/aeon/performance_metrics/tests/test_clustering_metrics.py
+++ b/aeon/performance_metrics/tests/test_clustering_metrics.py
@@ -1,6 +1,6 @@
 """Tests for performance metric functions."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/performance_metrics/tests/test_performance_metrics_forecasting.py
+++ b/aeon/performance_metrics/tests/test_performance_metrics_forecasting.py
@@ -1,4 +1,4 @@
-__author__ = ["Tomasz Chodakowski", "Ryan Kuhns"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/pipeline/_make_pipeline.py
+++ b/aeon/pipeline/_make_pipeline.py
@@ -1,6 +1,6 @@
 """Pipeline making utility."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 
 def make_pipeline(*steps):

--- a/aeon/pipeline/_sklearn_to_aeon.py
+++ b/aeon/pipeline/_sklearn_to_aeon.py
@@ -1,6 +1,6 @@
 """Sklearn to aeon coercion utility."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 from aeon.pipeline._make_pipeline import make_pipeline
 

--- a/aeon/registry/_base_classes.py
+++ b/aeon/registry/_base_classes.py
@@ -28,7 +28,7 @@ BASE_CLASS_LOOKUP - dictionary
 
 """
 
-__author__ = ["fkiraly", "MatthewMiddlehurst", "TonyBagnall"]
+__maintainer__ = []
 
 import pandas as pd
 

--- a/aeon/registry/_identifier.py
+++ b/aeon/registry/_identifier.py
@@ -1,6 +1,6 @@
 """Utility to determine type identifier of estimator, based on base class type."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 from inspect import isclass
 

--- a/aeon/registry/_lookup.py
+++ b/aeon/registry/_lookup.py
@@ -10,16 +10,7 @@ all_tags(estimator_identifiers)
     lookup and filtering of estimator tags
 """
 
-__author__ = [
-    "fkiraly",
-    "mloning",
-    "katiebuc",
-    "miraep8",
-    "xloem",
-    "MatthewMiddlehurst",
-]
-# all_estimators is also based on the sklearn utility of the same name
-
+__maintainer__ = []
 
 import inspect
 import pkgutil
@@ -59,6 +50,8 @@ def all_estimators(
 
     Not included are: the base classes themselves, classes defined in test
     modules.
+
+    Based on the sklearn utility of the same name.
 
     Parameters
     ----------

--- a/aeon/registry/_tags.py
+++ b/aeon/registry/_tags.py
@@ -40,7 +40,7 @@ check_tag_is_valid(tag_name, tag_value) - checks whether tag_value is valid for 
 
 """
 
-__author__ = ["fkiraly", "victordremov", "TonyBagnall"]
+__maintainer__ = []
 
 import pandas as pd
 

--- a/aeon/registry/tests/test_lookup.py
+++ b/aeon/registry/tests/test_lookup.py
@@ -1,6 +1,6 @@
 """Testing of registry lookup functionality."""
 
-__author__ = ["fkiraly", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 import pytest
 

--- a/aeon/regression/_delegate.py
+++ b/aeon/regression/_delegate.py
@@ -5,7 +5,7 @@ For that purpose, inherit from this estimator and then override only the methods
     that are not delegated.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["_DelegatedRegressor"]
 
 from aeon.regression.base import BaseRegressor

--- a/aeon/regression/_dummy.py
+++ b/aeon/regression/_dummy.py
@@ -1,6 +1,6 @@
 """Dummy time series regressor."""
 
-__author__ = ["Badr-Eddine Marani"]
+__maintainer__ = []
 __all__ = ["DummyRegressor"]
 
 import numpy as np

--- a/aeon/regression/base.py
+++ b/aeon/regression/base.py
@@ -20,7 +20,7 @@ State:
 __all__ = [
     "BaseRegressor",
 ]
-__author__ = ["MatthewMiddlehurst", "TonyBagnll", "mloning", "fkiraly"]
+__maintainer__ = []
 import time
 from abc import ABC, abstractmethod
 from typing import final

--- a/aeon/regression/compose/_pipeline.py
+++ b/aeon/regression/compose/_pipeline.py
@@ -9,7 +9,7 @@ from aeon.transformations.compose import TransformerPipeline
 from aeon.utils.conversion import convert_collection
 from aeon.utils.sklearn import is_sklearn_regressor
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["RegressorPipeline", "SklearnRegressorPipeline"]
 
 

--- a/aeon/regression/convolution_based/_rocket_regressor.py
+++ b/aeon/regression/convolution_based/_rocket_regressor.py
@@ -3,7 +3,7 @@
 Pipeline regressor using the ROCKET transformer and RidgeCV estimator.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["RocketRegressor"]
 
 import numpy as np

--- a/aeon/regression/deep_learning/_cnn.py
+++ b/aeon/regression/deep_learning/_cnn.py
@@ -1,6 +1,6 @@
 """Time Convolutional Neural Network (CNN) for regression."""
 
-__author__ = ["AurumnPegasus", "achieveordie", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["CNNRegressor"]
 
 import gc

--- a/aeon/regression/deep_learning/_fcn.py
+++ b/aeon/regression/deep_learning/_fcn.py
@@ -1,6 +1,6 @@
 """Fully Convolutional Network (FCN) for regression."""
 
-__author__ = ["James-Large", "AurumnPegasus", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["FCNRegressor"]
 
 import gc

--- a/aeon/regression/deep_learning/_inception_time.py
+++ b/aeon/regression/deep_learning/_inception_time.py
@@ -1,6 +1,6 @@
 """InceptionTime regressor."""
 
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["InceptionTimeRegressor"]
 
 import gc

--- a/aeon/regression/deep_learning/_resnet.py
+++ b/aeon/regression/deep_learning/_resnet.py
@@ -1,6 +1,6 @@
 """Residual Network (ResNet) for regression."""
 
-__author__ = ["James-Large", "AurumnPegasus", "nilesh05apr", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["ResNetRegressor"]
 
 import gc

--- a/aeon/regression/deep_learning/_tapnet.py
+++ b/aeon/regression/deep_learning/_tapnet.py
@@ -1,8 +1,6 @@
 """Time Convolutional Neural Network (CNN) for classification."""
 
-__author__ = [
-    "Jack Russon",
-]
+__maintainer__ = []
 __all__ = [
     "TapNetRegressor",
 ]

--- a/aeon/regression/deep_learning/base.py
+++ b/aeon/regression/deep_learning/base.py
@@ -5,7 +5,7 @@ The reason for this class between BaseClassifier and deep_learning classifiers i
 because we can generalise tags and _predict
 """
 
-__author__ = ["AurumnPegasus", "achieveordie"]
+__maintainer__ = []
 __all__ = ["BaseDeepRegressor"]
 
 from abc import ABC, abstractmethod

--- a/aeon/regression/deep_learning/tests/test_deep_regressor_base.py
+++ b/aeon/regression/deep_learning/tests/test_deep_regressor_base.py
@@ -10,7 +10,7 @@ from aeon.regression.deep_learning.base import BaseDeepRegressor
 from aeon.testing.utils.data_gen import make_example_2d_numpy
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-__author__ = ["achieveordie", "hadifawaz1999"]
+__maintainer__ = []
 
 
 class _DummyDeepRegressor(BaseDeepRegressor):

--- a/aeon/regression/distance_based/_time_series_neighbors.py
+++ b/aeon/regression/distance_based/_time_series_neighbors.py
@@ -5,7 +5,7 @@ The class has hardcoded string references to numba based distances in aeon.dista
 It can also be used with callables, or aeon (pairwise transformer) estimators.
 """
 
-__author__ = ["TonyBagnall", "GuiArcencio"]
+__maintainer__ = []
 __all__ = ["KNeighborsTimeSeriesRegressor"]
 
 import numpy as np

--- a/aeon/regression/feature_based/_catch22.py
+++ b/aeon/regression/feature_based/_catch22.py
@@ -3,7 +3,7 @@
 Pipeline regressor using the Catch22 transformer and an estimator.
 """
 
-__author__ = ["MatthewMiddlehurst", "RavenRudi", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["Catch22Regressor"]
 
 import numpy as np

--- a/aeon/regression/feature_based/_fresh_prince.py
+++ b/aeon/regression/feature_based/_fresh_prince.py
@@ -4,7 +4,7 @@ Pipeline regressor using the full set of TSFresh features and a RotationForestRe
 regressor.
 """
 
-__author__ = ["MatthewMiddlehurst", "DavidGuijo-Rubio"]
+__maintainer__ = []
 __all__ = ["FreshPRINCERegressor"]
 
 import numpy as np

--- a/aeon/regression/interval_based/_interval_forest.py
+++ b/aeon/regression/interval_based/_interval_forest.py
@@ -1,6 +1,6 @@
 """Interval forest regressor."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["IntervalForestRegressor"]
 
 import numpy as np

--- a/aeon/regression/interval_based/_interval_pipelines.py
+++ b/aeon/regression/interval_based/_interval_pipelines.py
@@ -3,7 +3,7 @@
 Pipeline regressors which extract interval features then build a base estimator.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RandomIntervalRegressor"]
 
 import numpy as np

--- a/aeon/regression/interval_based/_rise.py
+++ b/aeon/regression/interval_based/_rise.py
@@ -1,6 +1,6 @@
 """Random Interval Spectral Ensemble (RISE) regressor."""
 
-__author__ = ["TonyBagnall", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RandomIntervalSpectralEnsembleRegressor"]
 
 import numpy as np

--- a/aeon/regression/interval_based/_tsf.py
+++ b/aeon/regression/interval_based/_tsf.py
@@ -3,7 +3,7 @@
 Interval-based TSF regressor, extracts basic summary features from random intervals.
 """
 
-__author__ = ["Matthew Middlehurst"]
+__maintainer__ = []
 __all__ = ["TimeSeriesForestRegressor"]
 
 import numpy as np

--- a/aeon/regression/sklearn/_rotation_forest_regressor.py
+++ b/aeon/regression/sklearn/_rotation_forest_regressor.py
@@ -4,7 +4,7 @@ A Rotation Forest aeon implementation for continuous values only. Fits sklearn
 conventions.
 """
 
-__author__ = ["MatthewMiddlehurst", "DavidGuijo-Rubio"]
+__maintainer__ = []
 __all__ = ["RotationForestRegressor"]
 
 import time

--- a/aeon/regression/tests/test_all_regressors.py
+++ b/aeon/regression/tests/test_all_regressors.py
@@ -1,6 +1,6 @@
 """Unit tests for all time series regressors."""
 
-__author__ = ["mloning", "TonyBagnall", "fkiraly", "DavidGuijo-Rubio"]
+__maintainer__ = []
 
 
 import numpy as np

--- a/aeon/segmentation/_clasp.py
+++ b/aeon/segmentation/_clasp.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-__author__ = ["ermshaua", "patrickzib"]
+__maintainer__ = []
 __all__ = ["ClaSPSegmenter", "find_dominant_window_sizes"]
 
 from queue import PriorityQueue

--- a/aeon/segmentation/_eagglo.py
+++ b/aeon/segmentation/_eagglo.py
@@ -9,7 +9,7 @@ from numba import njit
 
 from aeon.segmentation.base import BaseSegmenter
 
-__author__ = ["KatieBuc", "patrickzib"]
+__maintainer__ = []
 __all__ = ["EAggloSegmenter"]
 
 

--- a/aeon/segmentation/_hidalgo.py
+++ b/aeon/segmentation/_hidalgo.py
@@ -1,6 +1,6 @@
 """Hidalgo (Heterogeneous Intrinsic Dimensionality Algorithm) Segmentation."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 __all__ = ["HidalgoSegmenter"]
 
 

--- a/aeon/segmentation/_hmm.py
+++ b/aeon/segmentation/_hmm.py
@@ -14,7 +14,7 @@ from scipy.stats import norm
 
 from aeon.segmentation.base import BaseSegmenter
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["HMMSegmenter"]
 
 

--- a/aeon/segmentation/_igts.py
+++ b/aeon/segmentation/_igts.py
@@ -27,7 +27,7 @@ import pandas as pd
 from aeon.segmentation.base import BaseSegmenter
 
 __all__ = ["InformationGainSegmenter"]
-__author__ = ["lmmentel"]
+__maintainer__ = []
 
 
 @dataclass

--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -1,7 +1,7 @@
 """Abstract base class for time series segmenters."""
 
 __all__ = ["BaseSegmenter"]
-__author__ = ["TonyBagnall"]
+__maintainer__ = []
 
 from abc import ABC, abstractmethod
 from typing import List, final

--- a/aeon/segmentation/tests/test_clasp.py
+++ b/aeon/segmentation/tests/test_clasp.py
@@ -1,6 +1,6 @@
 """Simple ClaSP test."""
 
-__author__ = ["patrickzib"]
+__maintainer__ = []
 __all__ = []
 
 from aeon.datasets import load_gun_point_segmentation

--- a/aeon/segmentation/tests/test_eagglo.py
+++ b/aeon/segmentation/tests/test_eagglo.py
@@ -1,6 +1,6 @@
 """Tests for E-Agglo (agglomerative clustering algorithm)."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/segmentation/tests/test_hmm.py
+++ b/aeon/segmentation/tests/test_hmm.py
@@ -1,6 +1,6 @@
 """Tests for HMM annotation estimator."""
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/similarity_search/__init__.py
+++ b/aeon/similarity_search/__init__.py
@@ -1,6 +1,5 @@
 """BaseSimilaritySearch."""
 
-__author__ = ["baraline"]
 __all__ = [
     "BaseSimiliaritySearch",
     "TopKSimilaritySearch",

--- a/aeon/similarity_search/_dummy.py
+++ b/aeon/similarity_search/_dummy.py
@@ -1,6 +1,6 @@
 """Dummy similarity seach estimator."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 __all__ = ["DummySimilaritySearch"]
 
 

--- a/aeon/similarity_search/base.py
+++ b/aeon/similarity_search/base.py
@@ -1,6 +1,6 @@
 """Base class for similarity search."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable

--- a/aeon/similarity_search/distance_profiles/__init__.py
+++ b/aeon/similarity_search/distance_profiles/__init__.py
@@ -1,6 +1,5 @@
 """Distance profiles."""
 
-__author__ = ["baraline"]
 __all__ = ["naive_distance_profile", "normalized_naive_distance_profile"]
 
 

--- a/aeon/similarity_search/distance_profiles/euclidean_distance_profile.py
+++ b/aeon/similarity_search/distance_profiles/euclidean_distance_profile.py
@@ -1,6 +1,6 @@
 """Optimized distance profile for euclidean distance."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 
 from aeon.similarity_search.distance_profiles.squared_distance_profile import (

--- a/aeon/similarity_search/distance_profiles/naive_distance_profile.py
+++ b/aeon/similarity_search/distance_profiles/naive_distance_profile.py
@@ -1,6 +1,6 @@
 """Naive distance profile computation."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 
 import numpy as np

--- a/aeon/similarity_search/distance_profiles/squared_distance_profile.py
+++ b/aeon/similarity_search/distance_profiles/squared_distance_profile.py
@@ -1,6 +1,6 @@
 """Optimized distance profile for euclidean distance."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 
 import numpy as np

--- a/aeon/similarity_search/distance_profiles/tests/test_euclidean_distance.py
+++ b/aeon/similarity_search/distance_profiles/tests/test_euclidean_distance.py
@@ -1,6 +1,6 @@
 """Tests for naive Euclidean distance profile."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/similarity_search/distance_profiles/tests/test_naive_distance.py
+++ b/aeon/similarity_search/distance_profiles/tests/test_naive_distance.py
@@ -1,6 +1,6 @@
 """Tests for naive Euclidean distance profile."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/similarity_search/tests/test_dummy.py
+++ b/aeon/similarity_search/tests/test_dummy.py
@@ -1,6 +1,6 @@
 """Tests for DummySimilaritySearch."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 
 import numpy as np

--- a/aeon/similarity_search/tests/test_top_k_similarity.py
+++ b/aeon/similarity_search/tests/test_top_k_similarity.py
@@ -1,6 +1,6 @@
 """Tests for TopKSimilaritySearch."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/similarity_search/top_k_similarity.py
+++ b/aeon/similarity_search/top_k_similarity.py
@@ -1,6 +1,6 @@
 """TopKSimilaritySearch."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import warnings
 

--- a/aeon/testing/mock_estimators/__init__.py
+++ b/aeon/testing/mock_estimators/__init__.py
@@ -1,7 +1,5 @@
 """Mock forecasters for testing and debugging."""
 
-__author__ = ["ltsaprounis"]
-
 __all__ = [
     "MockForecaster",
     "MockUnivariateForecasterLogger",

--- a/aeon/testing/mock_estimators/_mock_forecasters.py
+++ b/aeon/testing/mock_estimators/_mock_forecasters.py
@@ -3,7 +3,7 @@
 Used in the forecasting module to test composites and pipelines.
 """
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 __all__ = ["MockForecaster", "MockUnivariateForecasterLogger"]
 

--- a/aeon/testing/mock_estimators/tests/test_mock_forecasters.py
+++ b/aeon/testing/mock_estimators/tests/test_mock_forecasters.py
@@ -1,6 +1,6 @@
 """Tests for Mock Forecasters."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 from copy import deepcopy
 

--- a/aeon/testing/test_all_estimators.py
+++ b/aeon/testing/test_all_estimators.py
@@ -3,7 +3,7 @@
 adapted from scikit-learn's estimator_checks
 """
 
-__author__ = ["mloning", "fkiraly", "achieveordie", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 import numbers
 import types

--- a/aeon/testing/test_config.py
+++ b/aeon/testing/test_config.py
@@ -1,4 +1,4 @@
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["EXCLUDE_ESTIMATORS", "EXCLUDED_TESTS"]
 
 import os

--- a/aeon/testing/test_softdeps.py
+++ b/aeon/testing/test_softdeps.py
@@ -6,7 +6,7 @@ a certain module but otherwise not necessary.
 Adapted from code of mloning for the legacy Azure CI/CD build tools.
 """
 
-__author__ = ["mloning", "fkiraly"]
+__maintainer__ = []
 
 import pkgutil
 import re

--- a/aeon/testing/utils/_conditional_fixtures.py
+++ b/aeon/testing/utils/_conditional_fixtures.py
@@ -3,7 +3,7 @@
 Exports create_conditional_fixtures_and_names utility
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["create_conditional_fixtures_and_names"]
 

--- a/aeon/testing/utils/data_gen/_data_generators.py
+++ b/aeon/testing/utils/data_gen/_data_generators.py
@@ -1,6 +1,6 @@
 """Data generators."""
 
-__author__ = ["MatthewMiddlehurst", "TonyBagnall"]
+__maintainer__ = []
 
 from typing import Dict, Tuple, Union
 

--- a/aeon/testing/utils/data_gen/_series.py
+++ b/aeon/testing/utils/data_gen/_series.py
@@ -1,6 +1,6 @@
 """Series testing utils."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["make_series", "make_forecasting_problem"]
 
 import numpy as np

--- a/aeon/testing/utils/data_gen/annotation.py
+++ b/aeon/testing/utils/data_gen/annotation.py
@@ -1,6 +1,6 @@
 """Annotation testing utils."""
 
-__author__ = []
+__maintainer__ = []
 __all__ = []
 
 from sklearn.utils import check_random_state

--- a/aeon/testing/utils/data_gen/forecasting.py
+++ b/aeon/testing/utils/data_gen/forecasting.py
@@ -1,6 +1,6 @@
 """Forecasting testing utils."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/testing/utils/data_gen/hierarchical.py
+++ b/aeon/testing/utils/data_gen/hierarchical.py
@@ -1,6 +1,6 @@
 """Hierarchical Data Generators."""
 
-__author__ = ["ltsaprounis", "ciaran-g"]
+__maintainer__ = []
 
 from itertools import product
 from typing import Tuple, Union

--- a/aeon/testing/utils/data_gen/tests/test_collection.py
+++ b/aeon/testing/utils/data_gen/tests/test_collection.py
@@ -1,6 +1,6 @@
 """Tests for datagen functions."""
 
-__author__ = ["klam-data", "mgorlin", "pyyim"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/testing/utils/deep_equals.py
+++ b/aeon/testing/utils/deep_equals.py
@@ -6,7 +6,7 @@ Objects compared can have one of the following valid types:
     lists, tuples, or dicts of a valid type (recursive)
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["deep_equals"]
 

--- a/aeon/testing/utils/estimator_checks.py
+++ b/aeon/testing/utils/estimator_checks.py
@@ -1,6 +1,6 @@
 """Utility function for estimator testing."""
 
-__author__ = ["mloning", "fkiraly"]
+__maintainer__ = []
 
 from inspect import isclass, signature
 

--- a/aeon/testing/utils/scenarios.py
+++ b/aeon/testing/utils/scenarios.py
@@ -3,7 +3,7 @@
 Contains TestScenario class which applies method/args subsequently
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["TestScenario"]
 

--- a/aeon/testing/utils/scenarios_classification.py
+++ b/aeon/testing/utils/scenarios_classification.py
@@ -3,7 +3,7 @@
 Contains TestScenario concrete children to run in tests for classifiers/regressors.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "scenarios_classification",

--- a/aeon/testing/utils/scenarios_forecasting.py
+++ b/aeon/testing/utils/scenarios_forecasting.py
@@ -3,7 +3,7 @@
 Contains TestScenario concrete children to run in tests for forecasters.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = [
     "forecasting_scenarios_simple",

--- a/aeon/testing/utils/scenarios_getter.py
+++ b/aeon/testing/utils/scenarios_getter.py
@@ -1,6 +1,6 @@
 """Retrieval utility for test scenarios."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["retrieve_scenarios"]
 

--- a/aeon/testing/utils/scenarios_transformers.py
+++ b/aeon/testing/utils/scenarios_transformers.py
@@ -3,7 +3,7 @@
 Contains TestScenario concrete children to run in tests for transformers.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 __all__ = ["scenarios_transformers"]
 

--- a/aeon/testing/utils/tests/__init__.py
+++ b/aeon/testing/utils/tests/__init__.py
@@ -1,4 +1,1 @@
 """Tests for testing utils."""
-
-__author__ = ["mloning"]
-__all__ = []

--- a/aeon/testing/utils/tests/test_forecasting.py
+++ b/aeon/testing/utils/tests/test_forecasting.py
@@ -1,4 +1,4 @@
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = []
 
 import pandas as pd

--- a/aeon/testing/utils/tests/test_testscenario_getter.py
+++ b/aeon/testing/utils/tests/test_testscenario_getter.py
@@ -1,4 +1,4 @@
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/testing/utils/tests/test_testscenarios.py
+++ b/aeon/testing/utils/tests/test_testscenarios.py
@@ -1,4 +1,4 @@
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 

--- a/aeon/transformations/_delegate.py
+++ b/aeon/transformations/_delegate.py
@@ -5,7 +5,7 @@ For that purpose, inherit from this estimator and then override only the methods
     that are not delegated.
 """
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 __all__ = ["_DelegatedTransformer"]
 
 from aeon.transformations.base import BaseTransformer

--- a/aeon/transformations/acf.py
+++ b/aeon/transformations/acf.py
@@ -4,7 +4,7 @@ Module :mod:`aeon.transformations` implements auto-correlation
 transformers.
 """
 
-__author__ = ["afzal442"]
+__maintainer__ = []
 __all__ = ["AutoCorrelationTransformer", "PartialAutoCorrelationTransformer"]
 
 import pandas as pd

--- a/aeon/transformations/adapt.py
+++ b/aeon/transformations/adapt.py
@@ -1,6 +1,6 @@
 """Implements adaptor for applying Scikit-learn-like transformers to time series."""
 
-__author__ = ["mloning", "fkiraly"]
+__maintainer__ = []
 __all__ = ["TabularToSeriesAdaptor"]
 
 import numpy as np

--- a/aeon/transformations/augmenter.py
+++ b/aeon/transformations/augmenter.py
@@ -1,6 +1,6 @@
 """Series transformers for time series augmentation."""
 
-__author__ = ["MrPr3ntice", "MFehsenfeld", "iljamaurer"]
+__maintainer__ = []
 __all__ = [
     "WhiteNoiseAugmenter",
     "ReverseAugmenter",

--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -38,7 +38,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["mloning", "fkiraly", "miraep8"]
+__maintainer__ = []
 __all__ = [
     "BaseTransformer",
 ]

--- a/aeon/transformations/binning.py
+++ b/aeon/transformations/binning.py
@@ -1,6 +1,6 @@
 """Time binning for turning series equally spaced."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import warnings
 

--- a/aeon/transformations/bkfilter.py
+++ b/aeon/transformations/bkfilter.py
@@ -5,7 +5,7 @@ Please see the original library
 (https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/filters/bk_filter.py)
 """
 
-__author__ = ["klam-data", "pyyim", "mgorlin"]
+__maintainer__ = []
 __all__ = ["BKFilter"]
 
 

--- a/aeon/transformations/bootstrap/_mbb.py
+++ b/aeon/transformations/bootstrap/_mbb.py
@@ -1,6 +1,6 @@
 """Bootstrapping methods for time series."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 from copy import copy
 from typing import Tuple, Union

--- a/aeon/transformations/bootstrap/tests/test_mbb.py
+++ b/aeon/transformations/bootstrap/tests/test_mbb.py
@@ -1,6 +1,6 @@
 """Unit tests for Bootrstapping transformers."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/transformations/boxcox.py
+++ b/aeon/transformations/boxcox.py
@@ -1,6 +1,6 @@
 """Implemenents Box-Cox and Log Transformations."""
 
-__author__ = ["mloning", "aiwalter", "fkiraly"]
+__maintainer__ = []
 __all__ = ["BoxCoxTransformer", "LogTransformer"]
 
 import numpy as np

--- a/aeon/transformations/clasp.py
+++ b/aeon/transformations/clasp.py
@@ -12,7 +12,7 @@ As described in
 }
 """
 
-__author__ = ["ermshaua", "patrickzib"]
+__maintainer__ = []
 __all__ = ["ClaSPTransformer"]
 
 import warnings

--- a/aeon/transformations/clear_sky.py
+++ b/aeon/transformations/clear_sky.py
@@ -1,6 +1,6 @@
 """Clear sky transformer for solar time-series."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/transformations/collection/_collection_wrapper.py
+++ b/aeon/transformations/collection/_collection_wrapper.py
@@ -1,6 +1,6 @@
 """A wrapper to treat a BaseCollectionTransformer as a BaseTransformer."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["CollectionToSeriesWrapper"]
 
 from aeon.base._base import _clone_estimator

--- a/aeon/transformations/collection/acf.py
+++ b/aeon/transformations/collection/acf.py
@@ -3,7 +3,7 @@
 Efficient implementation for collections using numba.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["AutocorrelationFunctionTransformer"]
 
 import numpy as np

--- a/aeon/transformations/collection/ar_coefficient.py
+++ b/aeon/transformations/collection/ar_coefficient.py
@@ -1,6 +1,6 @@
 """AR coefficient feature transformer."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["ARCoefficientTransformer"]
 
 

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -19,7 +19,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__author__ = ["MatthewMiddlehurst", "TonyBagnall"]
+__maintainer__ = []
 __all__ = [
     "BaseCollectionTransformer",
 ]

--- a/aeon/transformations/collection/channel_selection.py
+++ b/aeon/transformations/collection/channel_selection.py
@@ -4,7 +4,7 @@ A transformer that selects a subset of channels/dimensions for time series
 classification using a scoring system with an elbow point method.
 """
 
-__author__ = ["haskarb"]
+__maintainer__ = []
 __all__ = ["ElbowClassSum", "ElbowClassPairwise"]
 
 

--- a/aeon/transformations/collection/convolution_based/_minirocket.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket.py
@@ -1,6 +1,6 @@
 """MiniRocket transformer."""
 
-__author__ = ["angus924"]
+__maintainer__ = []
 __all__ = ["MiniRocket"]
 
 import multiprocessing

--- a/aeon/transformations/collection/convolution_based/_minirocket_multivariate.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket_multivariate.py
@@ -1,6 +1,6 @@
 """Multivariate MiniRocket transformer."""
 
-__author__ = ["angus924"]
+__maintainer__ = []
 __all__ = ["MiniRocketMultivariate"]
 
 import multiprocessing

--- a/aeon/transformations/collection/convolution_based/_minirocket_mv.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket_mv.py
@@ -1,6 +1,6 @@
 """Multivariate MiniRocket transformer."""
 
-__author__ = ["angus924", "michaelfeil", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["MiniRocketMultivariateVariable"]
 
 import multiprocessing

--- a/aeon/transformations/collection/convolution_based/_rocket.py
+++ b/aeon/transformations/collection/convolution_based/_rocket.py
@@ -1,6 +1,6 @@
 """Rocket transformer."""
 
-__author__ = ["angus924"]
+__maintainer__ = []
 __all__ = ["Rocket"]
 
 import numpy as np

--- a/aeon/transformations/collection/dictionary_based/_paa.py
+++ b/aeon/transformations/collection/dictionary_based/_paa.py
@@ -1,6 +1,6 @@
 """Piecewise Aggregate Approximation Transformer (PAA)."""
 
-__author__ = ["MatthewMiddlehurst", "hadifawaz1999"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/transformations/collection/dictionary_based/_sax.py
+++ b/aeon/transformations/collection/dictionary_based/_sax.py
@@ -1,6 +1,6 @@
 """Symbolic Aggregate approXimation (SAX) transformer."""
 
-__author__ = ["MatthewMiddlehurst", "hadifawaz1999"]
+__maintainer__ = []
 __all__ = ["SAX", "_invert_sax_symbols"]
 
 import numpy as np

--- a/aeon/transformations/collection/dictionary_based/_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa.py
@@ -3,7 +3,7 @@
 Configurable SFA transform for discretising time series into words.
 """
 
-__author__ = ["MatthewMiddlehurst", "patrickzib"]
+__maintainer__ = []
 __all__ = ["SFA"]
 
 import math

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -4,7 +4,7 @@ Configurable SFA transform for discretising time series into words.
 
 """
 
-__author__ = ["patrickzib"]
+__maintainer__ = []
 __all__ = ["SFAFast"]
 
 import math

--- a/aeon/transformations/collection/dwt.py
+++ b/aeon/transformations/collection/dwt.py
@@ -1,6 +1,6 @@
 """Discrete wavelet transform."""
 
-__author__ = "Vincent Nicholson"
+__maintainer__ = []
 
 import math
 

--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -3,7 +3,7 @@
 A transformer for the Catch22 features.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["Catch22"]
 
 import math

--- a/aeon/transformations/collection/feature_based/_summary.py
+++ b/aeon/transformations/collection/feature_based/_summary.py
@@ -1,6 +1,6 @@
 """Summary feature transformer."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["SevenNumberSummaryTransformer"]
 
 import numpy as np

--- a/aeon/transformations/collection/feature_based/_tsfresh.py
+++ b/aeon/transformations/collection/feature_based/_tsfresh.py
@@ -1,6 +1,6 @@
 """tsfresh interface class."""
 
-__author__ = ["AyushmaanSeth", "mloning", "Alwin Wang", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["TSFreshFeatureExtractor", "TSFreshRelevantFeatureExtractor"]
 
 import numpy as np

--- a/aeon/transformations/collection/feature_based/tests/test_tsfresh.py
+++ b/aeon/transformations/collection/feature_based/tests/test_tsfresh.py
@@ -1,6 +1,6 @@
 """Tests for TSFreshFeatureExtractor."""
 
-__author__ = ["AyushmannSeth", "mloning"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/collection/interpolate.py
+++ b/aeon/transformations/collection/interpolate.py
@@ -1,7 +1,7 @@
 """Time series interpolator/re-sampler."""
 
 __all__ = ["TSInterpolator"]
-__author__ = ["mloning", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/transformations/collection/interval_based/_random_intervals.py
+++ b/aeon/transformations/collection/interval_based/_random_intervals.py
@@ -3,7 +3,7 @@
 A transformer for the extraction of features on randomly selected intervals.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["RandomIntervals"]
 
 import numpy as np

--- a/aeon/transformations/collection/interval_based/_supervised_intervals.py
+++ b/aeon/transformations/collection/interval_based/_supervised_intervals.py
@@ -4,7 +4,7 @@ A transformer for the extraction of features on intervals extracted from a super
 process.
 """
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["SupervisedIntervals"]
 
 import inspect

--- a/aeon/transformations/collection/matrix_profile.py
+++ b/aeon/transformations/collection/matrix_profile.py
@@ -1,6 +1,6 @@
 """Matrix profile transformer."""
 
-__author__ = ["Claudia Rincon Sanchez"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/transformations/collection/pad.py
+++ b/aeon/transformations/collection/pad.py
@@ -1,7 +1,7 @@
 """Padding transformer, pad unequal length time series to max length or fixed length."""
 
 __all__ = ["PaddingTransformer"]
-__author__ = ["abostrom", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/transformations/collection/periodogram.py
+++ b/aeon/transformations/collection/periodogram.py
@@ -1,6 +1,6 @@
 """Periodogram transformer."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = ["PeriodogramTransformer"]
 
 import math

--- a/aeon/transformations/collection/reduce.py
+++ b/aeon/transformations/collection/reduce.py
@@ -1,6 +1,6 @@
 """Tabularizer transform, for pipelining."""
 
-__author__ = ["mloning", "fkiraly", "kcc-lion"]
+__maintainer__ = []
 __all__ = ["Tabularizer"]
 
 from aeon.transformations.collection import BaseCollectionTransformer

--- a/aeon/transformations/collection/scaler.py
+++ b/aeon/transformations/collection/scaler.py
@@ -1,6 +1,6 @@
 """Wrapper for sklearn StandardScaler."""
 
-__author__ = ["TonyBagnall"]
+__maintainer__ = []
 __all__ = ["TimeSeriesScaler"]
 
 import numpy as np

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -4,7 +4,7 @@ A modification of the classic Shapelet Transform which add a dilation parameter 
 Shapelets.
 """
 
-__author__ = ["baraline"]
+__maintainer__ = []
 __all__ = ["RandomDilatedShapeletTransform"]
 
 import warnings

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -3,7 +3,7 @@
 A transformer from the time domain into the shapelet domain.
 """
 
-__author__ = ["MatthewMiddlehurst", "jasonlines", "dguijo", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["RandomShapeletTransform"]
 
 import heapq

--- a/aeon/transformations/collection/shapelet_based/tests/test_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/tests/test_dilated_shapelet_transform.py
@@ -1,6 +1,6 @@
 """Tests for dilated shapelet transform functions."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/collection/slope.py
+++ b/aeon/transformations/collection/slope.py
@@ -1,7 +1,7 @@
 """Slope transformer."""
 
 __all__ = ["SlopeTransformer"]
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import math
 

--- a/aeon/transformations/collection/tests/test_base.py
+++ b/aeon/transformations/collection/tests/test_base.py
@@ -1,6 +1,6 @@
 """Test input for the BaseCollectionTransformer."""
 
-__author__ = ["MatthewMiddlehurst", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/collection/truncate.py
+++ b/aeon/transformations/collection/truncate.py
@@ -1,7 +1,7 @@
 """Truncation transformer - truncate unequal length panels to lower/upper bounds."""
 
 __all__ = ["TruncationTransformer"]
-__author__ = ["abostrom", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/transformations/compose.py
+++ b/aeon/transformations/compose.py
@@ -17,7 +17,7 @@ from aeon.utils.sklearn import (
 )
 from aeon.utils.validation.series import check_series
 
-__author__ = ["fkiraly", "mloning", "miraep8", "aiwalter", "SveaMeyer13"]
+__maintainer__ = []
 __all__ = [
     "ColumnwiseTransformer",
     "ColumnConcatenator",

--- a/aeon/transformations/cos.py
+++ b/aeon/transformations/cos.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from aeon.transformations.base import BaseTransformer
 
-__author__ = ["afzal442"]
+__maintainer__ = []
 __all__ = ["CosineTransformer"]
 
 

--- a/aeon/transformations/date.py
+++ b/aeon/transformations/date.py
@@ -1,6 +1,6 @@
 """Extract calendar features from datetimeindex."""
 
-__author__ = ["danbartl", "KishManani"]
+__maintainer__ = []
 __all__ = ["DateTimeFeatures"]
 
 import warnings

--- a/aeon/transformations/detrend/__init__.py
+++ b/aeon/transformations/detrend/__init__.py
@@ -1,6 +1,5 @@
 """Transformer module for detrending and deseasonalization."""
 
-__author__ = ["mloning", "eyalshafran", "SveaMeyer13"]
 __all__ = ["Detrender", "Deseasonalizer", "ConditionalDeseasonalizer", "STLTransformer"]
 
 from aeon.transformations.detrend._deseasonalize import (

--- a/aeon/transformations/detrend/_deseasonalize.py
+++ b/aeon/transformations/detrend/_deseasonalize.py
@@ -1,6 +1,6 @@
 """Implements transformations to deseasonalize a timeseries."""
 
-__author__ = ["mloning", "eyalshafran", "aiwalter"]
+__maintainer__ = []
 __all__ = ["Deseasonalizer", "ConditionalDeseasonalizer", "STLTransformer"]
 
 import numpy as np

--- a/aeon/transformations/detrend/_detrend.py
+++ b/aeon/transformations/detrend/_detrend.py
@@ -1,7 +1,7 @@
 """Implements transformations to detrend a time series."""
 
 __all__ = ["Detrender"]
-__author__ = ["mloning", "SveaMeyer13", "KishManani", "fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 

--- a/aeon/transformations/detrend/tests/__init__.py
+++ b/aeon/transformations/detrend/tests/__init__.py
@@ -1,3 +1,1 @@
 """Tests for detrenders."""
-
-__author__ = "mloning"

--- a/aeon/transformations/detrend/tests/test_deseasonalise.py
+++ b/aeon/transformations/detrend/tests/test_deseasonalise.py
@@ -1,6 +1,6 @@
 """Tests for Deseasonalizer."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/detrend/tests/test_detrend.py
+++ b/aeon/transformations/detrend/tests/test_detrend.py
@@ -9,7 +9,7 @@ from aeon.forecasting.tests.test_trend import get_expected_polynomial_coefs
 from aeon.forecasting.trend import PolynomialTrendForecaster
 from aeon.transformations.detrend import Detrender
 
-__author__ = ["mloning", "KishManani"]
+__maintainer__ = []
 __all__ = []
 
 

--- a/aeon/transformations/difference.py
+++ b/aeon/transformations/difference.py
@@ -1,6 +1,6 @@
 """Class to iteratively apply differences to a time series."""
 
-__author__ = ["RNKuhns", "fkiraly"]
+__maintainer__ = []
 __all__ = ["Differencer"]
 
 from typing import Union

--- a/aeon/transformations/dobin.py
+++ b/aeon/transformations/dobin.py
@@ -12,7 +12,7 @@ from sklearn.neighbors import NearestNeighbors
 
 from aeon.transformations.base import BaseTransformer
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 __all__ = ["DOBIN"]
 
 

--- a/aeon/transformations/exponent.py
+++ b/aeon/transformations/exponent.py
@@ -1,6 +1,6 @@
 """Implements transformers raise time series to user provided exponent."""
 
-__author__ = ["Ryan Kuhns"]
+__maintainer__ = []
 __all__ = ["ExponentTransformer", "SqrtTransformer"]
 
 from warnings import warn

--- a/aeon/transformations/feature_selection.py
+++ b/aeon/transformations/feature_selection.py
@@ -1,6 +1,6 @@
 """Implements feature selection algorithms."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = ["FeatureSelection"]
 
 import math

--- a/aeon/transformations/filter.py
+++ b/aeon/transformations/filter.py
@@ -1,6 +1,6 @@
 """Frequency filters."""
 
-__author__ = ["sveameyer13"]
+__maintainer__ = []
 __all__ = ["Filter"]
 
 import numpy as np

--- a/aeon/transformations/fourier.py
+++ b/aeon/transformations/fourier.py
@@ -1,6 +1,6 @@
 """Fourier features for time series with long/complex seasonality."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 import warnings
 from typing import List, Optional, Union
 

--- a/aeon/transformations/func_transform.py
+++ b/aeon/transformations/func_transform.py
@@ -1,6 +1,6 @@
 """Implements FunctionTransformer, a class to create custom transformers."""
 
-__author__ = ["BoukePostma"]
+__maintainer__ = []
 __all__ = ["FunctionTransformer"]
 
 import numpy as np

--- a/aeon/transformations/hidalgo.py
+++ b/aeon/transformations/hidalgo.py
@@ -1,6 +1,6 @@
 """Hidalgo (Heterogeneous Intrinsic Dimensionality Algorithm) Segmentation."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 __all__ = ["Hidalgo"]
 
 

--- a/aeon/transformations/hierarchical/aggregate.py
+++ b/aeon/transformations/hierarchical/aggregate.py
@@ -1,6 +1,6 @@
 """Implements a transfromer to generate hierarcical data from bottom level."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/transformations/hierarchical/reconcile.py
+++ b/aeon/transformations/hierarchical/reconcile.py
@@ -3,7 +3,7 @@
 These reconcilers only depend on the structure of the hierarchy.
 """
 
-__author__ = ["ciaran-g", "eenticott-shell", "k1m190r"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/transformations/hierarchical/tests/test_aggregate.py
+++ b/aeon/transformations/hierarchical/tests/test_aggregate.py
@@ -1,6 +1,6 @@
 """Tests for hierarchical aggregator."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 import pytest
 

--- a/aeon/transformations/hierarchical/tests/test_reconcile.py
+++ b/aeon/transformations/hierarchical/tests/test_reconcile.py
@@ -1,6 +1,6 @@
 """Tests for hierarchical reconcilers."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/impute.py
+++ b/aeon/transformations/impute.py
@@ -1,6 +1,6 @@
 """Transformer to impute missing values in series."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = ["Imputer"]
 
 

--- a/aeon/transformations/kalman_filter.py
+++ b/aeon/transformations/kalman_filter.py
@@ -5,7 +5,7 @@ and a transformer which is an adapter for the external package
 FilterPy.
 """
 
-__author__ = ["NoaBenAmi", "lielleravid", "hadifawaz1999", "lmmentel"]
+__maintainer__ = []
 __all__ = [
     "BaseKalmanFilter",
     "KalmanFilterTransformer",

--- a/aeon/transformations/lag.py
+++ b/aeon/transformations/lag.py
@@ -1,6 +1,6 @@
 """Lagging transformer."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/transformations/matrix_profile.py
+++ b/aeon/transformations/matrix_profile.py
@@ -1,6 +1,6 @@
 """Implements matrix profile transformation."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["MatrixProfileTransformer"]
 
 from deprecated.sphinx import deprecated

--- a/aeon/transformations/outlier_detection.py
+++ b/aeon/transformations/outlier_detection.py
@@ -1,6 +1,6 @@
 """Implements transformers for detecting outliers in a time series."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = ["HampelFilter"]
 
 import warnings

--- a/aeon/transformations/pca.py
+++ b/aeon/transformations/pca.py
@@ -1,6 +1,6 @@
 """sklearn PCA applied as transformation."""
 
-__author__ = ["prockenschaub", "fkiraly", "aiwalter"]
+__maintainer__ = []
 __all__ = ["PCATransformer"]
 
 import pandas as pd

--- a/aeon/transformations/scaledlogit.py
+++ b/aeon/transformations/scaledlogit.py
@@ -1,6 +1,6 @@
 """Implements the scaled logit transformation."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 __all__ = ["ScaledLogitTransformer"]
 
 from copy import deepcopy

--- a/aeon/transformations/series/_matrix_profile.py
+++ b/aeon/transformations/series/_matrix_profile.py
@@ -1,6 +1,6 @@
 """Implements matrix profile transformation."""
 
-__author__ = ["mloning", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["MatrixProfileSeriesTransformer"]
 
 from aeon.transformations.series.base import BaseSeriesTransformer

--- a/aeon/transformations/subset.py
+++ b/aeon/transformations/subset.py
@@ -1,6 +1,6 @@
 """Transformers for index and column subsetting."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 from pandas.api.types import is_integer_dtype

--- a/aeon/transformations/summarize.py
+++ b/aeon/transformations/summarize.py
@@ -1,6 +1,6 @@
 """Implement transformers for summarizing a time series."""
 
-__author__ = ["mloning", "RNKuhns", "danbartl", "grzegorzrut"]
+__maintainer__ = []
 __all__ = ["SummaryTransformer", "WindowSummarizer"]
 
 import numpy as np

--- a/aeon/transformations/tests/test_all_transformers.py
+++ b/aeon/transformations/tests/test_all_transformers.py
@@ -1,6 +1,6 @@
 """Unit tests common to all transformers."""
 
-__author__ = ["mloning", "fkiraly", "MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/tests/test_base.py
+++ b/aeon/transformations/tests/test_base.py
@@ -8,7 +8,7 @@ Concrete transformer classes from aeon are imported to cover
 Transformer scenarios cover different combinations of input data types.
 """
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 from inspect import isclass

--- a/aeon/transformations/tests/test_bkfilter.py
+++ b/aeon/transformations/tests/test_bkfilter.py
@@ -1,6 +1,6 @@
 """Tests for BKfilter wrapper annotation estimator."""
 
-__author__ = ["klam-data", "pyyim"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/transformations/tests/test_boxcox.py
+++ b/aeon/transformations/tests/test_boxcox.py
@@ -1,6 +1,6 @@
 """Tests for BoxCoxTransformer."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/tests/test_clear_sky.py
+++ b/aeon/transformations/tests/test_clear_sky.py
@@ -1,6 +1,6 @@
 """Tests for ClearSky transformer."""
 
-__author__ = ["ciaran-g"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/transformations/tests/test_compose.py
+++ b/aeon/transformations/tests/test_compose.py
@@ -1,6 +1,6 @@
 """Unit tests for transformer composition functionality attached to the base class."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 import pandas as pd

--- a/aeon/transformations/tests/test_differencer.py
+++ b/aeon/transformations/tests/test_differencer.py
@@ -1,6 +1,6 @@
 """Unit tests of Differencer functionality."""
 
-__author__ = ["RNKuhns", "fkiraly", "ilkersigirci"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/tests/test_dobin.py
+++ b/aeon/transformations/tests/test_dobin.py
@@ -1,6 +1,6 @@
 """Tests for DOBIN (Distance based Outlier BasIs using Neighbors)."""
 
-__author__ = ["KatieBuc"]
+__maintainer__ = []
 
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler, RobustScaler

--- a/aeon/transformations/tests/test_exponent.py
+++ b/aeon/transformations/tests/test_exponent.py
@@ -1,4 +1,4 @@
-__author__ = ["Ryan Kuhns"]
+__maintainer__ = []
 __all__ = []
 
 import pytest

--- a/aeon/transformations/tests/test_feature_selection.py
+++ b/aeon/transformations/tests/test_feature_selection.py
@@ -1,6 +1,6 @@
 """Test FeatureSelection transformer."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = []
 
 import math

--- a/aeon/transformations/tests/test_featureizer.py
+++ b/aeon/transformations/tests/test_featureizer.py
@@ -1,6 +1,6 @@
 """Test YtoX."""
 
-__author__ = ["aiwalter", "fkiraly"]
+__maintainer__ = []
 
 from numpy.testing import assert_array_equal
 

--- a/aeon/transformations/tests/test_fitintransform.py
+++ b/aeon/transformations/tests/test_fitintransform.py
@@ -1,6 +1,6 @@
 """Unit tests of FitInTransform functionality."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = []
 
 from pandas.testing import assert_series_equal

--- a/aeon/transformations/tests/test_fittedparamextractor.py
+++ b/aeon/transformations/tests/test_fittedparamextractor.py
@@ -1,6 +1,6 @@
 """Tests for FittedParamExtractor."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = []
 
 import pytest

--- a/aeon/transformations/tests/test_imputer.py
+++ b/aeon/transformations/tests/test_imputer.py
@@ -1,6 +1,6 @@
 """Unit tests of Imputer functionality."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/tests/test_kalman_filter.py
+++ b/aeon/transformations/tests/test_kalman_filter.py
@@ -1,6 +1,6 @@
 """Kalman Filter transformers unit tests."""
 
-__author__ = ["NoaBenAmi", "hadifawaz1999", "lmmentel"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/tests/test_lag.py
+++ b/aeon/transformations/tests/test_lag.py
@@ -1,6 +1,6 @@
 """Tests for Lag transformer."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import itertools
 

--- a/aeon/transformations/tests/test_multiplexer.py
+++ b/aeon/transformations/tests/test_multiplexer.py
@@ -1,6 +1,6 @@
 """Tests for MultiplexTransformer and associated dunders."""
 
-__author__ = ["miraep8"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/transformations/tests/test_pca.py
+++ b/aeon/transformations/tests/test_pca.py
@@ -1,6 +1,6 @@
 """Tests for PCATransformer."""
 
-__author__ = ["aiwalter"]
+__maintainer__ = []
 
 from aeon.testing.utils.data_gen import make_series
 from aeon.transformations.pca import PCATransformer

--- a/aeon/transformations/tests/test_scaledlogit.py
+++ b/aeon/transformations/tests/test_scaledlogit.py
@@ -1,6 +1,6 @@
 """ScaledLogit transform unit tests."""
 
-__author__ = ["ltsaprounis"]
+__maintainer__ = []
 
 from warnings import warn
 

--- a/aeon/transformations/tests/test_sklearn_adaptor.py
+++ b/aeon/transformations/tests/test_sklearn_adaptor.py
@@ -1,6 +1,6 @@
 """Tests for TabularToSeriesAdaptor."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 
 import numpy as np
 from scipy.stats import boxcox

--- a/aeon/transformations/tests/test_subset.py
+++ b/aeon/transformations/tests/test_subset.py
@@ -1,6 +1,6 @@
 """Tests for the subsetting transformers."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pandas as pd
 import pytest

--- a/aeon/transformations/tests/test_summarize.py
+++ b/aeon/transformations/tests/test_summarize.py
@@ -1,6 +1,6 @@
 """Test functionality of summary transformer."""
 
-__author__ = ["RNKuhns"]
+__maintainer__ = []
 import re
 
 import numpy as np

--- a/aeon/transformations/tests/test_theta.py
+++ b/aeon/transformations/tests/test_theta.py
@@ -1,6 +1,6 @@
 """Unit tests of ThetaLinesTransformer functionality."""
 
-__author__ = ["Guzal Bulatova"]
+__maintainer__ = []
 __all__ = []
 
 import numpy as np

--- a/aeon/transformations/tests/test_time_since.py
+++ b/aeon/transformations/tests/test_time_since.py
@@ -1,6 +1,6 @@
 """Tests for TimeSince transformer."""
 
-__author__ = ["KishManani"]
+__maintainer__ = []
 
 
 import pandas as pd

--- a/aeon/transformations/tests/test_window_summarizer.py
+++ b/aeon/transformations/tests/test_window_summarizer.py
@@ -1,6 +1,6 @@
 """Test extraction of features across (shifted) windows."""
 
-__author__ = ["danbartl"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/transformations/theta.py
+++ b/aeon/transformations/theta.py
@@ -1,6 +1,6 @@
 """Implements Theta-lines transformation for use with Theta forecasting."""
 
-__author__ = ["GuzalBulatova", "mloning"]
+__maintainer__ = []
 __all__ = ["ThetaLinesTransformer"]
 
 import numpy as np

--- a/aeon/transformations/time_since.py
+++ b/aeon/transformations/time_since.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__author__ = ["KishManani"]
+__maintainer__ = []
 
 import datetime
 import warnings

--- a/aeon/utils/_maint/_show_versions.py
+++ b/aeon/utils/_maint/_show_versions.py
@@ -3,7 +3,7 @@
 adapted from :func:`sklearn.show_versions`
 """
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["show_versions"]
 
 import platform

--- a/aeon/utils/datetime.py
+++ b/aeon/utils/datetime.py
@@ -1,6 +1,6 @@
 """Time format related utilities."""
 
-__author__ = ["mloning", "xiaobenbenecho", "khrapovs"]
+__maintainer__ = []
 __all__ = []
 
 import warnings

--- a/aeon/utils/estimator_checks.py
+++ b/aeon/utils/estimator_checks.py
@@ -1,6 +1,6 @@
 """Estimator checker for extension."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = ["check_estimator"]
 
 from inspect import isclass

--- a/aeon/utils/mlflow_aeon.py
+++ b/aeon/utils/mlflow_aeon.py
@@ -32,7 +32,7 @@ mlflow.pyfunc
     `pyfunc.predict()` will return output from aeon `predict()` method.
 """
 
-__author__ = ["benjaminbluhm"]
+__maintainer__ = []
 __all__ = [
     "get_default_pip_requirements",
     "get_default_conda_env",

--- a/aeon/utils/multiindex.py
+++ b/aeon/utils/multiindex.py
@@ -1,6 +1,6 @@
 """Multiindex formatting related utilities."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 __all__ = []
 
 import pandas as pd

--- a/aeon/utils/numba/general.py
+++ b/aeon/utils/numba/general.py
@@ -1,6 +1,6 @@
 """General numba utilities."""
 
-__author__ = ["MatthewMiddlehurst", "baraline"]
+__maintainer__ = []
 __all__ = [
     "generate_new_default_njit_func",
     "unique_count",

--- a/aeon/utils/numba/stats.py
+++ b/aeon/utils/numba/stats.py
@@ -1,6 +1,6 @@
 """Numba statistic utilities."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 __all__ = [
     "mean",
     "row_mean",

--- a/aeon/utils/numba/tests/__init__.py
+++ b/aeon/utils/numba/tests/__init__.py
@@ -1,3 +1,1 @@
 """Tests for numba utils."""
-
-__author__ = ["TonyBagnall"]

--- a/aeon/utils/numba/tests/test_general.py
+++ b/aeon/utils/numba/tests/test_general.py
@@ -1,6 +1,6 @@
 """Tests for numba functions."""
 
-__author__ = ["TonyBagnall", "baraline"]
+__maintainer__ = []
 
 import numpy as np
 import pytest

--- a/aeon/utils/numba/tests/test_stats.py
+++ b/aeon/utils/numba/tests/test_stats.py
@@ -1,6 +1,6 @@
 """Tests for numba utils functions related to statistical operations."""
 
-__author__ = ["baraline"]
+__maintainer__ = []
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/aeon/utils/plotting.py
+++ b/aeon/utils/plotting.py
@@ -4,7 +4,7 @@ Moved to aeon.visualisation in v0.6.*. todo remove in v0.8.0
 """
 
 __all__ = ["plot_series", "plot_correlations", "plot_windows"]
-__author__ = ["mloning", "RNKuhns", "Drishti Bhasin", "chillerobscuro"]
+__maintainer__ = []
 
 import math
 from warnings import simplefilter, warn

--- a/aeon/utils/seasonality.py
+++ b/aeon/utils/seasonality.py
@@ -1,6 +1,6 @@
 # noqa: D100
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = []
 
 from warnings import warn

--- a/aeon/utils/sklearn.py
+++ b/aeon/utils/sklearn.py
@@ -9,7 +9,7 @@ from sklearn.pipeline import Pipeline
 
 from aeon.base import BaseObject
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 
 def is_sklearn_estimator(obj):

--- a/aeon/utils/stats.py
+++ b/aeon/utils/stats.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.utils.stats import _weighted_percentile
 from sklearn.utils.validation import check_consistent_length
 
-__author__ = ["RNKuhns", "GuzalBulatova"]
+__maintainer__ = []
 __all__ = [
     "_weighted_geometric_mean",
     "_weighted_median",

--- a/aeon/utils/tests/test_check_estimator.py
+++ b/aeon/utils/tests/test_check_estimator.py
@@ -1,6 +1,6 @@
 """Tests for check_estimator."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 import pytest
 

--- a/aeon/utils/tests/test_datetime.py
+++ b/aeon/utils/tests/test_datetime.py
@@ -1,6 +1,6 @@
 """Tests for datetime functions."""
 
-__author__ = ["xiaobenbenecho", "khrapovs"]
+__maintainer__ = []
 
 import datetime
 

--- a/aeon/utils/tests/test_mlflow_aeon_model_export.py
+++ b/aeon/utils/tests/test_mlflow_aeon_model_export.py
@@ -1,6 +1,6 @@
 """Tests for mlflow-aeon custom model flavor."""
 
-__author__ = ["benjaminbluhm"]
+__maintainer__ = []
 
 import sys
 from pathlib import Path

--- a/aeon/utils/tests/test_sklearn_typing.py
+++ b/aeon/utils/tests/test_sklearn_typing.py
@@ -1,6 +1,6 @@
 """Tests for sklearn typing utilities in utils.aeon."""
 
-__author__ = ["fkiraly"]
+__maintainer__ = []
 
 
 import pytest

--- a/aeon/utils/validation/__init__.py
+++ b/aeon/utils/validation/__init__.py
@@ -20,7 +20,6 @@ __all__ = [
     "is_pred_quantiles_proba",
     "is_pdmultiindex_hierarchical",
 ]
-__author__ = ["mloning", "Taiwo Owoseni", "khrapovs", "TonyBagnall"]
 
 import os
 from datetime import timedelta

--- a/aeon/utils/validation/_dependencies.py
+++ b/aeon/utils/validation/_dependencies.py
@@ -1,6 +1,6 @@
 """Utility to check soft dependency imports, and raise warnings or errors."""
 
-__author__ = ["fkiraly", "mloning"]
+__maintainer__ = []
 
 import io
 import sys

--- a/aeon/utils/validation/annotation.py
+++ b/aeon/utils/validation/annotation.py
@@ -1,6 +1,6 @@
 """Series of checks for annotation classes."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = ["check_fmt", "check_labels"]
 
 

--- a/aeon/utils/validation/forecasting.py
+++ b/aeon/utils/validation/forecasting.py
@@ -13,7 +13,7 @@ __all__ = [
     "check_sp",
     "check_regressor",
 ]
-__author__ = ["mloning", "@big-o", "khrapovs"]
+__maintainer__ = []
 
 from datetime import timedelta
 from typing import Optional, Union

--- a/aeon/utils/validation/panel.py
+++ b/aeon/utils/validation/panel.py
@@ -1,6 +1,6 @@
 """Utilities for validating panel data."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 __all__ = [
     "check_X",
     "check_y",

--- a/aeon/utils/validation/series.py
+++ b/aeon/utils/validation/series.py
@@ -1,6 +1,6 @@
 """Functions for checking input data."""
 
-__author__ = ["mloning", "Drishti Bhasin", "khrapovs"]
+__maintainer__ = []
 __all__ = [
     "check_series",
     "check_time_index",

--- a/aeon/utils/validation/tests/test_forecasting.py
+++ b/aeon/utils/validation/tests/test_forecasting.py
@@ -1,6 +1,6 @@
 """Test forecasting module."""
 
-__author__ = ["mloning"]
+__maintainer__ = []
 
 from datetime import timedelta
 

--- a/aeon/utils/validation/tests/test_panel.py
+++ b/aeon/utils/validation/tests/test_panel.py
@@ -1,6 +1,6 @@
 """Unit tests for aeon.utils.validation.panel check functions."""
 
-__author__ = ["mloning", "TonyBagnall"]
+__maintainer__ = []
 __all__ = ["test_check_X_bad_input_args"]
 
 import numpy as np

--- a/aeon/utils/validation/tests/test_series.py
+++ b/aeon/utils/validation/tests/test_series.py
@@ -1,6 +1,6 @@
 """Test series module."""
 
-__author__ = ["benheid", "TonyBagnall"]
+__maintainer__ = []
 
 import numpy as np
 import pandas as pd

--- a/aeon/visualisation/estimator/_clasp.py
+++ b/aeon/visualisation/estimator/_clasp.py
@@ -2,7 +2,7 @@ __all__ = [
     "plot_series_with_profiles",
 ]
 
-__author__ = ["patrickzib"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/visualisation/estimator/_clustering.py
+++ b/aeon/visualisation/estimator/_clustering.py
@@ -1,6 +1,6 @@
 """Cluster plotting tools."""
 
-__author__ = ["Christopher Holder", "Tony Bagnall"]
+__maintainer__ = []
 
 __all__ = ["plot_cluster_algorithm"]
 

--- a/aeon/visualisation/estimator/_temporal_importance_curves.py
+++ b/aeon/visualisation/estimator/_temporal_importance_curves.py
@@ -1,6 +1,6 @@
 """Temporal importance curve diagram generators for interval forests."""
 
-__author__ = ["MatthewMiddlehurst"]
+__maintainer__ = []
 
 __all__ = ["plot_temporal_importance_curves"]
 

--- a/aeon/visualisation/estimator/deep_learning/_network_plot.py
+++ b/aeon/visualisation/estimator/deep_learning/_network_plot.py
@@ -1,5 +1,5 @@
 __all__ = ["plot_network"]
-__author__ = ["hadifawaz1999"]
+__maintainer__ = []
 
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 

--- a/aeon/visualisation/learning_task/_segmentation.py
+++ b/aeon/visualisation/learning_task/_segmentation.py
@@ -4,7 +4,7 @@ __all__ = [
     "plot_series_with_change_points",
 ]
 
-__author__ = ["patrickzib"]
+__maintainer__ = []
 
 import numpy as np
 

--- a/aeon/visualisation/results/_boxplot.py
+++ b/aeon/visualisation/results/_boxplot.py
@@ -1,6 +1,6 @@
 """Functions for plotting results boxplot diagrams."""
 
-__author__ = ["dguijo"]
+__maintainer__ = []
 
 __all__ = [
     "plot_boxplot_median",

--- a/aeon/visualisation/results/_critical_difference.py
+++ b/aeon/visualisation/results/_critical_difference.py
@@ -1,6 +1,6 @@
 """Function to compute and plot critical difference diagrams."""
 
-__author__ = ["SveaMeyer13", "dguijo", "TonyBagnall"]
+__maintainer__ = []
 
 __all__ = [
     "plot_critical_difference",

--- a/aeon/visualisation/results/_scatter.py
+++ b/aeon/visualisation/results/_scatter.py
@@ -1,6 +1,6 @@
 """Functions for plotting results scatter diagrams."""
 
-__author__ = ["dguijo"]
+__maintainer__ = []
 
 __all__ = [
     "plot_pairwise_scatter",

--- a/aeon/visualisation/results/_significance.py
+++ b/aeon/visualisation/results/_significance.py
@@ -1,6 +1,6 @@
 """Function to compute and plot significance."""
 
-__author__ = ["dguijo", "TonyBagnall"]
+__maintainer__ = []
 
 __all__ = [
     "plot_significance",

--- a/aeon/visualisation/series/_series.py
+++ b/aeon/visualisation/series/_series.py
@@ -1,7 +1,7 @@
 """Common timeseries plotting functionality."""
 
 __all__ = ["plot_series", "plot_lags", "plot_correlations"]
-__author__ = ["mloning", "RNKuhns", "Drishti Bhasin", "chillerobscuro"]
+__maintainer__ = []
 
 import math
 from warnings import warn

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ tests are run on each operating system at least once, and on each python version
 least once, but not necessarily on each operating system / python version combination.
 """
 
-__author__ = ["fkiraly", "MatthewMiddlehurst"]
+__maintainer__ = []
 
 from aeon.testing import test_config
 

--- a/extension_templates/forecasting.py
+++ b/extension_templates/forecasting.py
@@ -39,7 +39,7 @@ Testing - implement if aeon forecaster (not needed locally):
 # todo: write an informative docstring for the file or module, remove the above
 
 # todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+# __maintainer__ = []
 
 
 from aeon.forecasting.base import BaseForecaster

--- a/extension_templates/forecasting_simple.py
+++ b/extension_templates/forecasting_simple.py
@@ -36,7 +36,7 @@ Testing - implement if aeon forecaster (not needed locally):
 # todo: write an informative docstring for the file or module, remove the above
 
 # todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+# __maintainer__ = []
 
 
 from aeon.forecasting.base import BaseForecaster

--- a/extension_templates/transformer.py
+++ b/extension_templates/transformer.py
@@ -36,7 +36,7 @@ Testing - implement if aeon transformer (not needed locally):
 # todo: write an informative docstring for the file or module, remove the above
 
 # todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+# __maintainer__ = []
 
 # todo: add any necessary aeon external imports here
 

--- a/extension_templates/transformer_simple.py
+++ b/extension_templates/transformer_simple.py
@@ -36,7 +36,7 @@ Testing - implement if aeon transformer (not needed locally):
 # todo: write an informative docstring for the file or module, remove the above
 
 # todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
+# __maintainer__ = []
 
 # todo: add any necessary aeon external imports here
 


### PR DESCRIPTION
 Implements #1095. See issue for reasoning.

Big annoying PR that replaces `__author__` with blank `__maintainer__` lines.