### PR TITLE
[DEP] Deprecating ShapeDTW classifier, to be replaced with a newer correct version

### DIFF
--- a/aeon/classification/distance_based/_shape_dtw.py
+++ b/aeon/classification/distance_based/_shape_dtw.py
@@ -4,6 +4,7 @@ Nearest neighbour classifier that extracts shape features.
 """
 
 import numpy as np
+from deprecated.sphinx import deprecated
 
 # Tuning
 from sklearn.model_selection import GridSearchCV, KFold
@@ -26,6 +27,12 @@ from aeon.utils.numba.general import slope_derivative_3d
 __maintainer__ = []
 
 
+# TODO: remove in v0.9.0
+@deprecated(
+    version="0.8.0",
+    reason="ShapeDTW classifier will be removed in v0.9.0.",
+    category=FutureWarning,
+)
 class ShapeDTW(BaseClassifier):
     """
     ShapeDTW classifier.


### PR DESCRIPTION
Referring to issue #788 

The implementation supposes that shapeDTW with knn is simply knn-dtw on transformed series, this is false.
As shapeDTW distance does 2 steps:

- step 1: find dtw path on transformed series
- step 2: transfer the path on the pairwise distance between the two raw series and calculate a dtw value based on this new path