### PR TITLE
[BUG] write_to_tsfile not writing header

### DIFF
--- a/aeon/datasets/_data_writers.py
+++ b/aeon/datasets/_data_writers.py
@@ -50,7 +50,9 @@ def write_to_tsfile(
         problem_name = problem_name + ".ts"
 
     if isinstance(X, np.ndarray) or isinstance(X, list):
-        _write_data_to_tsfile(X, path, problem_name, y=y, regression=regression)
+        _write_data_to_tsfile(
+            X, path, problem_name, y=y, comment=header, regression=regression
+        )
     else:
         _write_dataframe_to_tsfile(
             X,


### PR DESCRIPTION
* Parameter now passed correctly.

#### What does this implement/fix? Explain your changes.

Saving a collection of time series in np.ndarrays or list format with the write_to_tsfile method did not create the header correctly. A parameter was missing and is now passed.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

My first ever PR, let me know if there is anything to improve!
Unsure if this is a BUG or MNT.

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

<!--
Thanks for contributing!
-->
