### PR TITLE
[DOC] Change about text, add a link from docs to repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,14 @@ hide-toc: true
 <h1 style="text-align: center;">Welcome to <b>aeon</b></h1>
 
 `aeon` is a scikit-learn compatible toolkit for time series tasks such as
-forecasting, classification and clustering.</p>
+forecasting, classification, regression, clustering and anomaly detection.</p>
 
 - Provides a broad library of time series algorithms, including the latest advances.
 - Efficient implementation of time series algorithms using numba.
 - Interfaces with other time series packages to provide a single framework for algorithm
 comparison.
+
+Please visit our [GitHub repository](https://github.com/aeon-toolkit/aeon).
 
 ::::{grid} 1 2 2 2
 :gutter: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "aeon"
 version = "0.8.1"
-description = "A toolkit for time series machine learning"
+description = "A toolkit for machine learning from time series"
 authors = [
     {name = "aeon developers", email = "contact@aeon-toolkit.org"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "aeon"
 version = "0.8.1"
-description = "A toolkit for conducting machine learning tasks with time series data"
+description = "A toolkit for time series machine learning"
 authors = [
     {name = "aeon developers", email = "contact@aeon-toolkit.org"},
 ]


### PR DESCRIPTION
1. Changes about text from  "A toolkit for conducting machine learning tasks with time series data" to "A toolkit for machine learning from time series". The current text does not scan, "conducting machine learning tasks" doesnt seem to make sense to me
2. Added an explicit link to github from the top of aeon-toolkit.com. 