### PR TITLE
[DOC] Correct `WeightedEnsembleClassifier` parameter docstring

### DIFF
--- a/aeon/classification/compose/_ensemble.py
+++ b/aeon/classification/compose/_ensemble.py
@@ -32,9 +32,8 @@ class WeightedEnsembleClassifier(_HeterogenousMetaEstimator, BaseClassifier):
 
     Parameters
     ----------
-    classifiers : dict or None, default=None
-        Parameters for the ShapeletTransformClassifier module. If None, uses the
-        default parameters with a 2 hour transform contract.
+    classifiers : list of tuples (str, classifier) of aeon classifiers
+        Classifiers to apply to the input series.
     weights : float, or iterable of float, optional, default=None
         if float, ensemble weight for classifier i will be train score to this power
         if iterable of float, must be equal length as classifiers


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->

The current docstring for the `classifiers` parameter of `WeightedEnsembleClassifier` is not correct.

This change updates the docstring to match what other ensemble docstrings look like (see [forecasing.compose._ensemble.py](https://github.com/aeon-toolkit/aeon/blob/5f8974f3fca240f66cb52a626658931489871962/aeon/forecasting/compose/_ensemble.py#L46-L47))

#### Does your contribution introduce a new dependency? If yes, which one?

No

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

<!--
Thanks for contributing!
-->
