### PR TITLE
[BUG] Set dynamic tag after `__init__` for classifiers and regressors.

### DIFF
--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -132,7 +132,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
             n_jobs=n_jobs,
         )
 
-        self.set_tags(**{"python_dependencies": d})
+        self.set_tags(**{"python_dependencies": d if len(d) > 1 else d[0]})
 
     _tags = {
         "capability:multivariate": True,

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -121,8 +121,6 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         if use_pyfftw:
             d.append("pyfftw")
 
-        self.set_tags(**{"python_dependencies": d})
-
         super().__init__(
             n_intervals=n_intervals,
             n_shapelets=n_shapelets,
@@ -133,6 +131,8 @@ class RISTClassifier(BaseRIST, BaseClassifier):
             random_state=random_state,
             n_jobs=n_jobs,
         )
+
+        self.set_tags(**{"python_dependencies": d})
 
     _tags = {
         "capability:multivariate": True,

--- a/aeon/classification/interval_based/_cif.py
+++ b/aeon/classification/interval_based/_cif.py
@@ -183,8 +183,6 @@ class CanonicalIntervalForestClassifier(BaseIntervalForest, BaseClassifier):
         parallel_backend=None,
     ):
         self.use_pycatch22 = use_pycatch22
-        if use_pycatch22:
-            self.set_tags(**{"python_dependencies": "pycatch22"})
 
         if isinstance(base_estimator, ContinuousIntervalTree):
             replace_nan = "nan"
@@ -215,6 +213,9 @@ class CanonicalIntervalForestClassifier(BaseIntervalForest, BaseClassifier):
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if use_pycatch22:
+            self.set_tags(**{"python_dependencies": "pycatch22"})
 
     def _fit(self, X, y):
         return super()._fit(X, y)

--- a/aeon/classification/interval_based/_drcif.py
+++ b/aeon/classification/interval_based/_drcif.py
@@ -208,9 +208,6 @@ class DrCIFClassifier(BaseIntervalForest, BaseClassifier):
         if use_pyfftw:
             d.append("pyfftw")
 
-        if d:
-            self.set_tags(**{"python_dependencies": d})
-
         if isinstance(base_estimator, ContinuousIntervalTree):
             replace_nan = "nan"
         else:
@@ -250,6 +247,9 @@ class DrCIFClassifier(BaseIntervalForest, BaseClassifier):
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if d:
+            self.set_tags(**{"python_dependencies": d})
 
     def _fit(self, X, y):
         return super()._fit(X, y)

--- a/aeon/classification/interval_based/_rise.py
+++ b/aeon/classification/interval_based/_rise.py
@@ -152,10 +152,7 @@ class RandomIntervalSpectralEnsembleClassifier(BaseIntervalForest, BaseClassifie
     ):
         self.acf_lag = acf_lag
         self.acf_min_values = acf_min_values
-
         self.use_pyfftw = use_pyfftw
-        if use_pyfftw:
-            self.set_tags(**{"python_dependencies": "pyfftw"})
 
         if isinstance(base_estimator, ContinuousIntervalTree):
             replace_nan = "nan"
@@ -186,6 +183,9 @@ class RandomIntervalSpectralEnsembleClassifier(BaseIntervalForest, BaseClassifie
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if use_pyfftw:
+            self.set_tags(**{"python_dependencies": "pyfftw"})
 
     def _fit(self, X, y):
         return super()._fit(X, y)

--- a/aeon/classification/interval_based/_rstsf.py
+++ b/aeon/classification/interval_based/_rstsf.py
@@ -95,10 +95,10 @@ class RSTSF(BaseClassifier):
         self.random_state = random_state
         self.n_jobs = n_jobs
 
+        super().__init__()
+
         if use_pyfftw:
             self.set_tags(**{"python_dependencies": ["statsmodels", "pyfftw"]})
-
-        super().__init__()
 
     def _fit(self, X, y):
         self.n_cases_, self.n_channels_, self.n_timepoints_ = X.shape

--- a/aeon/classification/interval_based/_stsf.py
+++ b/aeon/classification/interval_based/_stsf.py
@@ -141,8 +141,6 @@ class SupervisedTimeSeriesForest(BaseIntervalForest, BaseClassifier):
         parallel_backend=None,
     ):
         self.use_pyfftw = use_pyfftw
-        if use_pyfftw:
-            self.set_tags(**{"python_dependencies": "pyfftw"})
 
         series_transformers = [
             None,
@@ -177,6 +175,9 @@ class SupervisedTimeSeriesForest(BaseIntervalForest, BaseClassifier):
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if use_pyfftw:
+            self.set_tags(**{"python_dependencies": "pyfftw"})
 
     def _fit(self, X, y):
         return super()._fit(X, y)

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -124,7 +124,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
             n_jobs=n_jobs,
         )
 
-        self.set_tags(**{"python_dependencies": d})
+        self.set_tags(**{"python_dependencies": d if len(d) > 1 else d[0]})
 
     _tags = {
         "capability:multivariate": True,

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -113,8 +113,6 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         if use_pyfftw:
             d.append("pyfftw")
 
-        self.set_tags(**{"python_dependencies": d})
-
         super().__init__(
             n_intervals=n_intervals,
             n_shapelets=n_shapelets,
@@ -125,6 +123,8 @@ class RISTRegressor(BaseRIST, BaseRegressor):
             random_state=random_state,
             n_jobs=n_jobs,
         )
+
+        self.set_tags(**{"python_dependencies": d})
 
     _tags = {
         "capability:multivariate": True,

--- a/aeon/regression/interval_based/_cif.py
+++ b/aeon/regression/interval_based/_cif.py
@@ -164,8 +164,6 @@ class CanonicalIntervalForestRegressor(BaseIntervalForest, BaseRegressor):
         parallel_backend=None,
     ):
         self.use_pycatch22 = use_pycatch22
-        if use_pycatch22:
-            self.set_tags(**{"python_dependencies": "pycatch22"})
 
         interval_features = [
             Catch22(outlier_norm=True, use_pycatch22=use_pycatch22),
@@ -191,6 +189,9 @@ class CanonicalIntervalForestRegressor(BaseIntervalForest, BaseRegressor):
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if use_pycatch22:
+            self.set_tags(**{"python_dependencies": "pycatch22"})
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/aeon/regression/interval_based/_drcif.py
+++ b/aeon/regression/interval_based/_drcif.py
@@ -188,9 +188,6 @@ class DrCIFRegressor(BaseIntervalForest, BaseRegressor):
         if use_pyfftw:
             d.append("pyfftw")
 
-        if d:
-            self.set_tags(**{"python_dependencies": d})
-
         series_transformers = [
             None,
             FunctionTransformer(func=first_order_differences_3d, validate=False),
@@ -225,6 +222,9 @@ class DrCIFRegressor(BaseIntervalForest, BaseRegressor):
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if d:
+            self.set_tags(**{"python_dependencies": d})
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/aeon/regression/interval_based/_rise.py
+++ b/aeon/regression/interval_based/_rise.py
@@ -140,10 +140,7 @@ class RandomIntervalSpectralEnsembleRegressor(BaseIntervalForest, BaseRegressor)
     ):
         self.acf_lag = acf_lag
         self.acf_min_values = acf_min_values
-
         self.use_pyfftw = use_pyfftw
-        if use_pyfftw:
-            self.set_tags(**{"python_dependencies": "pyfftw"})
 
         interval_features = [
             PeriodogramTransformer(use_pyfftw=use_pyfftw, pad_with="mean"),
@@ -168,6 +165,9 @@ class RandomIntervalSpectralEnsembleRegressor(BaseIntervalForest, BaseRegressor)
             n_jobs=n_jobs,
             parallel_backend=parallel_backend,
         )
+
+        if use_pyfftw:
+            self.set_tags(**{"python_dependencies": "pyfftw"})
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):


### PR DESCRIPTION
Bug fix for certain estimators based on the current failing coverage tests. Didn't look into why for now, but setting tags dynamically prior to `__init__` will reset them.