### PR TITLE
[ENH] BaseSeriesTransformer maintains axis for user determined output with BaseSeriesEstimator function

### DIFF
--- a/aeon/base/_base_series.py
+++ b/aeon/base/_base_series.py
@@ -195,7 +195,7 @@ class BaseSeriesEstimator(BaseEstimator):
                 X = pd.DataFrame(X)
             else:
                 tag = self.get_tag("X_inner_type")
-                raise ValueError(f"Unknown inner type {inner} derived from {tag}")
+                raise ValueError(f"Unsupported inner type {inner} derived from {tag}")
         if axis > 1 or axis < 0:
             raise ValueError("Axis should be 0 or 1")
         if not self.get_tag("capability:multivariate"):

--- a/aeon/base/_base_series.py
+++ b/aeon/base/_base_series.py
@@ -237,8 +237,8 @@ class BaseSeriesEstimator(BaseEstimator):
 
     def _postprocess_series(self, X, axis=None):
         """Postprocess data X to revert to original shape."""
-        # If passed a univariate series, return a univariate series
-        if not self.metadata_["multivariate"]:
+        # If a univariate only transformer, return a univariate series
+        if not self.get_tag("capability:multivariate"):
             return X.squeeze()
         # If passed an axis, return with that axis
         if axis is None or axis == self.axis:

--- a/aeon/base/_base_series.py
+++ b/aeon/base/_base_series.py
@@ -235,6 +235,16 @@ class BaseSeriesEstimator(BaseEstimator):
             self.metadata_ = meta
         return self._convert_X(X, axis)
 
