### PR TITLE
[REF] Refactoring some bits of code

### DIFF
--- a/aeon/forecasting/dynamic_factor.py
+++ b/aeon/forecasting/dynamic_factor.py
@@ -259,7 +259,7 @@ class DynamicFactor(_StatsModelsAdapter):
                 Upper/lower interval end forecasts are equivalent to
                 quantile forecasts at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        if type(coverage) is not list:
+        if not isinstance(coverage, list):
             coverage_list = [coverage]
         else:
             coverage_list = coverage

--- a/aeon/testing/expected_results/classifier_results_reproduction.py
+++ b/aeon/testing/expected_results/classifier_results_reproduction.py
@@ -1,7 +1,7 @@
 """Functions for generating stored unit test results for classifiers."""
 
 import numpy as np
-from sklearn.ensemble import IsolationForest, RandomForestClassifier
+from sklearn.ensemble import IsolationForest
 from sklearn.utils._testing import set_random_state
 
 from aeon.classification import BaseClassifier
@@ -38,7 +38,6 @@ from aeon.classification.interval_based import (
 )
 from aeon.classification.shapelet_based import ShapeletTransformClassifier
 from aeon.datasets import load_basic_motions, load_unit_test
-from aeon.transformations.summarize import SummaryTransformer
 
 
 def _reproduce_classification_unit_test(estimator):

--- a/aeon/visualisation/results/_critical_difference.py
+++ b/aeon/visualisation/results/_critical_difference.py
@@ -181,7 +181,8 @@ def plot_critical_difference(
     ordered_avg_ranks = ranks.mean(axis=0)
     # Sort labels and ranks
     ordered_labels_ranks = np.array(
-        [(l, float(r)) for r, l in sorted(zip(ordered_avg_ranks, labels))], dtype=object
+        [(labels, float(r)) for r, labels in sorted(zip(ordered_avg_ranks, labels))],
+        dtype=object,
     )
     ordered_labels = np.array([la for la, _ in ordered_labels_ranks], dtype=str)
     ordered_avg_ranks = np.array([r for _, r in ordered_labels_ranks], dtype=np.float32)


### PR DESCRIPTION
-`type()` cant be used to check the specific type, thus we use `isinstance()` to check if an object is of a particular type. -`RandomForestCLassifier` and `SummaryTransformer` were not called but imported -Undefined name `l` was replaced by labels

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
from: https://github.com/aeon-toolkit/aeon/issues/1191 , See also: https://github.com/aeon-toolkit/aeon/pull/1055
closes: #1197 
