### PR TITLE
[MNT] split up and simplified ba test

### DIFF
--- a/aeon/clustering/tests/test_k_means.py
+++ b/aeon/clustering/tests/test_k_means.py
@@ -8,6 +8,7 @@ from sklearn.utils import check_random_state
 from aeon.clustering._k_means import TimeSeriesKMeans
 from aeon.datasets import load_basic_motions, load_gunpoint
 from aeon.distances import euclidean_distance
+from aeon.testing.utils.data_gen import make_example_3d_numpy
 from aeon.utils.validation._dependencies import _check_estimator_deps
 
 expected_results = {
@@ -199,12 +200,9 @@ def _get_model_centres(data, distance, average_params=None, distance_params=None
     return model.cluster_centers_
 
 
-def test_different_ba():
-    """Test different ba methods."""
-    X_train, y_train = load_basic_motions(split="train")
-
-    num_test_values = 5
-    data = X_train[0:num_test_values]
+def test_petitjean_ba_params():
+    """Test different petitjean ba params."""
+    data = make_example_3d_numpy(5, 2, 10, random_state=1, return_y=False)
 
     # Test passing distance param
     default_dba = _get_model_centres(data, distance="dtw")
@@ -235,7 +233,7 @@ def test_different_ba():
 
     # Test passing multiple params
     mba_custom_params_window_and_indep = _get_model_centres(
-        data, distance="msm", average_params={"window": 0.2, "independent": False}
+        data, distance="msm", average_params={"window": 0.1, "independent": False}
     )
 
     # Check not equal to just when indep set
@@ -247,13 +245,17 @@ def test_different_ba():
     # Check not equal to default
     assert not np.array_equal(default_mba, mba_custom_params_window_and_indep)
 
+
+def test_ssg_ba_params():
+    """Test different ssg-ba params."""
+    data = make_example_3d_numpy(5, 2, 10, random_state=1, return_y=False)
+
     # Test subgradient ba
     subgradient_dba_specified = _get_model_centres(
         data,
         distance="dtw",
         average_params={"distance": "dtw", "method": "subgradient"},
     )
-    assert not np.array_equal(dba_specified, subgradient_dba_specified)
 
     # Test another distance and check passing custom distance param
     subgradient_mba_specified = _get_model_centres(
@@ -261,7 +263,6 @@ def test_different_ba():
         distance="msm",
         average_params={"distance": "msm", "method": "subgradient"},
     )
-    assert not np.array_equal(mba_specified, subgradient_mba_specified)
     assert not np.array_equal(subgradient_dba_specified, subgradient_mba_specified)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR splits up and makes the kmeans-ba tests run faster and are easier to read.

<!--
A clear and concise description of what you have implemented.
-->
The updated test was timing out in the nightly CI runs. While I don't think it was directly the cause (think the runner was dodgy) this test should be split up and simplified anyway so this PR fixes that.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
