### PR TITLE
[BUG] Fix MultiRocketMultivariate failures

### DIFF
--- a/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
@@ -112,6 +112,9 @@ class MultiRocketMultivariate(BaseCollectionTransformer):
         -------
         self
         """
+        if self.random_state is not None:
+            np.random.seed(self.random_state)
+
         if self.normalise:
             X = (X - X.mean(axis=-1, keepdims=True)) / (
                 X.std(axis=-1, keepdims=True) + 1e-8


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1278

#### What does this implement/fix? Explain your changes.

Random state was not set in outside of numba function, which, as both need to be set (see [docs](https://numba.readthedocs.io/en/stable/reference/numpysupported.html#initialization)). This caused difference in accuracy during some tests.

#### Any other comments?

Using the new numpy random generator would bump numba version to `0.56` from `0.55`, so I stick with the old numpy random seed.