### PR TITLE
[MNT] Test if pycatch22 on windows passes all nighter

### DIFF
--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -141,10 +141,10 @@ class Catch22(BaseCollectionTransformer):
     def __init__(
         self,
         features="all",
-        catch24=True,
+        catch24=False,
         outlier_norm=False,
         replace_nans=False,
-        use_pycatch22=False,
+        use_pycatch22=True,
         n_jobs=1,
         parallel_backend=None,
     ):

--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -77,7 +77,7 @@ class Catch22(BaseCollectionTransformer):
         while to process for large values.
     replace_nans : bool, default=False
         Replace NaN or inf values from the Catch22 transform with 0.
-    use_pycatch22 : bool, optional, default=False
+    use_pycatch22 : bool, optional, default=True
         Wraps the C based pycatch22 implementation for aeon.
         (https://github.com/DynamicsAndNeuralSystems/pycatch22). This requires the
         ``pycatch22`` package to be installed if True.
@@ -141,7 +141,7 @@ class Catch22(BaseCollectionTransformer):
     def __init__(
         self,
         features="all",
-        catch24=False,
+        catch24=True,
         outlier_norm=False,
         replace_nans=False,
         use_pycatch22=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ all_extras = [
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",
     "xarray",
+    "pycatch22<=0.4.3",
 ]
 dl = [
     "keras-self-attention",
@@ -92,7 +93,6 @@ dl = [
 ]
 unstable_extras = [
     "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'",  # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
-    "pycatch22<=0.4.3",  # known to fail installation on some setups
 ]
 dev = [
     "backoff",


### PR DESCRIPTION
Trying to see if setting `use_pycatch22` to True would fail or not on windows tests

- [ ] run 1
- [ ] run 2
- [ ] run 3
- [ ] run 4
- [ ] run 5
- [ ] run 6
- [ ] run 7
- [ ] run 8
- [ ] run 9
- [ ] run 10
