### PR TITLE
[DOC] Adds previously implemented classifiers to docs/api_references

### DIFF
--- a/docs/api_reference/classification.rst
+++ b/docs/api_reference/classification.rst
@@ -20,6 +20,8 @@ Convolution-based
 
     Arsenal
     RocketClassifier
+    HydraClassifier
+    MultiRocketHydraClassifier
 
 Deep learning
 -------------

--- a/docs/api_reference/regression.rst
+++ b/docs/api_reference/regression.rst
@@ -37,6 +37,8 @@ Deep learning
     InceptionTimeRegressor
     IndividualInceptionRegressor
     ResNetRegressor
+    LITETimeRegressor
+    IndividualLITERegressor
 
 Distance-based
 --------------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->

Assuming the updates to docs/api_reference were done in error, these changes add entries for classifiers implemented in the following PRs:
- https://github.com/aeon-toolkit/aeon/pull/1221
- https://github.com/aeon-toolkit/aeon/pull/1173

#### Any other comments?

I didn't do an exhaustive search for implemented classifiers that aren't in the API reference, so there may be some greatness that's still (relatively) hard to discover.
 
### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

<!--
Thanks for contributing!
-->
