### PR TITLE
[BUG] Fix RDST doctest failure & numba deprecration warning

### DIFF
--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -4,7 +4,7 @@ A Random Dilated Shapelet Transform classifier pipeline that simply performs a r
 shapelet dilated transform and build (by default) a ridge classifier on the output.
 """
 
-__maintainer__ = []
+__maintainer__ = ["baraline"]
 __all__ = ["RDSTClassifier"]
 
 import numpy as np

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -4,7 +4,7 @@ A modification of the classic Shapelet Transform which add a dilation parameter 
 Shapelets.
 """
 
-__maintainer__ = []
+__maintainer__ = ["baraline"]
 __all__ = ["RandomDilatedShapeletTransform"]
 
 import warnings

--- a/aeon/transformations/collection/shapelet_based/tests/test_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/tests/test_dilated_shapelet_transform.py
@@ -1,6 +1,6 @@
 """Tests for dilated shapelet transform functions."""
 
-__maintainer__ = []
+__maintainer__ = ["baraline"]
 
 import numpy as np
 import pytest


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1444 

#### What does this implement/fix? Explain your changes.

Fix sporadic doctest failure. At the end of shapelet extraction, a check is performed to remove shapelets which values were full of 0. This should happen if a shapelet is pruned during the extraction process, the value of 0 is due to the initialization of the array of shapelet values as full of 0 (`np.zeros`). But as the covid dataset has long successive 0 values, it was possible that they were all pruned with bad luck, causing the failure.

The test is now based on `np.inf` value, and the array initialized as full of `np.inf` to avoid any problem related to input values.