+    def _postprocess_series(self, X, axis=None):
+        """Postprocess data X to revert to original shape."""
+        # If passed a univariate series, return a univariate series
+        if not self.metadata_["multivariate"]:
+            return X.squeeze()
+        # If passed an axis, return with that axis
+        if axis is None or axis == self.axis:
+            return X
+        return X.T
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """

--- a/aeon/base/tests/test_base_series.py
+++ b/aeon/base/tests/test_base_series.py
@@ -176,26 +176,28 @@ def test_check_y_wrong(y_wrong):
         BaseSeriesEstimator._check_y(None, y_wrong)
 
 
-@pytest.mark.parametrize("multi", [True, False])
-def test_postprocess_univariate_series(multi):
+@pytest.mark.parametrize("returned_type", VALID_TYPES)
+def test__postprocess_series(returned_type):
     """Test data reformatted correctly."""
+    x = UNIVARIATE[returned_type]
     dummy1 = BaseSeriesEstimator()
-    dummy1.metadata_ = {}
-    dummy1.metadata_["multivariate"] = multi
-    x = np.random.random(size=(10))
+    tags = {"capability:multivariate": False}
+    dummy1.set_tags(**tags)
     y = dummy1._postprocess_series(x)
-    assert y.shape == x.shape
-    x = np.random.random(size=(1, 10))
-    y1 = dummy1._postprocess_series(x)
     y2 = dummy1._postprocess_series(x, axis=0)
     y3 = dummy1._postprocess_series(x, axis=1)
-    if multi:
-        assert y1.shape == x.shape and y2.shape == x.shape
-        assert y3.shape[1] == x.shape[0] and y3.shape[0] == x.shape[1]
-    else:
-        assert len(y1) == 10 and y1.ndim == 1
-        assert len(y2) == 10 and y2.ndim == 1
-        assert len(y3) == 10 and y3.ndim == 1
+    assert y.ndim == 1
+    assert y2.shape == y3.shape
+    tags = {"capability:multivariate": True}
+    dummy1.set_tags(**tags)
+    x = MULTIVARIATE[returned_type]
+    y = dummy1._postprocess_series(x)
+    y2 = dummy1._postprocess_series(x, axis=0)
+    y3 = dummy1._postprocess_series(x, axis=1)
+    assert x.shape == y.shape
+    assert y.shape == y2.shape
+    if returned_type != "pd.Series":
+        assert y.shape[0] == y3.shape[1] and y.shape[1] == y3.shape[0]
 
 
 def test_postprocess_multivariate_series():

--- a/aeon/base/tests/test_base_series.py
+++ b/aeon/base/tests/test_base_series.py
@@ -198,17 +198,3 @@ def test__postprocess_series(returned_type):
     assert y.shape == y2.shape
     if returned_type != "pd.Series":
         assert y.shape[0] == y3.shape[1] and y.shape[1] == y3.shape[0]
-
-
-def test_postprocess_multivariate_series():
-    """Test data reformatted correctly."""
-    dummy1 = BaseSeriesEstimator()
-    dummy1.metadata_ = {}
-    dummy1.metadata_["multivariate"] = True
-    x = np.random.random(size=(3, 10))
-    y = dummy1._postprocess_series(x)
-    assert y.shape == x.shape
-    y1 = dummy1._postprocess_series(x, axis=0)
-    assert y1.shape == x.shape
-    y2 = dummy1._postprocess_series(x, axis=1)
-    assert y2.shape[1] == x.shape[0] and y2.shape[0] == x.shape[1]

--- a/aeon/base/tests/test_base_series.py
+++ b/aeon/base/tests/test_base_series.py
@@ -25,6 +25,11 @@ def test__check_X():
         dummy1._check_X(multi_np)
     with pytest.raises(ValueError, match=r"Multivariate data not supported"):
         dummy1._check_X(multi_pd)
+    missing = np.random.rand(4, 10)
+    missing[3][8] = np.NAN
+    with pytest.raises(ValueError, match=r"Missing values not supported"):
+        dummy1._check_X(missing)
+
     dummy2 = BaseSeriesEstimator()
     all_tags = {
         "capability:multivariate": True,
@@ -58,6 +63,9 @@ def test__check_X():
         dummy2._check_X(uni_np)
     with pytest.raises(ValueError, match=r"Univariate data not supported"):
         dummy2._check_X(uni_pd)
+    wrong_size = np.random.rand(10, 2, 20)
+    with pytest.raises(ValueError, match=r"Should be 1D or 2D"):
+        dummy2._check_X(wrong_size)
 
 
 UNIVARIATE = {

--- a/aeon/testing/mock_estimators/__init__.py
+++ b/aeon/testing/mock_estimators/__init__.py
@@ -12,6 +12,8 @@ __all__ = [
     "SupervisedMockSegmenter",
     "MockHandlesAllInput",
     "MockRegressor",
+    "MockSeriesTransformer",
+    "MockSeriesTransformerNoFit",
 ]
 
 from aeon.testing.mock_estimators._mock_classifiers import (
@@ -32,4 +34,8 @@ from aeon.testing.mock_estimators._mock_regressors import (
 from aeon.testing.mock_estimators._mock_segmenters import (
     MockSegmenter,
     SupervisedMockSegmenter,
+)
+from aeon.testing.mock_estimators._mock_series_transformers import (
+    MockSeriesTransformer,
+    MockSeriesTransformerNoFit,
 )

--- a/aeon/testing/mock_estimators/__init__.py
+++ b/aeon/testing/mock_estimators/__init__.py
@@ -12,8 +12,9 @@ __all__ = [
     "SupervisedMockSegmenter",
     "MockHandlesAllInput",
     "MockRegressor",
-    "MockSeriesTransformer",
+    "MockMultivariateSeriesTransformer",
     "MockSeriesTransformerNoFit",
+    "MockUnivariateSeriesTransformer",
 ]
 
 from aeon.testing.mock_estimators._mock_classifiers import (
@@ -36,6 +37,7 @@ from aeon.testing.mock_estimators._mock_segmenters import (
     SupervisedMockSegmenter,
 )
 from aeon.testing.mock_estimators._mock_series_transformers import (
-    MockSeriesTransformer,
+    MockMultivariateSeriesTransformer,
     MockSeriesTransformerNoFit,
+    MockUnivariateSeriesTransformer,
 )

--- a/aeon/testing/mock_estimators/_mock_series_transformers.py
+++ b/aeon/testing/mock_estimators/_mock_series_transformers.py
@@ -5,7 +5,103 @@ import numpy as np
 from aeon.transformations.series import BaseSeriesTransformer
 
 
-class MockSeriesTransformer(BaseSeriesTransformer):
+class MockUnivariateSeriesTransformer(BaseSeriesTransformer):
+    """
+    MockSeriesTransformer adds a random value and a constant to the input series.
+
+    Parameters
+    ----------
+    constant : int, default=0
+        The constant to be added to each element of the input time series.
+    random_state : int or None, default=None
+        Seed for random number generation.
+    """
+
+    _tags = {
+        "capability:univariate": True,
+        "capability:multivariate": False,
+        "capability:inverse_transform": True,
+    }
+
+    def __init__(self, constant: int = 0, random_state=None) -> None:
+        self.constant = constant
+        self.random_state = random_state
+        super().__init__(axis=1)
+
+    def _fit(self, X: np.ndarray, y=None):
+        """Simulate a fit on X by generating a random value to be added to inputs.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        self
+        """
+        self.n_features_ = X.shape[0]
+        rng = np.random.RandomState(seed=self.random_state)
+        self.random_values_ = rng.random(self.n_features_)
+        return self
+
+    def _transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Transform X by adding the constant and random value set during fit.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        for i in range(self.n_features_):
+            X_new[i] = X[i] + (self.constant + self.random_values_[i])
+        return X_new
+
+    def _inverse_transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Inverse transform X by substracting the constant and random value.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D inverse transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        for i in range(self.n_features_):
+            X_new[i] = X[i] - (self.constant + self.random_values_[i])
+        return X_new
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """
+        Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class.
+        """
+        return {}
+
+
+class MockMultivariateSeriesTransformer(BaseSeriesTransformer):
     """
     MockSeriesTransformer adds a random value and a constant to the input series.
 

