### PR TITLE
[MNT] added unequal length utils function

### DIFF
--- a/aeon/testing/utils/data_gen/__init__.py
+++ b/aeon/testing/utils/data_gen/__init__.py
@@ -24,7 +24,6 @@ __all__ = [
     "_make_collection",
     "_make_nested_from_array",
     "_make_regression_y",
-    "_make_tabular_data",
     "_make_fh",
     "_assert_correct_columns",
     "_assert_correct_pred_time_index",
@@ -32,6 +31,7 @@ __all__ = [
     "_convert_tsf_to_hierarchical",
     "_get_n_columns",
     "get_examples",
+    "make_example_2d_unequal_length",
 ]
 
 
@@ -42,6 +42,7 @@ from aeon.testing.utils.data_gen._collection import (
     _make_nested_from_array,
     _make_regression_y,
     make_example_2d_numpy,
+    make_example_2d_unequal_length,
     make_example_3d_numpy,
     make_example_long_table,
     make_example_multi_index_dataframe,

--- a/aeon/testing/utils/data_gen/_collection.py
+++ b/aeon/testing/utils/data_gen/_collection.py
@@ -116,7 +116,7 @@ def make_example_2d_numpy(
     Returns
     -------
     X : np.ndarray
-        Randomly generated 2D data.
+        Randomly generated 1D data.
     y : np.ndarray
         Randomly generated labels if return_y is True.
 

--- a/aeon/testing/utils/data_gen/_collection.py
+++ b/aeon/testing/utils/data_gen/_collection.py
@@ -148,6 +148,78 @@ def make_example_2d_numpy(
     return X
 
 
+def make_example_2d_unequal_length(
+    n_cases: int = 10,
+    min_series_length: int = 6,
+    max_series_length: int = 8,
+    n_labels: int = 2,
+    regression_target: bool = False,
+    random_state: Union[int, None] = None,
+    return_y: bool = True,
+) -> Union[List[np.ndarray], Tuple[List[np.ndarray], np.ndarray]]:
+    """Randomly generate 2D unequal length X and y for testing.
+
+    Will ensure there is at least one sample per label if a classification
+    label is being returned (regression_target=False).
+
+    Parameters
+    ----------
+    n_cases : int
+        The number of samples to generate.
+    min_series_length : int
+        The minimum number of features/series length to generate for invidiaul series.
+    max_series_length : int
+        The maximum number of features/series length to generate for invidiaul series.
+    n_labels : int
+        The number of unique labels to generate.
+    regression_target : bool
+        If True, the target will be a scalar float, otherwise an int.
+    random_state : int or None
+        Seed for random number generation.
+    return_y : bool, default = True
+        Return the y target variable.
+
+    Returns
+    -------
+    X : list of np.ndarray
+        Randomly generated unequal length 2D data.
+    y : np.ndarray
+        Randomly generated labels.
+
+    Examples
+    --------
+    >>> from aeon.testing.utils.data_gen import make_example_2d_unequal_length
+    >>> data, labels = make_example_2d_unequal_length(
+    ...     n_cases=20,
+    ...     min_series_length=8,
+    ...     max_series_length=12,
+    ...     n_labels=3,
+    ... )
+    """
+    rng = np.random.RandomState(random_state)
+    X = []
+    y = np.zeros(n_cases, dtype=np.int32)
+    for i in range(n_cases):
+        series_length = rng.randint(min_series_length, max_series_length + 1)
+        x = n_labels * rng.uniform(size=series_length)
+        label = x[0].astype(int)
+        if i < n_labels and n_cases > i:
+            x[0] = i
+            label = i
+        x = x * (label + 1)
+
+        X.append(x)
+        y[i] = label
+
+    if regression_target:
+        y = y.astype(np.float32)
+        y += rng.uniform(size=y.shape)
+
+    if return_y:
+        return X, y
+    return X
+
+
 def make_example_unequal_length(
     n_cases: int = 10,
     n_channels: int = 1,
@@ -156,6 +228,7 @@ def make_example_unequal_length(
     n_labels: int = 2,
     regression_target: bool = False,
     random_state: Union[int, None] = None,
+    return_y: bool = True,
 ) -> Tuple[List[np.ndarray], np.ndarray]:
     """Randomly generate unequal length X and y for testing.
 
@@ -178,6 +251,8 @@ def make_example_unequal_length(
         If True, the target will be a scalar float, otherwise an int.
     random_state : int or None
         Seed for random number generation.
+    return_y : bool, default = True
+        Return the y target variable.
 
     Returns
     -------
@@ -217,7 +292,9 @@ def make_example_unequal_length(
         y = y.astype(np.float32)
         y += rng.uniform(size=y.shape)
 
-    return X, y
+    if return_y:
+        return X, y
+    return X
 
 
 def make_example_nested_dataframe(

--- a/aeon/testing/utils/data_gen/tests/test_collection.py
+++ b/aeon/testing/utils/data_gen/tests/test_collection.py
@@ -12,6 +12,7 @@ from aeon.testing.utils.data_gen import (
     _make_nested_from_array,
     _make_regression_y,
     make_example_2d_numpy,
+    make_example_2d_unequal_length,
     make_example_3d_numpy,
     make_example_nested_dataframe,
     make_example_unequal_length,
@@ -122,6 +123,28 @@ def test_make_unequal_length_data(
     assert len(X) == len(y) == n_cases
     assert X[0].shape[0] == n_channels
     assert abs(X[0].shape[1] - n_timepoints) <= 1
+    if regression:
+        assert y.dtype == np.float32
+    else:
+        assert len(np.unique(y)) == n_classes
+
+
+@pytest.mark.parametrize("n_cases", N_INSTANCES)
+@pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
+@pytest.mark.parametrize("n_classes", N_CLASSES)
+@pytest.mark.parametrize("regression", [True, False])
+def test_make_2d_unequal_length_data(n_cases, n_timepoints, n_classes, regression):
+    """Test data of right format."""
+    X, y = make_example_2d_unequal_length(
+        n_cases=n_cases,
+        min_series_length=n_timepoints - 1,
+        max_series_length=n_timepoints + 1,
+        n_labels=n_classes,
+        regression_target=regression,
+    )
+    assert isinstance(X, list)
+    assert len(X) == len(y) == n_cases
+    assert abs(X[0].shape[0] - n_timepoints) <= 1
     if regression:
         assert y.dtype == np.float32
     else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR adds a function to generate 2d unequal length time series list[np.ndarray(n_timepoints,)], which is a collection of univariate 1d time series. In addition it adds the option to choose to return_y to be consistent with other test functions in the file (such as make_example_3d_numpy and make_example_2d_numpy)

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
