### PR TITLE
[ENH] Type hints for primitives and string arguments:Part2

### DIFF
--- a/aeon/classification/distance_based/_elastic_ensemble.py
+++ b/aeon/classification/distance_based/_elastic_ensemble.py
@@ -9,6 +9,7 @@ __all__ = ["ElasticEnsemble"]
 import math
 import time
 from itertools import product
+from typing import List, Union
 
 import numpy as np
 from sklearn.metrics import accuracy_score
@@ -99,15 +100,15 @@ class ElasticEnsemble(BaseClassifier):
 
     def __init__(
         self,
-        distance_measures="all",
-        proportion_of_param_options=1.0,
-        proportion_train_in_param_finding=1.0,
-        proportion_train_for_test=1.0,
-        n_jobs=1,
-        random_state=0,
-        verbose=0,
-        majority_vote=False,
-    ):
+        distance_measures: Union[str, List[str]] = "all",
+        proportion_of_param_options: float = 1.0,
+        proportion_train_in_param_finding: float = 1.0,
+        proportion_train_for_test: float = 1.0,
+        n_jobs: int = 1,
+        random_state: int = 0,
+        verbose: int = 0,
+        majority_vote: bool = False,
+    ) -> None:
         self.distance_measures = distance_measures
         self.proportion_train_in_param_finding = proportion_train_in_param_finding
         self.proportion_of_param_options = proportion_of_param_options
@@ -396,7 +397,7 @@ class ElasticEnsemble(BaseClassifier):
         preds = np.asarray([self.classes_[x] for x in idx])
         return preds
 
-    def get_metric_params(self):
+    def get_metric_params(self) -> dict:
         """Return the parameters for the distance metrics used."""
         return {
             self._distance_measures[dm]: str(self.estimators_[dm]._distance_params)
@@ -404,8 +405,8 @@ class ElasticEnsemble(BaseClassifier):
         }
 
     @staticmethod
-    def _get_100_param_options(distance_measure, train_x=None):
-        def get_inclusive(min_val, max_val, num_vals):
+    def _get_100_param_options(distance_measure: str, train_x=None):
+        def get_inclusive(min_val: float, max_val: float, num_vals: float):
             inc = (max_val - min_val) / (num_vals - 1)
             return np.arange(min_val, max_val + inc / 2, inc)
 
@@ -472,7 +473,7 @@ class ElasticEnsemble(BaseClassifier):
             )
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -8,7 +8,7 @@ distances in aeon.distances.
 __maintainer__ = []
 __all__ = ["KNeighborsTimeSeriesClassifier"]
 
-from typing import List
+from typing import Callable, List, Union
 
 import numpy as np
 
@@ -71,10 +71,10 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
     def __init__(
         self,
-        distance: str = "dtw",
+        distance: Union[str, Callable] = "dtw",
         distance_params: dict = None,
         n_neighbors: int = 1,
-        weights: str = "uniform",
+        weights: Union[str, Callable] = "uniform",
         n_jobs: int = 1,
     ) -> None:
         self.distance = distance
@@ -216,7 +216,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         return closest_idx, ws
 
     @classmethod
-    def get_test_params(cls, parameter_set: str = "default") -> List[dict]:
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -9,6 +9,7 @@ __all__ = ["RotationForestClassifier"]
 
 import time
 import warnings
+from typing import Type, Union
 
 import numpy as np
 import pandas as pd
@@ -102,16 +103,16 @@ class RotationForestClassifier(BaseEstimator):
 
     def __init__(
         self,
-        n_estimators=200,
-        min_group=3,
-        max_group=3,
-        remove_proportion=0.5,
-        base_estimator=None,
-        time_limit_in_minutes=0.0,
-        contract_max_n_estimators=500,
-        save_transformed_data="deprecated",
-        n_jobs=1,
-        random_state=None,
+        n_estimators: int = 200,
+        min_group: int = 3,
+        max_group: int = 3,
+        remove_proportion: float = 0.5,
+        base_estimator: Union[Type[BaseEstimator], None] = None,
+        time_limit_in_minutes: int = 0.0,
+        contract_max_n_estimators: int = 500,
+        save_transformed_data: bool = "deprecated",
+        n_jobs: int = 1,
+        random_state: Union[int, Type[np.random.RandomState], None] = None,
     ):
         self.n_estimators = n_estimators
         self.min_group = min_group
@@ -315,7 +316,7 @@ class RotationForestClassifier(BaseEstimator):
 
         return results
 
-    def _fit_rotf(self, X, y, save_transformed_data=False):
+    def _fit_rotf(self, X, y, save_transformed_data: bool = False):
         if isinstance(X, np.ndarray) and len(X.shape) == 3 and X.shape[1] == 1:
             X = np.reshape(X, (X.shape[0], -1))
         elif isinstance(X, pd.DataFrame) and len(X.shape) == 2:
@@ -414,7 +415,14 @@ class RotationForestClassifier(BaseEstimator):
         self._is_fitted = True
         return X_t
 
-    def _fit_estimator(self, X, X_cls_split, y, rng, save_transformed_data):
+    def _fit_estimator(
+        self,
+        X,
+        X_cls_split,
+        y,
+        rng: Type[np.random.RandomState],
+        save_transformed_data: bool,
+    ):
         groups = self._generate_groups(rng)
         pcas = []
 
@@ -471,7 +479,7 @@ class RotationForestClassifier(BaseEstimator):
 
         return tree, pcas, groups, X_t if save_transformed_data else None
 
-    def _predict_proba_for_estimator(self, X, clf, pcas, groups):
+    def _predict_proba_for_estimator(self, X, clf: int, pcas: Type[PCA], groups):
         X_t = np.concatenate(
             [pcas[i].transform(X[:, group]) for i, group in enumerate(groups)], axis=1
         )
@@ -491,7 +499,9 @@ class RotationForestClassifier(BaseEstimator):
 
         return probas
 
-    def _train_probas_for_estimator(self, X_t, y, idx, rng):
+    def _train_probas_for_estimator(
+        self, X_t, y, idx, rng: Type[np.random.RandomState]
+    ):
         indices = range(self.n_cases_)
         subsample = rng.choice(self.n_cases_, size=self.n_cases_)
         oob = [n for n in indices if n not in subsample]
@@ -516,7 +526,7 @@ class RotationForestClassifier(BaseEstimator):
 
         return [results, oob]
 
-    def _generate_groups(self, rng):
+    def _generate_groups(self, rng: Type[np.random.RandomState]):
         permutation = rng.permutation(np.arange(0, self._n_atts))
 
         # select the size of each group.


### PR DESCRIPTION
Reference Issues/PRs
Part of https://github.com/aeon-toolkit/aeon/issues/1454

What does this implement/fix? Explain your changes.
Adding type hints to remaining scripts in :  aeon.classification.distance_based module, and improvements based on earlier feedback. 
Added type hints to "aeon/classification/sklearn/_rotation_forest_classifier.py"

Does your contribution introduce a new dependency? If yes, which one?
None

Any other comments?
Type hints are NOT added in other methods since they were not primitive types.