--- a/aeon/testing/mock_estimators/_mock_series_transformers.py
+++ b/aeon/testing/mock_estimators/_mock_series_transformers.py
@@ -1,0 +1,173 @@
+"""Mock series transformers."""
+
+import numpy as np
+
+from aeon.transformations.series import BaseSeriesTransformer
+
+
+class MockSeriesTransformer(BaseSeriesTransformer):
+    """
+    MockSeriesTransformer adds a random value and a constant to the input series.
+
+    Parameters
+    ----------
+    constant : int, default=0
+        The constant to be added to each element of the input time series.
+    random_state : int or None, default=None
+        Seed for random number generation.
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "capability:inverse_transform": True,
+    }
+
+    def __init__(self, constant: int = 0, random_state=None) -> None:
+        self.constant = constant
+        self.random_state = random_state
+        super().__init__(axis=1)
+
+    def _fit(self, X: np.ndarray, y=None):
+        """Simulate a fit on X by generating a random value to be added to inputs.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        self
+        """
+        self.n_features_ = X.shape[0]
+        rng = np.random.RandomState(seed=self.random_state)
+        self.random_values_ = rng.random(self.n_features_)
+        return self
+
+    def _transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Transform X by adding the constant and random value set during fit.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        for i in range(self.n_features_):
+            X_new[i] = X[i] + (self.constant + self.random_values_[i])
+        return X_new
+
+    def _inverse_transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Inverse transform X by substracting the constant and random value.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D inverse transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        for i in range(self.n_features_):
+            X_new[i] = X[i] - (self.constant + self.random_values_[i])
+        return X_new
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """
+        Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class.
+        """
+        return {}
+
+
+class MockSeriesTransformerNoFit(BaseSeriesTransformer):
+    """
+    MockSeriesTransformerNoFit adds a value to all elements the input series.
+
+    Parameters
+    ----------
+    constant : int, default=0
+        The constant to be added to each element of the input time series.
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "capability:inverse_transform": True,
+        "fit_is_empty": True,
+    }
+
+    def __init__(self, constant: int = 0) -> None:
+        self.constant = constant
+        super().__init__(axis=1)
+
+    def _transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Transform X by adding the constant value given in init.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        X_new = X + self.constant
+        return X_new
+
+    def _inverse_transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """Inverse transform X by substracting the constant.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape = (n_channels, n_timepoints)
+            2D time series to be transformed
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        np.ndarray, shape = (n_channels, n_timepoints)
+            2D inverse transformed version of X
+        """
+        X_new = np.zeros_like(X)
+        X_new = X - self.constant
+        return X_new
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """
+        Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class.
+        """
+        return {}

