### PR TITLE
[MNT] Force all numba functions to cache during CI runs

### DIFF
--- a/aeon/testing/utils/_cicd_numba_caching.py
+++ b/aeon/testing/utils/_cicd_numba_caching.py
@@ -88,3 +88,23 @@ def custom_load_index(self):
 
 original_load_index = numba.core.caching.IndexDataCacheFile._load_index
 numba.core.caching.IndexDataCacheFile._load_index = custom_load_index
+
+
+# Force all numba functions to be cached
+original_jit = numba.core.decorators._jit
+
+def custom_njit(*args, **kwargs):
+    """Custom wrapper for numba's jit decorator to enforce caching.
+
+    This is used for libraries like stumpy that doesn't cache by default. This
+    function will force all functions running to be cache'd
+    """
+    target = kwargs['targetoptions']
+    # This target can't be cached
+    if 'no_cpython_wrapper' not in target:
+        kwargs["cache"] = True
+    return original_jit(*args, **kwargs)
+
+
+# Overwrite the jit function with the custom version
+numba.core.decorators._jit = custom_njit

--- a/aeon/transformations/series/tests/test_matrix_profile.py
+++ b/aeon/transformations/series/tests/test_matrix_profile.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from aeon.transformations.series import MatrixProfileSeriesTransformer
 from aeon.utils.validation._dependencies import _check_soft_dependencies
-
+import aeon.testing.utils._cicd_numba_caching
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("stumpy", severity="none"),
@@ -28,3 +27,49 @@ def test_matrix_profile():
     )
     np.testing.assert_allclose(res1, expected, rtol=1e-04, atol=1e-04)
     np.testing.assert_allclose(res1, res2, rtol=1e-04, atol=1e-04)
+
+# Now, when you import your library, any usage of @jit will have cache=True enforced
+
+# if __name__ == "__main__":
+#
+#     import numba.core.decorators
+#     # Capture the original jit function
+#     original_jit = numba.core.decorators._jit
+#
+#
+#     def custom_njit(*args, **kwargs):
+#         """Custom wrapper for numba's jit decorator to enforce caching."""
+#         # Check if the first argument is a callable (i.e., a function), indicating that
+#         # jit is used as a decorator without parentheses.
+#         # kwargs.update({"cache": True})
+#         target = kwargs['targetoptions']
+#         if 'no_cpython_wrapper' not in target:
+#             kwargs["cache"] = True
+#         return original_jit(*args, **kwargs)
+#
+#
+#     # Overwrite the jit function with the custom version
+#     numba.core.decorators._jit = custom_njit
+#
+#     from aeon.distances import dtw_distance
+#     from aeon.transformations.series import MatrixProfileSeriesTransformer
+#
+#     print("Starting")
+#     dtw_distance(np.array([1, 2, 3]), np.array([1, 2, 3]))
+#
+#     series = np.array([584.0, -11.0, 23.0, 79.0, 1001.0, 0.0, -19.0])
+#     series2 = pd.Series([584.0, -11.0, 23.0, 79.0, 1001.0, 0.0, -19.0])
+#     mp = MatrixProfileSeriesTransformer(window_length=3)
+#     res1 = mp.fit_transform(series)
+#     res2 = mp.fit_transform(series2)
+#     expected = np.array(
+#         [
+#             0.11633857113691416,
+#             2.694073918063438,
+#             3.0000926340485923,
+#             2.694073918063438,
+#             0.11633857113691416,
+#         ]
+#     )
+#     np.testing.assert_allclose(res1, expected, rtol=1e-04, atol=1e-04)
+#     np.testing.assert_allclose(res1, res2, rtol=1e-04, atol=1e-04)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ addopts = '''
     --reruns 2
     --only-rerun "crashed while running"
 '''
+
 filterwarnings = '''
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
