### PR TITLE
[ENH] Kmeans allow empty clusters

### DIFF
--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -295,7 +295,7 @@ class TimeSeriesKMeans(BaseClusterer):
                 isinstance(self.init_algorithm, np.ndarray)
                 and len(self.init_algorithm) == self.n_clusters
             ):
-                self._init_algorithm = self.init_algorithm
+                self._init_algorithm = self.init_algorithm.copy()
             else:
                 raise ValueError(
                     f"The value provided for init_algorithm: {self.init_algorithm} is "
@@ -367,6 +367,8 @@ class TimeSeriesKMeans(BaseClusterer):
         max_iterations = self.n_clusters
 
         while empty_clusters.size > 0:
+            # Assign each time series to the cluster that is closest to it
+            # and then find the time series that is furthest from the centre
             index_furthest_from_centre = curr_pw.min(axis=1).argmax()
             cluster_centres[empty_clusters[0]] = X[index_furthest_from_centre]
             curr_pw = pairwise_distance(

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -147,6 +147,9 @@ def _ba_update(
     descriptor: str = "identity",
     reach: int = 30,
     warp_penalty: float = 1.0,
+    transformation_precomputed: bool = False,
+    transformed_x: Optional[np.ndarray] = None,
+    transformed_y: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, float]:
     X_size, X_dims, X_timepoints = X.shape
     sum = np.zeros(X_timepoints)
@@ -174,7 +177,14 @@ def _ba_update(
             )
         elif distance == "shape_dtw":
             curr_alignment, _ = shape_dtw_alignment_path(
-                curr_ts, center, window=window, descriptor=descriptor, reach=reach
+                curr_ts,
+                center,
+                window=window,
+                descriptor=descriptor,
+                reach=reach,
+                transformed_x=transformed_x,
+                transformed_y=transformed_y,
+                transformation_precomputed=transformation_precomputed,
             )
         elif distance == "adtw":
             curr_alignment, _ = adtw_alignment_path(

--- a/aeon/clustering/tests/test_k_means.py
+++ b/aeon/clustering/tests/test_k_means.py
@@ -341,7 +341,10 @@ def test_empty_cluster():
 
     kmeans.fit(np.array([first, second, third, forth]))
 
-    # Test that if a duplicate centre would be created the algorithm throws an error
+    assert not np.array_equal(kmeans.cluster_centers_, init_centres)
+    assert np.unique(kmeans.labels_).size == 3
+
+    # Test that if a duplicate centre would be created the algorithm
     init_centres = np.array([first, first, first])
 
     kmeans = TimeSeriesKMeans(
@@ -354,5 +357,39 @@ def test_empty_cluster():
         n_clusters=3,
     )
 
+    kmeans.fit(np.array([first, second, third]))
+
+    assert not np.array_equal(kmeans.cluster_centers_, init_centres)
+    assert np.unique(kmeans.labels_).size == 3
+
+    # Test duplicate data in dataset
+    init_centres = np.array([first, empty_cluster])
+    kmeans = TimeSeriesKMeans(
+        random_state=1,
+        n_init=1,
+        max_iter=5,
+        init_algorithm=init_centres,
+        distance="euclidean",
+        averaging_method="mean",
+        n_clusters=2,
+    )
+
+    kmeans.fit(np.array([first, first, first, first, second]))
+
+    assert not np.array_equal(kmeans.cluster_centers_, init_centres)
+    assert np.unique(kmeans.labels_).size == 2
+
+    # Test impossible to have 3 different clusters
+    init_centres = np.array([first, empty_cluster, empty_cluster])
+    kmeans = TimeSeriesKMeans(
+        random_state=1,
+        n_init=1,
+        max_iter=5,
+        init_algorithm=init_centres,
+        distance="euclidean",
+        averaging_method="mean",
+        n_clusters=3,
+    )
+
     with pytest.raises(ValueError):
-        kmeans.fit(np.array([first, first, third]))
+        kmeans.fit(np.array([first, first, first, first, first]))

--- a/aeon/clustering/tests/test_k_means.py
+++ b/aeon/clustering/tests/test_k_means.py
@@ -316,3 +316,43 @@ def test_custom_distance_params():
         data, distance="msm", distance_params={"window": 0.2}
     )
     assert not np.array_equal(default_dist, custom_params_dist)
+
+
+def test_empty_cluster():
+    """Test empty cluster handling."""
+    first = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    second = np.array([[4, 5, 6], [7, 8, 9], [11, 12, 13]])
+    third = np.array([[24, 25, 26], [27, 28, 29], [30, 31, 32]])
+    forth = np.array([[14, 15, 16], [17, 18, 19], [20, 21, 22]])
+
+    # Test where two swap must happen to avoid empty clusters
+    empty_cluster = np.array([[100, 100, 100], [100, 100, 100], [100, 100, 100]])
+    init_centres = np.array([first, empty_cluster, empty_cluster])
+
+    kmeans = TimeSeriesKMeans(
+        random_state=1,
+        n_init=1,
+        max_iter=5,
+        init_algorithm=init_centres,
+        distance="euclidean",
+        averaging_method="mean",
+        n_clusters=3,
+    )
+
+    kmeans.fit(np.array([first, second, third, forth]))
+
+    # Test that if a duplicate centre would be created the algorithm throws an error
+    init_centres = np.array([first, first, first])
+
+    kmeans = TimeSeriesKMeans(
+        random_state=1,
+        n_init=1,
+        max_iter=5,
+        init_algorithm=init_centres,
+        distance="euclidean",
+        averaging_method="mean",
+        n_clusters=3,
+    )
+
+    with pytest.raises(ValueError):
+        kmeans.fit(np.array([first, first, third]))

--- a/aeon/distances/_adtw.py
+++ b/aeon/distances/_adtw.py
@@ -2,15 +2,16 @@ r"""Amercing dynamic time warping (ADTW) between two time series."""
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import compute_min_return_path
 from aeon.distances._bounding_matrix import create_bounding_matrix
 from aeon.distances._squared import _univariate_squared_distance
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -195,10 +196,9 @@ def _adtw_cost_matrix(
     return cost_matrix[1:, 1:]
 
 
-@njit(cache=True, fastmath=True)
 def adtw_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
     warp_penalty: float = 1.0,
@@ -207,16 +207,14 @@ def adtw_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or List of np.ndarray
         A collection of time series instances  of shape ``(n_cases, n_timepoints)``
         or ``(n_cases, n_channels, n_timepoints)``.
-    y : np.ndarray or None, default=None
+    y : np.ndarray or List of np.ndarray or None, default=None
         A single series or a collection of time series of shape ``(m_timepoints,)`` or
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
-        If None, then the adtw pairwise distance between the instances of X is
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
-
-
     window : float or None, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
         is used.
@@ -265,37 +263,48 @@ def adtw_pairwise_distance(
     array([[300.],
            [147.],
            [ 48.]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> adtw_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]])
     """
+    _X = _convert_to_list(X, "X")
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _adtw_pairwise_distance(X, window, itakura_max_slope, warp_penalty)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _adtw_pairwise_distance(_X, window, itakura_max_slope, warp_penalty)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
+        return _adtw_pairwise_distance(_X, window, itakura_max_slope, warp_penalty)
+
+    _y = _convert_to_list(y, "y")
     return _adtw_from_multiple_to_multiple_distance(
-        _x, _y, window, itakura_max_slope, warp_penalty
+        _X, _y, window, itakura_max_slope, warp_penalty
     )
 
 
 @njit(cache=True, fastmath=True)
 def _adtw_pairwise_distance(
-    X: np.ndarray,
+    X: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
     warp_penalty: float,
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2], X.shape[2], window, itakura_max_slope
-    )
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
 
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _adtw_distance(X[i], X[j], bounding_matrix, warp_penalty)
+            x1, x2 = X[i], X[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _adtw_distance(x1, x2, bounding_matrix, warp_penalty)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -303,22 +312,29 @@ def _adtw_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _adtw_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
     warp_penalty: float,
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
 
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _adtw_distance(x[i], y[j], bounding_matrix, warp_penalty)
+            x1, y1 = x[i], y[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _adtw_distance(x1, y1, bounding_matrix, warp_penalty)
     return distances
 
 

--- a/aeon/distances/_adtw.py
+++ b/aeon/distances/_adtw.py
@@ -267,18 +267,20 @@ def adtw_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> adtw_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]])
+    array([[  0.,  44., 294.],
+           [ 44.,   0.,  87.],
+           [294.,  87.,   0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
     if y is None:
         # To self
-        return _adtw_pairwise_distance(_X, window, itakura_max_slope, warp_penalty)
+        return _adtw_pairwise_distance(
+            _X, window, itakura_max_slope, warp_penalty, unequal_length
+        )
 
-    _y = _convert_to_list(y, "y")
+    _y, unequal_length = _convert_to_list(y, "y")
     return _adtw_from_multiple_to_multiple_distance(
-        _X, _y, window, itakura_max_slope, warp_penalty
+        _X, _y, window, itakura_max_slope, warp_penalty, unequal_length
     )
 
 
@@ -288,21 +290,22 @@ def _adtw_pairwise_distance(
     window: Optional[float],
     itakura_max_slope: Optional[float],
     warp_penalty: float,
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
-        )
 
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _adtw_distance(x1, x2, bounding_matrix, warp_penalty)
             distances[j, i] = distances[i, j]
@@ -317,22 +320,22 @@ def _adtw_from_multiple_to_multiple_distance(
     window: Optional[float],
     itakura_max_slope: Optional[float],
     warp_penalty: float,
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
-        )
 
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _adtw_distance(x1, y1, bounding_matrix, warp_penalty)
     return distances

--- a/aeon/distances/_bounding_matrix.py
+++ b/aeon/distances/_bounding_matrix.py
@@ -52,7 +52,7 @@ def create_bounding_matrix(
         if itakura_max_slope < 0 or itakura_max_slope > 1:
             raise ValueError("itakura_max_slope must be between 0 and 1")
         return _itakura_parallelogram(x_size, y_size, itakura_max_slope)
-    if window is not None:
+    if window is not None and window != 1.0:
         if window < 0 or window > 1:
             raise ValueError("window must be between 0 and 1")
         return _sakoe_chiba_bounding(x_size, y_size, window)

--- a/aeon/distances/_ddtw.py
+++ b/aeon/distances/_ddtw.py
@@ -2,14 +2,15 @@
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import compute_min_return_path
 from aeon.distances._dtw import _dtw_cost_matrix, _dtw_distance, create_bounding_matrix
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -92,8 +93,8 @@ def ddtw_distance(
 
 @njit(cache=True, fastmath=True)
 def ddtw_cost_matrix(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
 ) -> np.ndarray:
@@ -161,10 +162,9 @@ def ddtw_cost_matrix(
     raise ValueError("x and y must be 1D or 2D")
 
 
-@njit(cache=True, fastmath=True)
 def ddtw_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
 ) -> np.ndarray:
@@ -172,12 +172,14 @@ def ddtw_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
-        First time series, either univariate, shape ``(n_timepoints,)``, or
-        multivariate, shape ``(n_channels, n_timepoints)``.
-    y : np.ndarray
-        Second time series, either univariate, shape ``(n_timepoints,)``, or
-        multivariate, shape ``(n_channels, n_timepoints)``.
+    X : np.ndarray or List of np.ndarray
+        A collection of time series instances  of shape ``(n_cases, n_timepoints)``
+        or ``(n_cases, n_channels, n_timepoints)``.
+    y : np.ndarray or List of np.ndarray or None, default=None
+        A single series or a collection of time series of shape ``(m_timepoints,)`` or
+        ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
+        If None, then the msm pairwise distance between the instances of X is
+        calculated.
     window : float, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
         is used.
@@ -222,38 +224,50 @@ def ddtw_pairwise_distance(
     array([[ 15129.    ],
            [322624.    ],
            [  3220.5625]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> ddtw_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
+
     if y is None:
-        # To self
-        if X.ndim == 3:
-            return _ddtw_pairwise_distance(X, window, itakura_max_slope)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _ddtw_pairwise_distance(_X, window, itakura_max_slope)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
-    return _ddtw_from_multiple_to_multiple_distance(_x, _y, window, itakura_max_slope)
+        return _ddtw_pairwise_distance(_X, window, itakura_max_slope)
+
+    _y = _convert_to_list(y, "y")
+    return _ddtw_from_multiple_to_multiple_distance(_X, _y, window, itakura_max_slope)
 
 
 @njit(cache=True, fastmath=True)
 def _ddtw_pairwise_distance(
-    X: np.ndarray, window: Optional[float], itakura_max_slope: Optional[float]
+    X: NumbaList[np.ndarray],
+    window: Optional[float],
+    itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2] - 2, X.shape[2] - 2, window, itakura_max_slope
-    )
 
-    X_average_of_slope = np.zeros((n_cases, X.shape[1], X.shape[2] - 2))
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
+
+    X_average_of_slope = NumbaList()
     for i in range(n_cases):
-        X_average_of_slope[i] = average_of_slope(X[i])
+        X_average_of_slope.append(average_of_slope(X[i]))
 
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _dtw_distance(
-                X_average_of_slope[i], X_average_of_slope[j], bounding_matrix
-            )
+            x1, x2 = X_average_of_slope[i], X_average_of_slope[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _dtw_distance(x1, x2, bounding_matrix)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -261,30 +275,38 @@ def _ddtw_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _ddtw_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
+
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
 
     # Derive the arrays before so that we dont have to redo every iteration
-    derive_x = np.zeros((x.shape[0], x.shape[1], x.shape[2] - 2))
-    for i in range(x.shape[0]):
-        derive_x[i] = average_of_slope(x[i])
+    x_average_of_slope = NumbaList()
+    for i in range(n_cases):
+        x_average_of_slope.append(average_of_slope(x[i]))
 
-    derive_y = np.zeros((y.shape[0], y.shape[1], y.shape[2] - 2))
-    for i in range(y.shape[0]):
-        derive_y[i] = average_of_slope(y[i])
+    y_average_of_slope = NumbaList()
+    for i in range(m_cases):
+        y_average_of_slope.append(average_of_slope(y[i]))
 
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _dtw_distance(derive_x[i], derive_y[j], bounding_matrix)
+            x1, y1 = x_average_of_slope[i], y_average_of_slope[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _dtw_distance(x1, y1, bounding_matrix)
     return distances
 
 

--- a/aeon/distances/_distance.py
+++ b/aeon/distances/_distance.py
@@ -443,14 +443,14 @@ def _custom_func_pairwise(
                 return _custom_pairwise_distance(_X, dist_func, **kwargs)
             raise ValueError("x and y must be 1D, 2D, or 3D arrays")
         else:
-            _X = _convert_to_list(X)
+            _X, unequal_length = _convert_to_list(X)
             return _custom_pairwise_distance(_X, dist_func, **kwargs)
     if isinstance(X, np.ndarray) and isinstance(y, np.ndarray):
         _x, _y = reshape_pairwise_to_multiple(X, y)
         return _custom_from_multiple_to_multiple_distance(_x, _y, dist_func, **kwargs)
     else:
-        _x = _convert_to_list(X)
-        _y = _convert_to_list(y)
+        _x, unequal_length = _convert_to_list(X)
+        _y, unequal_length = _convert_to_list(y)
         return _custom_from_multiple_to_multiple_distance(_x, _y, dist_func, **kwargs)
 
 

--- a/aeon/distances/_dtw.py
+++ b/aeon/distances/_dtw.py
@@ -2,15 +2,16 @@ r"""Dynamic time warping (DTW) between two time series."""
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import compute_min_return_path
 from aeon.distances._bounding_matrix import create_bounding_matrix
 from aeon.distances._squared import _univariate_squared_distance
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -226,10 +227,9 @@ def _dtw_cost_matrix(
     return cost_matrix[1:, 1:]
 
 
-@njit(cache=True, fastmath=True)
 def dtw_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
 ) -> np.ndarray:
@@ -253,13 +253,13 @@ def dtw_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or List of np.ndarray
         A collection of time series instances  of shape ``(n_cases, n_timepoints)``
         or ``(n_cases, n_channels, n_timepoints)``.
-    y : np.ndarray or None, default=None
+    y : np.ndarray or List of np.ndarray or None, default=None
         A single series or a collection of time series of shape ``(m_timepoints,)`` or
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
-        If None, then the dtw pairwise distance between the instances of X is
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
     window : float or None, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
@@ -305,32 +305,45 @@ def dtw_pairwise_distance(
     array([[300.],
            [147.],
            [ 48.]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> dtw_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
+
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _dtw_pairwise_distance(X, window, itakura_max_slope)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _dtw_pairwise_distance(_X, window, itakura_max_slope)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
-    return _dtw_from_multiple_to_multiple_distance(_x, _y, window, itakura_max_slope)
+        return _dtw_pairwise_distance(_X, window, itakura_max_slope)
+    _y = _convert_to_list(y, "y")
+    return _dtw_from_multiple_to_multiple_distance(_X, _y, window, itakura_max_slope)
 
 
 @njit(cache=True, fastmath=True)
 def _dtw_pairwise_distance(
-    X: np.ndarray, window: Optional[float], itakura_max_slope: Optional[float]
+    X: NumbaList[np.ndarray],
+    window: Optional[float],
+    itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2], X.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _dtw_distance(X[i], X[j], bounding_matrix)
+            x1, x2 = X[i], X[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _dtw_distance(x1, x2, bounding_matrix)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -338,21 +351,28 @@ def _dtw_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _dtw_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _dtw_distance(x[i], y[j], bounding_matrix)
+            x1, y1 = x[i], y[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _dtw_distance(x1, y1, bounding_matrix)
     return distances
 
 

--- a/aeon/distances/_dtw.py
+++ b/aeon/distances/_dtw.py
@@ -309,17 +309,19 @@ def dtw_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> dtw_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[  0.,  42., 292.],
+           [ 42.,   0.,  83.],
+           [292.,  83.,   0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
 
     if y is None:
         # To self
-        return _dtw_pairwise_distance(_X, window, itakura_max_slope)
-    _y = _convert_to_list(y, "y")
-    return _dtw_from_multiple_to_multiple_distance(_X, _y, window, itakura_max_slope)
+        return _dtw_pairwise_distance(_X, window, itakura_max_slope, unequal_length)
+    _y, unequal_length = _convert_to_list(y, "y")
+    return _dtw_from_multiple_to_multiple_distance(
+        _X, _y, window, itakura_max_slope, unequal_length
+    )
 
 
 @njit(cache=True, fastmath=True)
@@ -327,21 +329,22 @@ def _dtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _dtw_distance(x1, x2, bounding_matrix)
             distances[j, i] = distances[i, j]
@@ -355,22 +358,22 @@ def _dtw_from_multiple_to_multiple_distance(
     y: NumbaList[np.ndarray],
     window: Optional[float],
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _dtw_distance(x1, y1, bounding_matrix)
     return distances

--- a/aeon/distances/_edr.py
+++ b/aeon/distances/_edr.py
@@ -2,10 +2,11 @@
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import (
     _add_inf_to_out_of_bounds_cost_matrix,
@@ -13,7 +14,7 @@ from aeon.distances._alignment_paths import (
 )
 from aeon.distances._bounding_matrix import create_bounding_matrix
 from aeon.distances._euclidean import _univariate_euclidean_distance
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -222,10 +223,9 @@ def _edr_cost_matrix(
     return cost_matrix[1:, 1:]
 
 
-@njit(cache=True, fastmath=True)
 def edr_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     epsilon: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
@@ -234,13 +234,13 @@ def edr_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or List of np.ndarray
         A collection of time series instances  of shape ``(n_cases, n_timepoints)``
         or ``(n_cases, n_channels, n_timepoints)``.
-    y : np.ndarray or None, default=None
+    y : np.ndarray or List of np.ndarray or None, default=None
         A single series or a collection of time series of shape ``(m_timepoints,)`` or
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
-        If None, then the edr pairwise distance between the instances of X is
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
     window : float, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
@@ -289,37 +289,49 @@ def edr_pairwise_distance(
     array([[1.],
            [1.],
            [1.]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> edr_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
+
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _edr_pairwise_distance(X, window, epsilon, itakura_max_slope)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _edr_pairwise_distance(_X, window, epsilon, itakura_max_slope)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
+        return _edr_pairwise_distance(_X, window, epsilon, itakura_max_slope)
+
+    _y = _convert_to_list(y, "y")
     return _edr_from_multiple_to_multiple_distance(
-        _x, _y, window, epsilon, itakura_max_slope
+        _X, _y, window, epsilon, itakura_max_slope
     )
 
 
 @njit(cache=True, fastmath=True)
 def _edr_pairwise_distance(
-    X: np.ndarray,
+    X: NumbaList[np.ndarray],
     window: Optional[float] = None,
     epsilon: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2], X.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _edr_distance(X[i], X[j], bounding_matrix, epsilon)
+            x1, x2 = X[i], X[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _edr_distance(x1, x2, bounding_matrix, epsilon)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -327,22 +339,29 @@ def _edr_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _edr_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float] = None,
     epsilon: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _edr_distance(x[i], y[j], bounding_matrix, epsilon)
+            x1, y1 = x[i], y[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _edr_distance(x1, y1, bounding_matrix, epsilon)
     return distances
 
 

--- a/aeon/distances/_edr.py
+++ b/aeon/distances/_edr.py
@@ -293,43 +293,46 @@ def edr_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> edr_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[0.  , 0.75, 0.6 ],
+           [0.75, 0.  , 0.8 ],
+           [0.6 , 0.8 , 0.  ]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
 
     if y is None:
         # To self
-        return _edr_pairwise_distance(_X, window, epsilon, itakura_max_slope)
+        return _edr_pairwise_distance(
+            _X, window, epsilon, itakura_max_slope, unequal_length
+        )
 
-    _y = _convert_to_list(y, "y")
+    _y, unequal_length = _convert_to_list(y, "y")
     return _edr_from_multiple_to_multiple_distance(
-        _X, _y, window, epsilon, itakura_max_slope
+        _X, _y, window, epsilon, itakura_max_slope, unequal_length
     )
 
 
 @njit(cache=True, fastmath=True)
 def _edr_pairwise_distance(
     X: NumbaList[np.ndarray],
-    window: Optional[float] = None,
-    epsilon: Optional[float] = None,
-    itakura_max_slope: Optional[float] = None,
+    window: Optional[float],
+    epsilon: Optional[float],
+    itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _edr_distance(x1, x2, bounding_matrix, epsilon)
             distances[j, i] = distances[i, j]
@@ -341,25 +344,25 @@ def _edr_pairwise_distance(
 def _edr_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
-    window: Optional[float] = None,
-    epsilon: Optional[float] = None,
-    itakura_max_slope: Optional[float] = None,
+    window: Optional[float],
+    epsilon: Optional[float],
+    itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _edr_distance(x1, y1, bounding_matrix, epsilon)
     return distances

--- a/aeon/distances/_erp.py
+++ b/aeon/distances/_erp.py
@@ -325,16 +325,18 @@ def erp_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> erp_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[ 0., 16., 44.],
+           [16.,  0., 28.],
+           [44., 28.,  0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
     if y is None:
-        return _erp_pairwise_distance(_X, window, g, g_arr, itakura_max_slope)
-    _y = _convert_to_list(y, "y")
+        return _erp_pairwise_distance(
+            _X, window, g, g_arr, itakura_max_slope, unequal_length
+        )
+    _y, unequal_length = _convert_to_list(y, "y")
     return _erp_from_multiple_to_multiple_distance(
-        _X, _y, window, g, g_arr, itakura_max_slope
+        _X, _y, window, g, g_arr, itakura_max_slope, unequal_length
     )
 
 
@@ -345,22 +347,23 @@ def _erp_pairwise_distance(
     g: float,
     g_arr: Optional[np.ndarray],
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
 
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _erp_distance(x1, x2, bounding_matrix, g, g_arr)
             distances[j, i] = distances[i, j]
@@ -376,22 +379,22 @@ def _erp_from_multiple_to_multiple_distance(
     g: float,
     g_arr: Optional[np.ndarray],
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _erp_distance(x1, y1, bounding_matrix, g, g_arr)
     return distances

--- a/aeon/distances/_euclidean.py
+++ b/aeon/distances/_euclidean.py
@@ -120,16 +120,16 @@ def euclidean_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> euclidean_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[ 0.        ,  5.19615242, 12.12435565],
+           [ 5.19615242,  0.        ,  8.        ],
+           [12.12435565,  8.        ,  0.        ]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, _ = _convert_to_list(X, "X")
     if y is None:
         # To self
         return _euclidean_pairwise_distance(_X)
 
-    _y = _convert_to_list(y, "y")
+    _y, _ = _convert_to_list(y, "y")
     return _euclidean_from_multiple_to_multiple_distance(_X, _y)
 
 

--- a/aeon/distances/_lcss.py
+++ b/aeon/distances/_lcss.py
@@ -2,15 +2,16 @@ r"""Longest common subsequence (LCSS) between two time series."""
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import compute_lcss_return_path
 from aeon.distances._bounding_matrix import create_bounding_matrix
 from aeon.distances._euclidean import _univariate_euclidean_distance
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -217,10 +218,9 @@ def _lcss_cost_matrix(
     return cost_matrix
 
 
-@njit(cache=True, fastmath=True)
 def lcss_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     epsilon: float = 1.0,
     itakura_max_slope: Optional[float] = None,
@@ -229,13 +229,13 @@ def lcss_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or List of np.ndarray
         A collection of time series instances  of shape ``(n_cases, n_timepoints)``
         or ``(n_cases, n_channels, n_timepoints)``.
-    y : np.ndarray or None, default=None
+    y : np.ndarray or List of np.ndarray or None, default=None
         A single series or a collection of time series of shape ``(m_timepoints,)`` or
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
-        If None, then the lcss pairwise distance between the instances of X is
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
     window : float, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
@@ -283,37 +283,46 @@ def lcss_pairwise_distance(
     array([[1.],
            [1.],
            [1.]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> lcss_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _lcss_pairwise_distance(X, window, epsilon, itakura_max_slope)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _lcss_pairwise_distance(_X, window, epsilon, itakura_max_slope)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
+        return _lcss_pairwise_distance(_X, window, epsilon, itakura_max_slope)
+    _y = _convert_to_list(y, "y")
     return _lcss_from_multiple_to_multiple_distance(
-        _x, _y, window, epsilon, itakura_max_slope
+        _X, _y, window, epsilon, itakura_max_slope
     )
 
 
 @njit(cache=True, fastmath=True)
 def _lcss_pairwise_distance(
-    X: np.ndarray,
+    X: NumbaList[np.ndarray],
     window: Optional[float],
     epsilon: float,
     itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2], X.shape[2], window, itakura_max_slope
-    )
-
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _lcss_distance(X[i], X[j], bounding_matrix, epsilon)
+            x1, x2 = X[i], X[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _lcss_distance(x1, x2, bounding_matrix, epsilon)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -321,22 +330,29 @@ def _lcss_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _lcss_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float],
     epsilon: float,
     itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _lcss_distance(x[i], y[j], bounding_matrix, epsilon)
+            x1, y1 = x[i], y[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _lcss_distance(x1, y1, bounding_matrix, epsilon)
     return distances
 
 

--- a/aeon/distances/_manhattan.py
+++ b/aeon/distances/_manhattan.py
@@ -128,15 +128,15 @@ def manhattan_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> manhattan_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[ 0.,  9., 21.],
+           [ 9.,  0., 16.],
+           [21., 16.,  0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, _ = _convert_to_list(X, "X")
     if y is None:
         # To self
         return _manhattan_pairwise_distance(_X)
-    _y = _convert_to_list(y, "y")
+    _y, _ = _convert_to_list(y, "y")
     return _manhattan_from_multiple_to_multiple_distance(_X, _y)
 
 

--- a/aeon/distances/_manhattan.py
+++ b/aeon/distances/_manhattan.py
@@ -1,11 +1,12 @@
 __maintainer__ = []
 
-from typing import Optional
+from typing import List, Optional, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -72,23 +73,22 @@ def _univariate_manhattan_distance(x: np.ndarray, y: np.ndarray) -> float:
     return distance
 
 
-@njit(cache=True, fastmath=True)
 def manhattan_pairwise_distance(
-    X: np.ndarray, y: Optional[np.ndarray] = None
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
 ) -> np.ndarray:
     """Compute the manhattan pairwise distance between a set of time series.
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or List of np.ndarray
         A collection of time series instances  of shape ``(n_cases, n_timepoints)``
         or ``(n_cases, n_channels, n_timepoints)``.
-    y : np.ndarray or None, default=None
+    y : np.ndarray or List of np.ndarray or None, default=None
         A single series or a collection of time series of shape ``(m_timepoints,)`` or
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
-        If None, then the manhattan pairwise distance between the instances of X is
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
-
 
     Returns
     -------
@@ -125,22 +125,24 @@ def manhattan_pairwise_distance(
            [21.],
            [12.]])
 
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> manhattan_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _manhattan_pairwise_distance(X)
-        elif X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _manhattan_pairwise_distance(_X)
-        raise ValueError("X must be 2D or 3D array")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
-    return _manhattan_from_multiple_to_multiple_distance(_x, _y)
+        return _manhattan_pairwise_distance(_X)
+    _y = _convert_to_list(y, "y")
+    return _manhattan_from_multiple_to_multiple_distance(_X, _y)
 
 
 @njit(cache=True, fastmath=True)
-def _manhattan_pairwise_distance(X: np.ndarray) -> np.ndarray:
-    n_cases = X.shape[0]
+def _manhattan_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
     for i in range(n_cases):
@@ -153,10 +155,10 @@ def _manhattan_pairwise_distance(X: np.ndarray) -> np.ndarray:
 
 @njit(cache=True, fastmath=True)
 def _manhattan_from_multiple_to_multiple_distance(
-    x: np.ndarray, y: np.ndarray
+    x: NumbaList[np.ndarray], y: NumbaList[np.ndarray]
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
     for i in range(n_cases):

--- a/aeon/distances/_minkowski.py
+++ b/aeon/distances/_minkowski.py
@@ -1,11 +1,12 @@
 __maintainer__ = []
 
-from typing import Optional
+from typing import List, Optional, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -124,10 +125,9 @@ def _multivariate_minkowski_distance(
     return dist ** (1.0 / p)
 
 
-@njit(cache=True, fastmath=True)
 def minkowski_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     p: float = 2.0,
     w: Optional[np.ndarray] = None,
 ) -> np.ndarray:
@@ -135,15 +135,14 @@ def minkowski_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray
-        A collection of time series instances, of shape
-        (n_cases, n_channels, n_timepoints) or
-        (n_cases, n_timepoints) or (n_timepoints,).
-    y : np.ndarray, default=None
-        A second collection of time series instances, of
-        shape (m_cases, m_channels, m_timepoints) or
-        (m_cases, m_timepoints) or (m_timepoints,).
-        If None, the pairwise distances are calculated within X.
+    X : np.ndarray or List of np.ndarray
+        A collection of time series instances  of shape ``(n_cases, n_timepoints)``
+        or ``(n_cases, n_channels, n_timepoints)``.
+    y : np.ndarray or List of np.ndarray or None, default=None
+        A single series or a collection of time series of shape ``(m_timepoints,)`` or
+        ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
+        If None, then the msm pairwise distance between the instances of X is
+        calculated.
     p : float, default=2.0
         The order of the norm of the difference
         (default is 2.0, which represents the Euclidean distance).
@@ -194,23 +193,27 @@ def minkowski_pairwise_distance(
     array([[30.],
            [21.],
            [12.]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> minkowski_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
     if y is None:
-        if X.ndim == 3:
-            return _minkowski_pairwise_distance(X, p, w)
-        elif X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _minkowski_pairwise_distance(_X, p, w)
-        raise ValueError("X must be 2D or 3D array")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
-    return _minkowski_from_multiple_to_multiple_distance(_x, _y, p, w)
+        return _minkowski_pairwise_distance(_X, p, w)
+
+    _y = _convert_to_list(y, "y")
+    return _minkowski_from_multiple_to_multiple_distance(_X, _y, p, w)
 
 
 @njit(cache=True, fastmath=True)
 def _minkowski_pairwise_distance(
-    X: np.ndarray, p: float, w: Optional[np.ndarray] = None
+    X: NumbaList[np.ndarray], p: float, w: Optional[np.ndarray] = None
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
     for i in range(n_cases):
@@ -229,10 +232,13 @@ def _minkowski_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _minkowski_from_multiple_to_multiple_distance(
-    x: np.ndarray, y: np.ndarray, p: float, w: Optional[np.ndarray] = None
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
+    p: float,
+    w: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
     for i in range(n_cases):

--- a/aeon/distances/_minkowski.py
+++ b/aeon/distances/_minkowski.py
@@ -199,7 +199,7 @@ def minkowski_pairwise_distance(
     >>> minkowski_pairwise_distance(X)
     array([[ 0.        ,  5.19615242, 12.12435565],
            [ 5.19615242,  0.        ,  8.        ],
-           [12.12435565,  8.        ,  0.        ]])]
+           [12.12435565,  8.        ,  0.        ]])
     """
     _X, _ = _convert_to_list(X, "X")
     if y is None:

--- a/aeon/distances/_minkowski.py
+++ b/aeon/distances/_minkowski.py
@@ -197,15 +197,15 @@ def minkowski_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> minkowski_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[ 0.        ,  5.19615242, 12.12435565],
+           [ 5.19615242,  0.        ,  8.        ],
+           [12.12435565,  8.        ,  0.        ]])]
     """
-    _X = _convert_to_list(X, "X")
+    _X, _ = _convert_to_list(X, "X")
     if y is None:
         return _minkowski_pairwise_distance(_X, p, w)
 
-    _y = _convert_to_list(y, "y")
+    _y, _ = _convert_to_list(y, "y")
     return _minkowski_from_multiple_to_multiple_distance(_X, _y, p, w)
 
 

--- a/aeon/distances/_msm.py
+++ b/aeon/distances/_msm.py
@@ -68,7 +68,6 @@ def msm_distance(
     described in [2]_ for computing the pointwise MSM distance over channels.
     MSM satisfies triangular inequality and is a metric.
 
-
     Parameters
     ----------
     x : np.ndarray
@@ -444,7 +443,7 @@ def _msm_pairwise_distance(
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1:
+    if window == 1.0:
         max_shape = max([x.shape[-1] for x in X])
         bounding_matrix: np.ndarray = create_bounding_matrix(
             max_shape, max_shape, window, itakura_max_slope
@@ -452,7 +451,7 @@ def _msm_pairwise_distance(
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1:
+            if window != 1.0:
                 bounding_matrix = create_bounding_matrix(
                     x1.shape[-1], x2.shape[-1], window, itakura_max_slope
                 )
@@ -475,7 +474,7 @@ def _msm_from_multiple_to_multiple_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1:
+    if window == 1.0:
         max_shape = max([_x.shape[-1] for _x in x])
         bounding_matrix: np.ndarray = create_bounding_matrix(
             max_shape, max_shape, window, itakura_max_slope
@@ -483,7 +482,7 @@ def _msm_from_multiple_to_multiple_distance(
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1:
+            if window != 1.0:
                 bounding_matrix = create_bounding_matrix(
                     x1.shape[-1], y1.shape[-1], window, itakura_max_slope
                 )
@@ -491,7 +490,7 @@ def _msm_from_multiple_to_multiple_distance(
     return distances
 
 
-@njit(cache=True)
+@njit(cache=True, fastmath=True)
 def msm_alignment_path(
     x: np.ndarray,
     y: np.ndarray,

--- a/aeon/distances/_sbd.py
+++ b/aeon/distances/_sbd.py
@@ -187,13 +187,13 @@ def sbd_pairwise_distance(
            [0.36754447, 0.        , 0.29289322],
            [0.5527864 , 0.29289322, 0.        ]])
     """
-    _x = _convert_to_list(x, "x")
+    _x, _ = _convert_to_list(x, "x")
 
     if y is None:
         # To self
         return _sbd_pairwise_distance_single(_x, standardize)
 
-    _y = _convert_to_list(y, "y")
+    _y, _ = _convert_to_list(y, "y")
     return _sbd_pairwise_distance(_x, _y, standardize)
 
 

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -522,7 +522,7 @@ def shape_dtw_pairwise_distance(
     reach: int = 30,
     itakura_max_slope: Optional[float] = None,
     transformation_precomputed: bool = False,
-    transformed_X: Optional[np.ndarray] = None,
+    transformed_x: Optional[np.ndarray] = None,
     transformed_y: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Compute the ShapeDTW pairwise distance among a set of series.
@@ -558,7 +558,7 @@ def shape_dtw_pairwise_distance(
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
     transformation_precomputed : bool, default = False
         To choose if the transformation of the sub-sequences is pre-computed or not.
-    transformed_X : np.ndarray, default = None
+    transformed_x : np.ndarray, default = None
         The transformation of X, ignored if transformation_precomputed is False.
     transformed_y : np.ndarray, default = None
         The transformation of y, ignored if transformation_precomputed is False.
@@ -619,7 +619,7 @@ def shape_dtw_pairwise_distance(
             reach=reach,
             itakura_max_slope=itakura_max_slope,
             transformation_precomputed=transformation_precomputed,
-            transformed_X=transformed_X,
+            transformed_x=transformed_x,
             unequal_length=unequal_length,
         )
     _y, unequal_length = _convert_to_list(y)
@@ -633,7 +633,7 @@ def shape_dtw_pairwise_distance(
         reach=reach,
         itakura_max_slope=itakura_max_slope,
         transformation_precomputed=transformation_precomputed,
-        transformed_X=transformed_X,
+        transformed_x=transformed_x,
         transformed_y=transformed_y,
         unequal_length=unequal_length,
     )
@@ -647,7 +647,7 @@ def _shape_dtw_pairwise_distance(
     reach: int,
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
-    transformed_X: Optional[np.ndarray],
+    transformed_x: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
@@ -667,8 +667,8 @@ def _shape_dtw_pairwise_distance(
                 )
 
             if transformation_precomputed:
-                transformed_x1 = transformed_X[i]
-                transformed_x2 = transformed_X[j]
+                transformed_x1 = transformed_x[i]
+                transformed_x2 = transformed_x[j]
             else:
                 transformed_x1 = x1
                 transformed_x2 = x2
@@ -697,7 +697,7 @@ def _shape_dtw_from_multiple_to_multiple_distance(
     reach: int,
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
-    transformed_X: Optional[np.ndarray],
+    transformed_x: Optional[np.ndarray],
     transformed_y: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
@@ -718,7 +718,7 @@ def _shape_dtw_from_multiple_to_multiple_distance(
                 )
 
             if transformation_precomputed:
-                transformed_x1 = transformed_X[i]
+                transformed_x1 = transformed_x[i]
                 transformed_x2 = transformed_y[j]
             else:
                 transformed_x1 = x1

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -648,7 +648,6 @@ def _shape_dtw_pairwise_distance(
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
     transformed_x: Optional[np.ndarray],
-    transformed_y: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -648,6 +648,7 @@ def _shape_dtw_pairwise_distance(
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
     transformed_x: Optional[np.ndarray],
+    transformed_y: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -666,12 +666,12 @@ def _shape_dtw_pairwise_distance(
                     x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
 
-            if transformation_precomputed and transformed_x is not None:
-                _transformed_x1 = transformed_x[i]
-                _transformed_x2 = transformed_x[j]
+            if transformation_precomputed and transformed_x:
+                transformed_x1 = transformed_x[i]
+                transformed_x2 = transformed_x[j]
             else:
-                _transformed_x1 = x1
-                _transformed_x2 = x2
+                transformed_x1 = x1
+                transformed_x2 = x2
 
             distances[i, j] = _shape_dtw_distance(
                 x=x1,
@@ -680,8 +680,8 @@ def _shape_dtw_pairwise_distance(
                 reach=reach,
                 bounding_matrix=bounding_matrix,
                 transformation_precomputed=transformation_precomputed,
-                transformed_x=_transformed_x1,
-                transformed_y=_transformed_x2,
+                transformed_x=transformed_x1,
+                transformed_y=transformed_x2,
             )
             distances[j, i] = distances[i, j]
 
@@ -717,7 +717,7 @@ def _shape_dtw_from_multiple_to_multiple_distance(
                     x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
 
-            if transformation_precomputed:
+            if transformation_precomputed and transformed_y and transformed_x:
                 transformed_x1 = transformed_x[i]
                 transformed_x2 = transformed_y[j]
             else:

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -666,7 +666,7 @@ def _shape_dtw_pairwise_distance(
                     x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
 
-            if transformation_precomputed and transformed_x:
+            if transformation_precomputed and transformed_x is not None:
                 transformed_x1 = transformed_x[i]
                 transformed_x2 = transformed_x[j]
             else:
@@ -717,7 +717,11 @@ def _shape_dtw_from_multiple_to_multiple_distance(
                     x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
 
-            if transformation_precomputed and transformed_y and transformed_x:
+            if (
+                transformation_precomputed
+                and transformed_y is not None
+                and transformed_x is not None
+            ):
                 transformed_x1 = transformed_x[i]
                 transformed_x2 = transformed_y[j]
             else:

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -669,6 +669,9 @@ def _shape_dtw_pairwise_distance(
             if transformation_precomputed:
                 transformed_x1 = transformed_X[i]
                 transformed_x2 = transformed_X[j]
+            else:
+                transformed_x1 = x1
+                transformed_x2 = x2
 
             distances[i, j] = _shape_dtw_distance(
                 x=x1,
@@ -717,6 +720,9 @@ def _shape_dtw_from_multiple_to_multiple_distance(
             if transformation_precomputed:
                 transformed_x1 = transformed_X[i]
                 transformed_x2 = transformed_y[j]
+            else:
+                transformed_x1 = x1
+                transformed_x2 = y1
 
             distances[i, j] = _shape_dtw_distance(
                 x=x1,

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -522,7 +522,7 @@ def shape_dtw_pairwise_distance(
     reach: int = 30,
     itakura_max_slope: Optional[float] = None,
     transformation_precomputed: bool = False,
-    transformed_x: Optional[np.ndarray] = None,
+    transformed_X: Optional[np.ndarray] = None,
     transformed_y: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Compute the ShapeDTW pairwise distance among a set of series.
@@ -558,8 +558,8 @@ def shape_dtw_pairwise_distance(
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
     transformation_precomputed : bool, default = False
         To choose if the transformation of the sub-sequences is pre-computed or not.
-    transformed_x : np.ndarray, default = None
-        The transformation of x, ignored if transformation_precomputed is False.
+    transformed_X : np.ndarray, default = None
+        The transformation of X, ignored if transformation_precomputed is False.
     transformed_y : np.ndarray, default = None
         The transformation of y, ignored if transformation_precomputed is False.
 
@@ -619,8 +619,7 @@ def shape_dtw_pairwise_distance(
             reach=reach,
             itakura_max_slope=itakura_max_slope,
             transformation_precomputed=transformation_precomputed,
-            transformed_x=transformed_x,
-            transformed_y=transformed_y,
+            transformed_X=transformed_X,
             unequal_length=unequal_length,
         )
     _y, unequal_length = _convert_to_list(y)
@@ -634,7 +633,7 @@ def shape_dtw_pairwise_distance(
         reach=reach,
         itakura_max_slope=itakura_max_slope,
         transformation_precomputed=transformation_precomputed,
-        transformed_x=transformed_x,
+        transformed_X=transformed_X,
         transformed_y=transformed_y,
         unequal_length=unequal_length,
     )
@@ -648,8 +647,7 @@ def _shape_dtw_pairwise_distance(
     reach: int,
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
-    transformed_x: Optional[np.ndarray],
-    transformed_y: Optional[np.ndarray],
+    transformed_X: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
@@ -667,6 +665,11 @@ def _shape_dtw_pairwise_distance(
                 bounding_matrix = create_bounding_matrix(
                     x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
+
+            if transformation_precomputed:
+                transformed_x1 = transformed_X[i]
+                transformed_x2 = transformed_X[j]
+
             distances[i, j] = _shape_dtw_distance(
                 x=x1,
                 y=x2,
@@ -674,8 +677,8 @@ def _shape_dtw_pairwise_distance(
                 reach=reach,
                 bounding_matrix=bounding_matrix,
                 transformation_precomputed=transformation_precomputed,
-                transformed_x=transformed_x,
-                transformed_y=transformed_y,
+                transformed_x=transformed_x1,
+                transformed_y=transformed_x2,
             )
             distances[j, i] = distances[i, j]
 
@@ -691,7 +694,7 @@ def _shape_dtw_from_multiple_to_multiple_distance(
     reach: int,
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
-    transformed_x: Optional[np.ndarray],
+    transformed_X: Optional[np.ndarray],
     transformed_y: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
@@ -710,6 +713,11 @@ def _shape_dtw_from_multiple_to_multiple_distance(
                 bounding_matrix = create_bounding_matrix(
                     x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
+
+            if transformation_precomputed:
+                transformed_x1 = transformed_X[i]
+                transformed_x2 = transformed_y[j]
+
             distances[i, j] = _shape_dtw_distance(
                 x=x1,
                 y=y1,
@@ -717,8 +725,8 @@ def _shape_dtw_from_multiple_to_multiple_distance(
                 reach=reach,
                 bounding_matrix=bounding_matrix,
                 transformation_precomputed=transformation_precomputed,
-                transformed_x=transformed_x,
-                transformed_y=transformed_y,
+                transformed_x=transformed_x1,
+                transformed_y=transformed_x2,
             )
 
     return distances

--- a/aeon/distances/_shape_dtw.py
+++ b/aeon/distances/_shape_dtw.py
@@ -648,7 +648,6 @@ def _shape_dtw_pairwise_distance(
     itakura_max_slope: Optional[float],
     transformation_precomputed: bool,
     transformed_x: Optional[np.ndarray],
-    transformed_y: Optional[np.ndarray],
     unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
@@ -667,12 +666,12 @@ def _shape_dtw_pairwise_distance(
                     x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
 
-            if transformation_precomputed:
-                transformed_x1 = transformed_x[i]
-                transformed_x2 = transformed_x[j]
+            if transformation_precomputed and transformed_x is not None:
+                _transformed_x1 = transformed_x[i]
+                _transformed_x2 = transformed_x[j]
             else:
-                transformed_x1 = x1
-                transformed_x2 = x2
+                _transformed_x1 = x1
+                _transformed_x2 = x2
 
             distances[i, j] = _shape_dtw_distance(
                 x=x1,
@@ -681,8 +680,8 @@ def _shape_dtw_pairwise_distance(
                 reach=reach,
                 bounding_matrix=bounding_matrix,
                 transformation_precomputed=transformation_precomputed,
-                transformed_x=transformed_x1,
-                transformed_y=transformed_x2,
+                transformed_x=_transformed_x1,
+                transformed_y=_transformed_x2,
             )
             distances[j, i] = distances[i, j]
 

--- a/aeon/distances/_squared.py
+++ b/aeon/distances/_squared.py
@@ -127,17 +127,17 @@ def squared_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> squared_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[  0.,  27., 147.],
+           [ 27.,   0.,  64.],
+           [147.,  64.,   0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, _ = _convert_to_list(X, "X")
 
     if y is None:
         # To self
         return _squared_pairwise_distance(_X)
 
-    _y = _convert_to_list(y, "y")
+    _y, _ = _convert_to_list(y, "y")
     return _squared_from_multiple_to_multiple_distance(_X, _y)
 
 

--- a/aeon/distances/_squared.py
+++ b/aeon/distances/_squared.py
@@ -1,11 +1,12 @@
 __maintainer__ = []
 
-from typing import Optional
+from typing import List, Optional, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -71,21 +72,21 @@ def _univariate_squared_distance(x: np.ndarray, y: np.ndarray) -> float:
     return distance
 
 
-@njit(cache=True, fastmath=True)
 def squared_pairwise_distance(
-    X: np.ndarray, y: Optional[np.ndarray] = None
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
 ) -> np.ndarray:
     """Compute the squared pairwise distance between a set of time series.
 
     Parameters
     ----------
-    X : np.ndarray
-        First time series, either univariate, shape ``(n_timepoints,)``, or
-        multivariate, shape ``(n_channels, n_timepoints)``.
-    y : np.ndarray
-        Second time series, either univariate, shape ``(n_timepoints,)``, or
-        multivariate, shape ``(n_channels, n_timepoints)``.
-        If None, then the squared pairwise distance between the instances of X is
+    X : np.ndarray or List of np.ndarray
+        A collection of time series instances  of shape ``(n_cases, n_timepoints)``
+        or ``(n_cases, n_channels, n_timepoints)``.
+    y : np.ndarray or List of np.ndarray or None, default=None
+        A single series or a collection of time series of shape ``(m_timepoints,)`` or
+        ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
+        If None, then the msm pairwise distance between the instances of X is
         calculated.
 
     Returns
@@ -123,22 +124,26 @@ def squared_pairwise_distance(
            [147.],
            [ 48.]])
 
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> squared_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
+
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _squared_pairwise_distance(X)
-        elif X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _squared_pairwise_distance(_X)
-        raise ValueError("X must be 2D or 3D array")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
-    return _squared_from_multiple_to_multiple_distance(_x, _y)
+        return _squared_pairwise_distance(_X)
+
+    _y = _convert_to_list(y, "y")
+    return _squared_from_multiple_to_multiple_distance(_X, _y)
 
 
 @njit(cache=True, fastmath=True)
-def _squared_pairwise_distance(X: np.ndarray) -> np.ndarray:
-    n_cases = X.shape[0]
+def _squared_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
     for i in range(n_cases):
@@ -151,10 +156,10 @@ def _squared_pairwise_distance(X: np.ndarray) -> np.ndarray:
 
 @njit(cache=True, fastmath=True)
 def _squared_from_multiple_to_multiple_distance(
-    x: np.ndarray, y: np.ndarray
+    x: NumbaList[np.ndarray], y: NumbaList[np.ndarray]
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
     for i in range(n_cases):

--- a/aeon/distances/_twe.py
+++ b/aeon/distances/_twe.py
@@ -318,17 +318,19 @@ def twe_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> twe_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[ 0.   , 13.005, 19.006],
+           [13.005,  0.   , 18.007],
+           [19.006, 18.007,  0.   ]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
     if y is None:
         # To self
-        return _twe_pairwise_distance(_X, window, nu, lmbda, itakura_max_slope)
-    _y = _convert_to_list(y, "y")
+        return _twe_pairwise_distance(
+            _X, window, nu, lmbda, itakura_max_slope, unequal_length
+        )
+    _y, unequal_length = _convert_to_list(y, "y")
     return _twe_from_multiple_to_multiple_distance(
-        _X, _y, window, nu, lmbda, itakura_max_slope
+        _X, _y, window, nu, lmbda, itakura_max_slope, unequal_length
     )
 
 
@@ -339,14 +341,15 @@ def _twe_pairwise_distance(
     nu: float,
     lmbda: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
 
     # Pad the arrays before so that we don't have to redo every iteration
@@ -357,9 +360,9 @@ def _twe_pairwise_distance(
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = padded_X[i], padded_X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _twe_distance(x1, x2, bounding_matrix, nu, lmbda)
             distances[j, i] = distances[i, j]
@@ -375,14 +378,14 @@ def _twe_from_multiple_to_multiple_distance(
     nu: float,
     lmbda: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
 
     # Pad the arrays before so that we dont have to redo every iteration
@@ -397,9 +400,9 @@ def _twe_from_multiple_to_multiple_distance(
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = padded_x[i], padded_y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _twe_distance(x1, y1, bounding_matrix, nu, lmbda)
     return distances

--- a/aeon/distances/_wddtw.py
+++ b/aeon/distances/_wddtw.py
@@ -235,18 +235,20 @@ def wddtw_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> wddtw_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[0., 0., 0.],
+           [0., 0., 0.],
+           [0., 0., 0.]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
 
     if y is None:
-        return _wddtw_pairwise_distance(_X, window, g, itakura_max_slope)
+        return _wddtw_pairwise_distance(
+            _X, window, g, itakura_max_slope, unequal_length
+        )
 
-    _y = _convert_to_list(y, "y")
+    _y, unequal_length = _convert_to_list(y, "y")
     return _wddtw_from_multiple_to_multiple_distance(
-        _X, _y, window, g, itakura_max_slope
+        _X, _y, window, g, itakura_max_slope, unequal_length
     )
 
 
@@ -256,14 +258,15 @@ def _wddtw_pairwise_distance(
     window: Optional[float],
     g: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
     X_average_of_slope = NumbaList()
     for i in range(n_cases):
@@ -272,9 +275,9 @@ def _wddtw_pairwise_distance(
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X_average_of_slope[i], X_average_of_slope[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _wdtw_distance(x1, x2, bounding_matrix, g)
             distances[j, i] = distances[i, j]
@@ -289,15 +292,15 @@ def _wddtw_from_multiple_to_multiple_distance(
     window: Optional[float],
     g: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
 
     # Derive the arrays before so that we dont have to redo every iteration
@@ -312,9 +315,9 @@ def _wddtw_from_multiple_to_multiple_distance(
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x_average_of_slope[i], y_average_of_slope[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _wdtw_distance(x1, y1, bounding_matrix, g)
     return distances

--- a/aeon/distances/_wdtw.py
+++ b/aeon/distances/_wdtw.py
@@ -303,18 +303,18 @@ def wdtw_pairwise_distance(
     >>> # Distance between each TS in a collection of unequal-length time series
     >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
     >>> wdtw_pairwise_distance(X)
-    array([[ 0., 10., 17.],
-            [10.,  0., 14.],
-            [17., 14.,  0.]]
+    array([[  0.        ,  20.25043711, 139.70656066],
+           [ 20.25043711,   0.        ,  39.64543037],
+           [139.70656066,  39.64543037,   0.        ]])
     """
-    _X = _convert_to_list(X, "X")
+    _X, unequal_length = _convert_to_list(X, "X")
 
     if y is None:
         # To self
-        return _wdtw_pairwise_distance(_X, window, g, itakura_max_slope)
-    _y = _convert_to_list(y, "y")
+        return _wdtw_pairwise_distance(_X, window, g, itakura_max_slope, unequal_length)
+    _y, unequal_length = _convert_to_list(y, "y")
     return _wdtw_from_multiple_to_multiple_distance(
-        _X, _y, window, g, itakura_max_slope
+        _X, _y, window, g, itakura_max_slope, unequal_length
     )
 
 
@@ -324,21 +324,22 @@ def _wdtw_pairwise_distance(
     window: Optional[float],
     g: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    if window == 1.0:
-        max_shape = max([x.shape[-1] for x in X])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        n_timepoints = X[0].shape[1]
+        bounding_matrix = create_bounding_matrix(
+            n_timepoints, n_timepoints, window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                    x1.shape[1], x2.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _wdtw_distance(x1, x2, bounding_matrix, g)
             distances[j, i] = distances[i, j]
@@ -353,22 +354,22 @@ def _wdtw_from_multiple_to_multiple_distance(
     window: Optional[float],
     g: float,
     itakura_max_slope: Optional[float],
+    unequal_length: bool,
 ) -> np.ndarray:
     n_cases = len(x)
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    if window == 1.0:
-        max_shape = max([_x.shape[-1] for _x in x])
-        bounding_matrix: np.ndarray = create_bounding_matrix(
-            max_shape, max_shape, window, itakura_max_slope
+    if not unequal_length:
+        bounding_matrix = create_bounding_matrix(
+            x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
     for i in range(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
-            if window != 1.0:
+            if unequal_length:
                 bounding_matrix = create_bounding_matrix(
-                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                    x1.shape[1], y1.shape[1], window, itakura_max_slope
                 )
             distances[i, j] = _wdtw_distance(x1, y1, bounding_matrix, g)
     return distances

--- a/aeon/distances/_wdtw.py
+++ b/aeon/distances/_wdtw.py
@@ -2,15 +2,16 @@ r"""Weighted dynamic time warping (WDTW) distance between two time series."""
 
 __maintainer__ = []
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from numba import njit
+from numba.typed import List as NumbaList
 
 from aeon.distances._alignment_paths import compute_min_return_path
 from aeon.distances._bounding_matrix import create_bounding_matrix
 from aeon.distances._squared import _univariate_squared_distance
-from aeon.distances._utils import reshape_pairwise_to_multiple
+from aeon.distances._utils import _convert_to_list
 
 
 @njit(cache=True, fastmath=True)
@@ -233,10 +234,9 @@ def _wdtw_cost_matrix(
     return cost_matrix[1:, 1:]
 
 
-@njit(cache=True, fastmath=True)
 def wdtw_pairwise_distance(
-    X: np.ndarray,
-    y: Optional[np.ndarray] = None,
+    X: Union[np.ndarray, List[np.ndarray]],
+    y: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
     window: Optional[float] = None,
     g: float = 0.05,
     itakura_max_slope: Optional[float] = None,
@@ -245,12 +245,14 @@ def wdtw_pairwise_distance(
 
     Parameters
     ----------
-    X : np.ndarray, of shape (n_cases, n_channels, n_timepoints) or
-            (n_cases, n_timepoints)
-        A collection of time series instances.
-    y : np.ndarray, of shape (m_cases, m_channels, m_timepoints) or
-            (m_cases, m_timepoints) or (m_timepoints,), default=None
-        A collection of time series instances.
+    X : np.ndarray or List of np.ndarray
+        A collection of time series instances  of shape ``(n_cases, n_timepoints)``
+        or ``(n_cases, n_channels, n_timepoints)``.
+    y : np.ndarray or List of np.ndarray or None, default=None
+        A single series or a collection of time series of shape ``(m_timepoints,)`` or
+        ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
+        If None, then the msm pairwise distance between the instances of X is
+        calculated.
     window : float, default=None
         The window to use for the bounding matrix. If None, no bounding matrix
         is used.
@@ -297,34 +299,48 @@ def wdtw_pairwise_distance(
     array([[144.37763524],
            [ 70.74504127],
            [ 23.10042164]])
+
+    >>> # Distance between each TS in a collection of unequal-length time series
+    >>> X = [np.array([1, 2, 3]), np.array([4, 5, 6, 7]), np.array([8, 9, 10, 11, 12])]
+    >>> wdtw_pairwise_distance(X)
+    array([[ 0., 10., 17.],
+            [10.,  0., 14.],
+            [17., 14.,  0.]]
     """
+    _X = _convert_to_list(X, "X")
+
     if y is None:
         # To self
-        if X.ndim == 3:
-            return _wdtw_pairwise_distance(X, window, g, itakura_max_slope)
-        if X.ndim == 2:
-            _X = X.reshape((X.shape[0], 1, X.shape[1]))
-            return _wdtw_pairwise_distance(_X, window, g, itakura_max_slope)
-        raise ValueError("x and y must be 1D, 2D, or 3D arrays")
-    _x, _y = reshape_pairwise_to_multiple(X, y)
+        return _wdtw_pairwise_distance(_X, window, g, itakura_max_slope)
+    _y = _convert_to_list(y, "y")
     return _wdtw_from_multiple_to_multiple_distance(
-        _x, _y, window, g, itakura_max_slope
+        _X, _y, window, g, itakura_max_slope
     )
 
 
 @njit(cache=True, fastmath=True)
 def _wdtw_pairwise_distance(
-    X: np.ndarray, window: Optional[float], g: float, itakura_max_slope: Optional[float]
+    X: NumbaList[np.ndarray],
+    window: Optional[float],
+    g: float,
+    itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = X.shape[0]
+    n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
-    bounding_matrix = create_bounding_matrix(
-        X.shape[2], X.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([x.shape[-1] for x in X])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(i + 1, n_cases):
-            distances[i, j] = _wdtw_distance(X[i], X[j], bounding_matrix, g)
+            x1, x2 = X[i], X[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], x2.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _wdtw_distance(x1, x2, bounding_matrix, g)
             distances[j, i] = distances[i, j]
 
     return distances
@@ -332,22 +348,29 @@ def _wdtw_pairwise_distance(
 
 @njit(cache=True, fastmath=True)
 def _wdtw_from_multiple_to_multiple_distance(
-    x: np.ndarray,
-    y: np.ndarray,
+    x: NumbaList[np.ndarray],
+    y: NumbaList[np.ndarray],
     window: Optional[float],
     g: float,
     itakura_max_slope: Optional[float],
 ) -> np.ndarray:
-    n_cases = x.shape[0]
-    m_cases = y.shape[0]
+    n_cases = len(x)
+    m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
-    bounding_matrix = create_bounding_matrix(
-        x.shape[2], y.shape[2], window, itakura_max_slope
-    )
 
+    if window == 1.0:
+        max_shape = max([_x.shape[-1] for _x in x])
+        bounding_matrix: np.ndarray = create_bounding_matrix(
+            max_shape, max_shape, window, itakura_max_slope
+        )
     for i in range(n_cases):
         for j in range(m_cases):
-            distances[i, j] = _wdtw_distance(x[i], y[j], bounding_matrix, g)
+            x1, y1 = x[i], y[j]
+            if window != 1.0:
+                bounding_matrix = create_bounding_matrix(
+                    x1.shape[-1], y1.shape[-1], window, itakura_max_slope
+                )
+            distances[i, j] = _wdtw_distance(x1, y1, bounding_matrix, g)
     return distances
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "aeon"
 version = "0.8.0"
 description = "A toolkit for conducting machine learning tasks with time series data"
-authors = [
-    {name = "aeon developers", email = "contact@aeon-toolkit.org"},
-]
-maintainers = [
-    {name = "aeon developers", email = "contact@aeon-toolkit.org"},
-]
+authors = [{ name = "aeon developers", email = "contact@aeon-toolkit.org" }]
+maintainers = [{ name = "aeon developers", email = "contact@aeon-toolkit.org" }]
 readme = "README.md"
 keywords = [
     "data-science",
@@ -96,8 +92,8 @@ dl = [
     "tensorflow-addons; python_version < '3.12'",
 ]
 unstable_extras = [
-    "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'",  # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
-    "pycatch22<=0.4.3",  # known to fail installation on some setups
+    "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'", # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
+    "pycatch22<=0.4.3",                                  # known to fail installation on some setups
 ]
 dev = [
     "backoff",
@@ -111,10 +107,7 @@ dev = [
     "pytest-rerunfailures",
     "wheel",
 ]
-binder = [
-    "notebook",
-    "jupyterlab",
-]
+binder = ["notebook", "jupyterlab"]
 docs = [
     "sphinx<8.0.0",
     "sphinx-design",
@@ -146,15 +139,7 @@ file = "LICENSE"
 zip-safe = true
 
 [tool.setuptools.package-data]
-aeon = [
-    "*.csv",
-    "*.csv.gz",
-    "*.arff",
-    "*.arff.gz",
-    "*.txt",
-    "*.ts",
-    "*.tsv",
-]
+aeon = ["*.csv", "*.csv.gz", "*.arff", "*.arff.gz", "*.txt", "*.ts", "*.tsv"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
@@ -179,14 +164,14 @@ convention = "numpy"
 testpaths = "aeon"
 addopts = '''
     --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
-    --dist worksteal
-    --reruns 2
-    --only-rerun "crashed while running"
 '''
+# --durations 20
+# --timeout 600
+# --showlocals
+# --numprocesses auto
+# --dist worksteal
+# --reruns 2
+# --only-rerun "crashed while running"
 filterwarnings = '''
     ignore::UserWarning
     ignore:numpy.dtype size changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,12 @@ build-backend = "setuptools.build_meta"
 name = "aeon"
 version = "0.8.0"
 description = "A toolkit for conducting machine learning tasks with time series data"
-authors = [{ name = "aeon developers", email = "contact@aeon-toolkit.org" }]
-maintainers = [{ name = "aeon developers", email = "contact@aeon-toolkit.org" }]
+authors = [
+    {name = "aeon developers", email = "contact@aeon-toolkit.org"},
+]
+maintainers = [
+    {name = "aeon developers", email = "contact@aeon-toolkit.org"},
+]
 readme = "README.md"
 keywords = [
     "data-science",
@@ -92,8 +96,8 @@ dl = [
     "tensorflow-addons; python_version < '3.12'",
 ]
 unstable_extras = [
-    "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'", # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
-    "pycatch22<=0.4.3",                                  # known to fail installation on some setups
+    "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin'",  # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)
+    "pycatch22<=0.4.3",  # known to fail installation on some setups
 ]
 dev = [
     "backoff",
@@ -107,7 +111,10 @@ dev = [
     "pytest-rerunfailures",
     "wheel",
 ]
-binder = ["notebook", "jupyterlab"]
+binder = [
+    "notebook",
+    "jupyterlab",
+]
 docs = [
     "sphinx<8.0.0",
     "sphinx-design",
@@ -139,7 +146,15 @@ file = "LICENSE"
 zip-safe = true
 
 [tool.setuptools.package-data]
-aeon = ["*.csv", "*.csv.gz", "*.arff", "*.arff.gz", "*.txt", "*.ts", "*.tsv"]
+aeon = [
+    "*.csv",
+    "*.csv.gz",
+    "*.arff",
+    "*.arff.gz",
+    "*.txt",
+    "*.ts",
+    "*.tsv",
+]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
@@ -164,13 +179,13 @@ convention = "numpy"
 testpaths = "aeon"
 addopts = '''
     --doctest-modules
-     --durations 20
-     --timeout 600
-     --showlocals
-     --numprocesses auto
-     --dist worksteal
-     --reruns 2
-     --only-rerun "crashed while running"
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
+    --dist worksteal
+    --reruns 2
+    --only-rerun "crashed while running"
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,13 +179,6 @@ convention = "numpy"
 testpaths = "aeon"
 addopts = '''
     --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --numprocesses auto
-    --dist worksteal
-    --reruns 2
-    --only-rerun "crashed while running"
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,13 @@ convention = "numpy"
 testpaths = "aeon"
 addopts = '''
     --doctest-modules
+    --durations 20
+    --timeout 600
+    --showlocals
+    --numprocesses auto
+    --dist worksteal
+    --reruns 2
+    --only-rerun "crashed while running"
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,14 +164,14 @@ convention = "numpy"
 testpaths = "aeon"
 addopts = '''
     --doctest-modules
+     --durations 20
+     --timeout 600
+     --showlocals
+     --numprocesses auto
+     --dist worksteal
+     --reruns 2
+     --only-rerun "crashed while running"
 '''
-# --durations 20
-# --timeout 600
-# --showlocals
-# --numprocesses auto
-# --dist worksteal
-# --reruns 2
-# --only-rerun "crashed while running"
 filterwarnings = '''
     ignore::UserWarning
     ignore:numpy.dtype size changed


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
This PR adds a strategy to kmeans to handle/allow empty clusters. If a empty cluster occurs then the time series that contributes the most to sum of squared error (the time series furthest distance from its assigned cluster centre) is set to be a cluster centre.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
This follows the same logic sklearn does to handle empty clusters.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