--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -111,9 +111,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
             axis = self.axis
         X = self._preprocess_series(X, axis=axis)
         Xt = self._transform(X)
-        if axis != self.axis:
-            Xt = Xt.T
-        return Xt
+        return self._postprocess_series(Xt, axis=axis)
 
     @final
     def fit_transform(self, X, y=None, axis=None):
@@ -150,9 +148,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         X = self._preprocess_series(X, axis=axis)
         Xt = self._fit_transform(X=X, y=y)
         self._is_fitted = True
-        if axis is None or axis == self.axis:
-            return Xt
-        return Xt.T
+        return self._postprocess_series(Xt, axis=axis)
 
     @final
     def inverse_transform(self, X, y=None, axis=None):
@@ -185,9 +181,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         self.check_is_fitted()
         X = self._preprocess_series(X, axis=axis)
         Xt = self._inverse_transform(X=X, y=y)
-        if axis is None or axis == self.axis:
-            return Xt
-        return Xt.T
+        return self._postprocess_series(Xt, axis=axis)
 
     @final
     def update(self, X, y=None, update_params=True, axis=None):

--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -101,7 +101,8 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
 
         Returns
         -------
-        transformed version of X
+        transformed version of X with the same axis as passed by the user, if axis
+        not None.
         """
         # check whether is fitted
         self.check_is_fitted()
@@ -109,7 +110,10 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         if axis is None:
             axis = self.axis
         X = self._preprocess_series(X, axis=axis)
-        return self._transform(X)
+        Xt = self._transform(X)
+        if axis != self.axis:
+            Xt = Xt.T
+        return Xt
 
     @final
     def fit_transform(self, X, y=None, axis=None):
@@ -138,14 +142,17 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
 
         Returns
         -------
-        transformed version of X
+        transformed version of X with the same axis as passed by the user, if axis
+        not None.
         """
         # input checks and datatype conversion, to avoid doing in both fit and transform
         self.reset()
         X = self._preprocess_series(X, axis=axis)
         Xt = self._fit_transform(X=X, y=y)
         self._is_fitted = True
-        return Xt
+        if axis is None or axis == self.axis:
+            return Xt
+        return Xt.T
 
     @final
     def inverse_transform(self, X, y=None, axis=None):
@@ -177,7 +184,10 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         # check whether is fitted
         self.check_is_fitted()
         X = self._preprocess_series(X, axis=axis)
-        return self._inverse_transform(X=X, y=y)
+        Xt = self._inverse_transform(X=X, y=y)
+        if axis is None or axis == self.axis:
+            return Xt
+        return Xt.T
 
     @final
     def update(self, X, y=None, update_params=True, axis=None):

--- a/aeon/transformations/series/tests/test_base.py
+++ b/aeon/transformations/series/tests/test_base.py
@@ -4,13 +4,13 @@ import numpy as np
 import pytest
 
 from aeon.testing.mock_estimators import (
-    MockSeriesTransformer,
+    MockMultivariateSeriesTransformer,
     MockSeriesTransformerNoFit,
+    MockUnivariateSeriesTransformer,
 )
 
-ALL_TRANSFORMERS = [MockSeriesTransformer(), MockSeriesTransformerNoFit()]
-SERIES = [
-    np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+ALL_TRANSFORMERS = [MockMultivariateSeriesTransformer(), MockSeriesTransformerNoFit()]
+MULTIVARIATE_SERIES = [
     np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]),
     np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
     np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
