### PR TITLE
[ENH] Kmeans allow empty clusters

### DIFF
--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -234,8 +234,13 @@ class TimeSeriesKMeans(BaseClusterer):
             curr_labels = curr_pw.argmin(axis=1)
             curr_inertia = curr_pw.min(axis=1).sum()
 
+            # If an empty cluster is encountered
             if np.unique(curr_labels).size < self.n_clusters:
-                raise EmptyClusterError
+                curr_pw, curr_labels, curr_inertia, cluster_centres = (
+                    self._handle_empty_cluster(
+                        X, cluster_centres, curr_pw, curr_labels, curr_inertia
+                    )
+                )
 
             if self.verbose:
                 print("%.3f" % curr_inertia, end=" --> ")  # noqa: T001, T201
@@ -290,7 +295,7 @@ class TimeSeriesKMeans(BaseClusterer):
                 isinstance(self.init_algorithm, np.ndarray)
                 and len(self.init_algorithm) == self.n_clusters
             ):
-                self._init_algorithm = self.init_algorithm
+                self._init_algorithm = self.init_algorithm.copy()
             else:
                 raise ValueError(
                     f"The value provided for init_algorithm: {self.init_algorithm} is "
@@ -346,6 +351,38 @@ class TimeSeriesKMeans(BaseClusterer):
 
         centers = X[indexes]
         return centers
+
+    def _handle_empty_cluster(
+        self,
+        X: np.ndarray,
+        cluster_centres: np.ndarray,
+        curr_pw: np.ndarray,
+        curr_labels: np.ndarray,
+        curr_inertia: float,
+    ):
+        # Find the cluster that contributes most to the sum of squared error
+        # and make it a new centre in place of the empty
+        empty_clusters = np.setdiff1d(np.arange(self.n_clusters), curr_labels)
+        j = 0
+        max_iterations = self.n_clusters
+
+        while empty_clusters.size > 0:
+            # Assign each time series to the cluster that is closest to it
+            # and then find the time series that is furthest from the centre
+            index_furthest_from_centre = curr_pw.min(axis=1).argmax()
+            cluster_centres[empty_clusters[0]] = X[index_furthest_from_centre]
+            curr_pw = pairwise_distance(
+                X, cluster_centres, metric=self.distance, **self._distance_params
+            )
+            curr_labels = curr_pw.argmin(axis=1)
+            curr_inertia = curr_pw.min(axis=1).sum()
+            empty_clusters = np.setdiff1d(np.arange(self.n_clusters), curr_labels)
+            j += 1
+            if j > max_iterations:
+                # This should be unreachable but just a safety check to stop it looping
+                # forever
+                raise EmptyClusterError
+        return curr_pw, curr_labels, curr_inertia, cluster_centres
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
This PR adds a strategy to kmeans to handle/allow empty clusters. If a empty cluster occurs then the time series that contributes the most to sum of squared error (the time series furthest distance from its assigned cluster centre) is set to be a cluster centre.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
This follows the same logic sklearn does to handle empty clusters.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
