### PR TITLE
[ENH] allow np.ndarray with ndim>1 to convert to pd.series when squeezable to 1D

### DIFF
--- a/aeon/utils/conversion/_convert_series.py
+++ b/aeon/utils/conversion/_convert_series.py
@@ -46,6 +46,7 @@ def convert_series(y, output_type):
             y = y.iloc[:, 0]
             return y
         elif isinstance(y, np.ndarray):
+            y = y.squeeze()
             if y.ndim == 1:
                 # Convert 1D numpy array to pandas Series
                 return pd.Series(y)


### PR DESCRIPTION
subsequent to https://github.com/aeon-toolkit/aeon/pull/1338, test test_wrapper_series_mtype failing an overnight test. This function passes an (n,1) np.ndarray to a forecaster and tries to convert it to a pd.Series. Now the conversion squeezes before testing ndim > 1. 