@@ -18,19 +18,33 @@ SERIES = [
 
 
 @pytest.mark.parametrize("transformer", ALL_TRANSFORMERS)
-@pytest.mark.parametrize("series", SERIES)
-def test_fit_transform(transformer, series):
+@pytest.mark.parametrize("series", MULTIVARIATE_SERIES)
+def test_fit_transform_multivariate(transformer, series):
     """Test fit then transform equivalent to fit_transform with setting axis."""
     transformer.fit(series)
     x2 = transformer.transform(series)
     x3 = transformer.fit_transform(series)
     np.testing.assert_array_almost_equal(x2, x3)
+    assert series.shape == x2.shape
 
 
 @pytest.mark.parametrize("transformer", ALL_TRANSFORMERS)
-@pytest.mark.parametrize("series", SERIES)
+@pytest.mark.parametrize("series", MULTIVARIATE_SERIES)
 def test_axis(transformer, series):
     """Test axis."""
     transformer.fit(series, axis=1)
     x2 = transformer.transform(series, axis=1)
     assert series.shape == x2.shape
+
+
+def test_fit_transform_univariate():
+    """Test fit transform for univariate."""
+    x1 = np.array([10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+    transformer = MockUnivariateSeriesTransformer()
+    x2 = transformer.fit_transform(x1)
+    assert x1.shape == x2.shape
+    x3 = np.array([[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]])
+    x4 = transformer.fit_transform(x3)
+    assert isinstance(x4, np.ndarray) and x4.ndim == 1
+    with pytest.raises(ValueError, match="Multivariate data not supported"):
+        transformer.fit_transform(np.random.rand(2, 10))

--- a/aeon/transformations/series/tests/test_base.py
+++ b/aeon/transformations/series/tests/test_base.py
@@ -1,1 +1,10 @@
-""""Test the base series transformer."""
+"""Test the base series transformer."""
+
+
+def test_axis():
+    """Test axis conversion.
+
+     Test it works as expected for transformers with axis = 0 ,
+    axis =1 and both with and without multivariate capability
+    """
+    pass

--- a/aeon/transformations/series/tests/test_base.py
+++ b/aeon/transformations/series/tests/test_base.py
@@ -1,10 +1,36 @@
 """Test the base series transformer."""
 
+import numpy as np
+import pytest
 
-def test_axis():
-    """Test axis conversion.
+from aeon.testing.mock_estimators import (
+    MockSeriesTransformer,
+    MockSeriesTransformerNoFit,
+)
 
-     Test it works as expected for transformers with axis = 0 ,
-    axis =1 and both with and without multivariate capability
-    """
-    pass
+ALL_TRANSFORMERS = [MockSeriesTransformer(), MockSeriesTransformerNoFit()]
+SERIES = [
+    np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]),
+    np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
+    np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]),
+]
+
+
+@pytest.mark.parametrize("transformer", ALL_TRANSFORMERS)
+@pytest.mark.parametrize("series", SERIES)
+def test_fit_transform(transformer, series):
+    """Test fit then transform equivalent to fit_transform with setting axis."""
+    transformer.fit(series)
+    x2 = transformer.transform(series)
+    x3 = transformer.fit_transform(series)
+    np.testing.assert_array_almost_equal(x2, x3)
+
+
+@pytest.mark.parametrize("transformer", ALL_TRANSFORMERS)
+@pytest.mark.parametrize("series", SERIES)
+def test_axis(transformer, series):
+    """Test axis."""
+    transformer.fit(series, axis=1)
+    x2 = transformer.transform(series, axis=1)
+    assert series.shape == x2.shape

--- a/docs/developer_guide/deprecation.md
+++ b/docs/developer_guide/deprecation.md
@@ -18,8 +18,9 @@ Note that the deprecation policy does not necessarily apply to modules we class 
 - `benchmarking`
 - `segmentation`
 - `similarity_search`
-- `visualisation`
 - `testing`
+- `transformations/series`
+- `visualisation`
 
 When we introduce a new module, we may classify it as experimental until the API is stable. We will try to not make drastic changes to experimental modules, but we need to retain the freedom to be more agile with the design in these cases.
 


### PR DESCRIPTION
This introduces a new function in BaseSeriesEstimator called _postprocess_series that checks the axis  passed and is different to self.axis, then the series is transposed back to the axis passed.

It also squeezes the output for univariate only transformers back to being univariate. See #1375 for how this may change subsequently.

this function is called in  BaseSeriesTransformer in transform, fit_transform and inverse_transform  as follows

```python
        if axis is None:
            axis = self.axis
        X = self._preprocess_series(X, axis=axis)
        Xt = self._transform(X)
        return self._postprocess_series(Xt, axis=axis)
```