### PR TITLE
[DOC] Update papers page and remove GSoC advertisements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,6 @@ html_theme = "furo"
 # documentation.
 
 html_theme_options = {
-    "announcement": "<em>Announcement</em>: aeon is taking part in the Google Summer of Code (GSoC) 2024! See the home page for more information.",  # noqa: E501
     "sidebar_hide_name": True,
     "top_of_page_button": "edit",
     "source_repository": "https://github.com/aeon-toolkit/aeon/",

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,16 +12,6 @@ forecasting, classification and clustering.</p>
 - Interfaces with other time series packages to provide a single framework for algorithm
 comparison.
 
-```{admonition} GSoC 2024
-`aeon` is participating in Google Summer of Code 2024 under the NumFOCUS umbrella. If
-you are interested in participating, please see our [GSoC 2024 project page](https://github.com/aeon-toolkit/aeon-admin/blob/main/gsoc/gsoc-2024-projects.md).
-
-Feel free to ask questions on the dedicated [GitHub discussion](https://github.com/aeon-toolkit/aeon/discussions/1121)
-or our [Slack channel](https://join.slack.com/t/aeon-toolkit/shared_invite/zt-22vwvut29-HDpCu~7VBUozyfL_8j3dLA).
-If you are interested in contributing, click on the "Contributing to aeon" link in the
-sidebar for a contribution guide.
-```
-
 ::::{grid} 1 2 2 2
 :gutter: 3
 

--- a/docs/papers_using_aeon.md
+++ b/docs/papers_using_aeon.md
@@ -1,22 +1,34 @@
 # Papers using Aeon
 
 This is a list of papers that use `aeon`. If you have a paper that uses `aeon`,
-please
-add it to this list by sending a pull request. Please include a hyperlink to the paper and a link to the code in your personal GitHub or other repository.
+please add it to this list by sending a pull request. Please include a hyperlink to
+the paper and a link to the code in your personal GitHub or other repository.
 
 ## Classification
 
 - Middlehurst, M. and Schäfer, P. and  Bagnall, A. (2023). Bake off redux: a review
-  and experimental evaluation of recent time series classification algorithms. ArXiv. [https://arxiv.org/abs/2304.13029]
+  and experimental evaluation of recent time series classification algorithms. ArXiv.
+  [Paper](https://arxiv.org/abs/2304.13029) [Webpage/Code](https://tsml-eval.readthedocs.io/en/stable/publications/2023/tsc_bakeoff/tsc_bakeoff_2023.html)
 
 ## Clustering
 
-- Holder, C., Middlehurst, M. and Bagnall, A. (2023). A review and evaluation of elastic distance functions for time series clustering. Knowledge and Information Systems. [https://link.springer.com/article/10.1007/s10115-023-01952-0](https://link.springer.com/article/10.1007/s10115-023-01952-0)
+- Holder, C., Middlehurst, M. and Bagnall, A., 2024. A review and evaluation of elastic
+  distance functions for time series clustering. Knowledge and Information Systems,
+  66(2), pp.765-809.
+  [Paper](https://link.springer.com/article/10.1007/s10115-023-01952-0) [Webpage/Code](https://tsml-eval.readthedocs.io/en/stable/publications/2023/distance_based_clustering/distance_based_clustering.html)
 
-- Holder, C., Guijo-Rubio, D. and Bagnall, A. (2003). Clustering time series with
-  k-medoids based algorithms. 8th AALTD Workshop at ECML/PKDD. [https://ecml-aaltd.github.io/aaltd2023/papers/AALTD_K_Medoids_Clustering.pdf]
+- Holder, C., Guijo-Rubio, D. and Bagnall, A., 2023, September. Clustering time series
+  with k-medoids based algorithms. In International Workshop on Advanced Analytics and
+  Learning on Temporal Data (pp. 39-55).
+  [Paper](https://link.springer.com/chapter/10.1007/978-3-031-49896-1_4)
 
 ## Regression
 
 - Guijo-Rubio, D., Middlehurst, M., Arcencio, G., Silva, D. and Bagnall, A. (2023).
-  Unsupervised Feature Based Algorithms for Time Series Extrinsic Regression. ArXiv. [https://arxiv.org/abs/2305.01429]
+  Unsupervised Feature Based Algorithms for Time Series Extrinsic Regression. ArXiv.
+  [Paper](https://arxiv.org/abs/2305.01429) [Webpage/Code](https://tsml-eval.readthedocs.io/en/stable/publications/2023/tser_archive_expansion/tser_archive_expansion.html)
+- Middlehurst, M. and Bagnall, A., 2023, September. Extracting Features from Random
+  Subseries: A Hybrid Pipeline for Time Series Classification and Extrinsic Regression.
+  In International Workshop on Advanced Analytics and Learning on Temporal Data
+  (pp. 113-126).
+  [Paper](https://link.springer.com/chapter/10.1007/978-3-031-49896-1_8) [Webpage/Code](https://tsml-eval.readthedocs.io/en/stable/publications/2023/rist_pipeline/rist_pipeline.html)


### PR DESCRIPTION
Fixes and updates the papers page, it previously had some broken links.

Removes the GSoC announcement and advertisements now that the application deadline has passed.