### PR TITLE
[DEP] deprecate check_scorer

### DIFF
--- a/aeon/forecasting/compose/tests/test_multiplex.py
+++ b/aeon/forecasting/compose/tests/test_multiplex.py
@@ -15,13 +15,14 @@ from aeon.forecasting.model_selection import (
 )
 from aeon.forecasting.naive import NaiveForecaster
 from aeon.forecasting.theta import ThetaForecaster
+from aeon.performance_metrics.forecasting import mean_absolute_percentage_error
 from aeon.utils.validation._dependencies import _check_estimator_deps
-from aeon.utils.validation.forecasting import check_scoring
 
 
 def _score_forecasters(forecasters, cv, y):
     """Will evaluate all the forecasters on y and return the name of best."""
-    scoring = check_scoring(None)
+    scoring = mean_absolute_percentage_error
+
     scoring_name = f"test_{scoring.__name__}"
     score = None
     for name, forecaster in forecasters:

--- a/aeon/forecasting/model_evaluation/_functions.py
+++ b/aeon/forecasting/model_evaluation/_functions.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from aeon.exceptions import FitFailedWarning
 from aeon.forecasting.base import ForecastingHorizon
+from aeon.performance_metrics.forecasting import mean_absolute_percentage_error
 from aeon.utils.conversion import convert_collection, convert_series
 from aeon.utils.validation import (
     is_collection,
@@ -20,7 +21,7 @@ from aeon.utils.validation import (
     validate_input,
 )
 from aeon.utils.validation._dependencies import _check_soft_dependencies
-from aeon.utils.validation.forecasting import check_cv, check_scoring
+from aeon.utils.validation.forecasting import check_cv
 
 PANDAS_MTYPES = ["pd.DataFrame", "pd.Series", "pd-multiindex", "pd_multiindex_hier"]
 
@@ -331,10 +332,17 @@ def evaluate(
 
     _check_strategy(strategy)
     cv = check_cv(cv, enforce_start_with_window=True)
+
+    def _check_scoring(s):
+        if s is None:
+            return mean_absolute_percentage_error
+        if not callable(s):
+            raise TypeError("`scoring` must be a callable object")
+
     if isinstance(scoring, List):
-        scoring = [check_scoring(s) for s in scoring]
+        scoring = [_check_scoring(s) for s in scoring]
     else:
-        scoring = check_scoring(scoring)
+        scoring = [_check_scoring(scoring)]
 
     valid, y_metadata = validate_input(y)
     if not valid:

--- a/aeon/forecasting/model_evaluation/_functions.py
+++ b/aeon/forecasting/model_evaluation/_functions.py
@@ -338,6 +338,7 @@ def evaluate(
             return mean_absolute_percentage_error
         if not callable(s):
             raise TypeError("`scoring` must be a callable object")
+        return s
 
     if isinstance(scoring, List):
         scoring = [_check_scoring(s) for s in scoring]

--- a/aeon/forecasting/model_selection/_tune.py
+++ b/aeon/forecasting/model_selection/_tune.py
@@ -12,8 +12,8 @@ from sklearn.model_selection import ParameterGrid, ParameterSampler, check_cv
 from aeon.exceptions import NotFittedError
 from aeon.forecasting.base._delegate import _DelegatedForecaster
 from aeon.forecasting.model_evaluation import evaluate
+from aeon.performance_metrics.forecasting import mean_absolute_percentage_error
 from aeon.utils.validation import abstract_types
-from aeon.utils.validation.forecasting import check_scoring
 
 
 class BaseGridSearch(_DelegatedForecaster):
@@ -139,8 +139,12 @@ class BaseGridSearch(_DelegatedForecaster):
         self : returns an instance of self.
         """
         cv = check_cv(self.cv)
-
-        scoring = check_scoring(self.scoring)
+        if self.scoring is None:
+            scoring = mean_absolute_percentage_error
+        else:
+            scoring = self.scoring
+        if not callable(scoring):
+            raise TypeError("`scoring` must be a callable object")
         scoring_name = f"test_{scoring.__name__}"
 
         def _fit_and_score(params):

--- a/aeon/transformations/tests/test_multiplexer.py
+++ b/aeon/transformations/tests/test_multiplexer.py
@@ -15,9 +15,9 @@ from aeon.forecasting.model_selection import (
     ForecastingGridSearchCV,
 )
 from aeon.forecasting.naive import NaiveForecaster
+from aeon.performance_metrics.forecasting import mean_absolute_percentage_error
 from aeon.transformations.compose import MultiplexTransformer
 from aeon.transformations.exponent import ExponentTransformer
-from aeon.utils.validation.forecasting import check_scoring
 
 
 def test_multiplex_transformer_alone():
@@ -52,7 +52,7 @@ def test_multiplex_transformer_alone():
 
 def _find_best_transformer(forecaster, transformers, cv, y):
     """Evaluate all the transformers on y and return the name of best."""
-    scoring = check_scoring(None)
+    scoring = mean_absolute_percentage_error
     scoring_name = f"test_{scoring.__name__}"
     score = None
     for name, transformer in transformers:

--- a/aeon/utils/validation/forecasting.py
+++ b/aeon/utils/validation/forecasting.py
@@ -394,7 +394,7 @@ def check_cutoffs(cutoffs: VALID_CUTOFF_TYPES) -> np.ndarray:
     return np.sort(cutoffs)
 
 
-def check_scoring(scoring, allow_y_pred_benchmark=False):
+def check_scoring(scoring):
     """
     Validate the performance scoring.
 

--- a/aeon/utils/validation/forecasting.py
+++ b/aeon/utils/validation/forecasting.py
@@ -9,7 +9,6 @@ __all__ = [
     "check_step_length",
     "check_alpha",
     "check_cutoffs",
-    "check_scoring",
     "check_sp",
     "check_regressor",
 ]
@@ -20,6 +19,7 @@ from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
+from deprecated.sphinx import deprecated
 from pandas.api.types import is_numeric_dtype
 from sklearn.base import clone, is_regressor
 from sklearn.ensemble import GradientBoostingRegressor
@@ -394,6 +394,12 @@ def check_cutoffs(cutoffs: VALID_CUTOFF_TYPES) -> np.ndarray:
     return np.sort(cutoffs)
 
 
+# TODO: remove in v0.10.0
+@deprecated(
+    version="0.9.0",
+    reason=("check_scoring is being removed from aeon in v0.10.0."),
+    category=FutureWarning,
+)
 def check_scoring(scoring):
     """
     Validate the performance scoring.


### PR DESCRIPTION
deprecates the function check_scorer. This function is used in some places to set a scoring function through a call to check_scorer(None). This is confusing, and it is much clearer imo to set the scorer explicitly. This PR does that and tags the function for deprecation. 