### PR TITLE
[ENH] Type hints for primitives and string arguments:Part3

### DIFF
--- a/aeon/classification/shapelet_based/_ls.py
+++ b/aeon/classification/shapelet_based/_ls.py
@@ -6,6 +6,7 @@ Learning shapelet classifier that simply wraps the LearningShapelet class from t
 __maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["LearningShapeletClassifier"]
 
+from typing import Union
 
 import numpy as np
 
@@ -97,18 +98,18 @@ class LearningShapeletClassifier(BaseClassifier):
 
     def __init__(
         self,
-        n_shapelets_per_size=None,
-        max_iter=10000,
-        batch_size=256,
-        verbose=0,
-        optimizer="sgd",
-        weight_regularizer=0.0,
-        shapelet_length=0.15,
-        total_lengths=3,
-        max_size=None,
-        scale=False,
-        random_state=None,
-    ):
+        n_shapelets_per_size: Union[dict, None] = None,
+        max_iter: int = 10000,
+        batch_size: int = 256,
+        verbose: int = 0,
+        optimizer: str = "sgd",
+        weight_regularizer: Union[float, None] = 0.0,
+        shapelet_length: float = 0.15,
+        total_lengths: int = 3,
+        max_size: Union[int, None] = None,
+        scale: bool = False,
+        random_state: Union[int, None] = None,
+    ) -> None:
         self.n_shapelets_per_size = n_shapelets_per_size
         self.max_iter = max_iter
         self.batch_size = batch_size
@@ -184,7 +185,7 @@ class LearningShapeletClassifier(BaseClassifier):
     #     return self.clf_.locate(_X_transformed)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_ls.py
+++ b/aeon/classification/shapelet_based/_ls.py
@@ -6,7 +6,7 @@ Learning shapelet classifier that simply wraps the LearningShapelet class from t
 __maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["LearningShapeletClassifier"]
 
-from typing import Union
+from typing import List, Union
 
 import numpy as np
 
@@ -185,7 +185,7 @@ class LearningShapeletClassifier(BaseClassifier):
     #     return self.clf_.locate(_X_transformed)
 
     @classmethod
-    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_mrsqm.py
+++ b/aeon/classification/shapelet_based/_mrsqm.py
@@ -3,7 +3,7 @@
 __maintainer__ = []
 __all__ = ["MrSQMClassifier"]
 
-from typing import Union
+from typing import List, Union
 
 import numpy as np
 
@@ -126,7 +126,7 @@ class MrSQMClassifier(BaseClassifier):
         return self.clf_.predict_proba(X)
 
     @classmethod
-    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_mrsqm.py
+++ b/aeon/classification/shapelet_based/_mrsqm.py
@@ -3,6 +3,8 @@
 __maintainer__ = []
 __all__ = ["MrSQMClassifier"]
 
+from typing import Union
+
 import numpy as np
 
 from aeon.classification import BaseClassifier
@@ -73,15 +75,15 @@ class MrSQMClassifier(BaseClassifier):
 
     def __init__(
         self,
-        strat="RS",
-        features_per_rep=500,
-        selection_per_rep=2000,
-        nsax=0,
-        nsfa=5,
-        sfa_norm=True,
-        custom_config=None,
-        random_state=None,
-    ):
+        strat: str = "RS",
+        features_per_rep: int = 500,
+        selection_per_rep: int = 2000,
+        nsax: int = 0,
+        nsfa: int = 5,
+        sfa_norm: bool = True,
+        custom_config: Union[dict, None] = None,
+        random_state: Union[int, None] = None,
+    ) -> None:
         self.strat = strat
         self.features_per_rep = features_per_rep
         self.selection_per_rep = selection_per_rep
@@ -124,7 +126,7 @@ class MrSQMClassifier(BaseClassifier):
         return self.clf_.predict_proba(X)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -7,7 +7,7 @@ shapelet dilated transform and build (by default) a ridge classifier on the outp
 __maintainer__ = ["baraline"]
 __all__ = ["RDSTClassifier"]
 
-from typing import Union
+from typing import List, Union
 
 import numpy as np
 from sklearn.linear_model import RidgeClassifierCV
@@ -250,7 +250,7 @@ class RDSTClassifier(BaseClassifier):
             return dists
 
     @classmethod
-    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -7,7 +7,7 @@ shapelet dilated transform and build (by default) a ridge classifier on the outp
 __maintainer__ = ["baraline"]
 __all__ = ["RDSTClassifier"]
 
-from typing import List, Union
+from typing import List, Type, Union
 
 import numpy as np
 from sklearn.linear_model import RidgeClassifierCV
@@ -135,7 +135,7 @@ class RDSTClassifier(BaseClassifier):
         estimator=None,
         save_transformed_data: bool = False,
         n_jobs: int = 1,
-        random_state: Union[int, np.random.RandomState, None] = None,
+        random_state: Union[int, Type[np.random.RandomState], None] = None,
     ) -> None:
         self.max_shapelets = max_shapelets
         self.shapelet_lengths = shapelet_lengths

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -7,6 +7,8 @@ shapelet dilated transform and build (by default) a ridge classifier on the outp
 __maintainer__ = ["baraline"]
 __all__ = ["RDSTClassifier"]
 
+from typing import Union
+
 import numpy as np
 from sklearn.linear_model import RidgeClassifierCV
 from sklearn.pipeline import make_pipeline
@@ -124,17 +126,17 @@ class RDSTClassifier(BaseClassifier):
 
     def __init__(
         self,
-        max_shapelets=10000,
+        max_shapelets: int = 10000,
         shapelet_lengths=None,
-        proba_normalization=0.8,
+        proba_normalization: float = 0.8,
         threshold_percentiles=None,
-        alpha_similarity=0.5,
-        use_prime_dilations=False,
+        alpha_similarity: float = 0.5,
+        use_prime_dilations: bool = False,
         estimator=None,
-        save_transformed_data=False,
-        n_jobs=1,
-        random_state=None,
-    ):
+        save_transformed_data: bool = False,
+        n_jobs: int = 1,
+        random_state: Union[int, np.random.RandomState, None] = None,
+    ) -> None:
         self.max_shapelets = max_shapelets
         self.shapelet_lengths = shapelet_lengths
         self.proba_normalization = proba_normalization
@@ -248,7 +250,7 @@ class RDSTClassifier(BaseClassifier):
             return dists
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_sast_classifier.py
+++ b/aeon/classification/shapelet_based/_sast_classifier.py
@@ -67,12 +67,12 @@ class SASTClassifier(BaseClassifier):
     def __init__(
         self,
         length_list=None,
-        stride=1,
-        nb_inst_per_class=1,
-        seed=None,
+        stride: int = 1,
+        nb_inst_per_class: int = 1,
+        seed: int = None,
         classifier=None,
-        n_jobs=-1,
-    ):
+        n_jobs: int = -1,
+    ) -> None:
         super().__init__()
         self.length_list = length_list
         self.stride = stride
@@ -159,7 +159,7 @@ class SASTClassifier(BaseClassifier):
                 dists[i, np.where(self.classes_ == preds[i])] = 1
         return dists
 
-    def plot_most_important_feature_on_ts(self, ts, feature_importance, limit=5):
+    def plot_most_important_feature_on_ts(self, ts, feature_importance, limit: int = 5):
         """Plot the most important features on ts.
 
         Parameters

--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -7,7 +7,7 @@ transform then builds (by default) a rotation forest classifier on the output.
 __maintainer__ = []
 __all__ = ["ShapeletTransformClassifier"]
 
-from typing import List, Union
+from typing import List, Type, Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
@@ -142,7 +142,7 @@ class ShapeletTransformClassifier(BaseClassifier):
         contract_max_n_shapelet_samples: int = np.inf,
         n_jobs: int = 1,
         batch_size: Union[int, None] = 100,
-        random_state: Union[int, np.random.RandomState, None] = None,
+        random_state: Union[int, Type[np.random.RandomState], None] = None,
     ) -> None:
         self.n_shapelet_samples = n_shapelet_samples
         self.max_shapelets = max_shapelets

--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -7,6 +7,7 @@ transform then builds (by default) a rotation forest classifier on the output.
 __maintainer__ = []
 __all__ = ["ShapeletTransformClassifier"]
 
+from typing import Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
@@ -132,17 +133,17 @@ class ShapeletTransformClassifier(BaseClassifier):
 
     def __init__(
         self,
-        n_shapelet_samples=10000,
-        max_shapelets=None,
-        max_shapelet_length=None,
+        n_shapelet_samples: int = 10000,
+        max_shapelets: Union[int, None] = None,
+        max_shapelet_length: Union[int, None] = None,
         estimator=None,
-        transform_limit_in_minutes=0,
-        time_limit_in_minutes=0,
-        contract_max_n_shapelet_samples=np.inf,
-        n_jobs=1,
-        batch_size=100,
-        random_state=None,
-    ):
+        transform_limit_in_minutes: int = 0,
+        time_limit_in_minutes: int = 0,
+        contract_max_n_shapelet_samples: int = np.inf,
+        n_jobs: int = 1,
+        batch_size: Union[int, None] = 100,
+        random_state: Union[int, np.random.RandomState, None] = None,
+    ) -> None:
         self.n_shapelet_samples = n_shapelet_samples
         self.max_shapelets = max_shapelets
         self.max_shapelet_length = max_shapelet_length
@@ -317,7 +318,7 @@ class ShapeletTransformClassifier(BaseClassifier):
         return self._transformer.fit_transform(X, y)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -7,7 +7,7 @@ transform then builds (by default) a rotation forest classifier on the output.
 __maintainer__ = []
 __all__ = ["ShapeletTransformClassifier"]
 
-from typing import Union
+from typing import List, Union
 
 import numpy as np
 from sklearn.model_selection import cross_val_predict
@@ -318,7 +318,7 @@ class ShapeletTransformClassifier(BaseClassifier):
         return self._transformer.fit_transform(X, y)
 
     @classmethod
-    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, list[dict]]:
+    def get_test_params(cls, parameter_set: str = "default") -> Union[dict, List[dict]]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/sklearn/_continuous_interval_tree.py
+++ b/aeon/classification/sklearn/_continuous_interval_tree.py
@@ -10,6 +10,7 @@ __all__ = ["ContinuousIntervalTree"]
 
 import math
 import sys
+from typing import List, Tuple, Type, Union
 
 import numpy as np
 from numba import njit
@@ -18,6 +19,259 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import check_random_state
 
 from aeon.exceptions import NotFittedError
+
+
+class _TreeNode:
+    """ContinuousIntervalTree tree node."""
+
+    def __init__(
+        self, random_state: Union[int, Type[np.random.RandomState], None] = None
+    ) -> None:
+        self.random_state = random_state
+
+        self.best_split = -1
+        self.best_threshold = 0
+        self.best_gain = 0.000001
+        self.best_margin = -1
+        self.children = []
+        self.leaf_distribution = []
+        self.depth = -1
+
+    def build_tree(
+        self,
+        X,
+        y,
+        thresholds: int,
+        entropy: float,
+        distribution,
+        depth: int,
+        max_depth: int,
+        n_classes: int,
+        leaf: bool,
+    ):
+        self.depth = depth
+        best_distributions = []
+        best_entropies = []
+
+        if leaf is False and self.remaining_classes(distribution) and depth < max_depth:
+            for (_, att), threshold in np.ndenumerate(thresholds):
+                (
+                    info_gain,
+                    distributions,
+                    entropies,
+                ) = self.information_gain(X, y, att, threshold, entropy, n_classes)
+
+                if info_gain > self.best_gain:
+                    self.best_split = att
+                    self.best_threshold = threshold
+                    self.best_gain = info_gain
+                    self.best_margin = -1
+                    best_distributions = distributions
+                    best_entropies = entropies
+                elif info_gain == self.best_gain and info_gain > 0.000001:
+                    margin = self.margin_gain(X, att, threshold)
+                    if self.best_margin == -1:
+                        self.best_margin = self.margin_gain(
+                            X, self.best_split, self.best_threshold
+                        )
+
+                    if margin > self.best_margin or (
+                        margin == self.best_margin
+                        and self.random_state.choice([True, False])
+                    ):
+                        self.best_split = att
+                        self.best_threshold = threshold
+                        self.best_margin = margin
+                        best_distributions = distributions
+                        best_entropies = entropies
+
+        if self.best_split > -1:
+            self.children = [None, None, None]
+
+            left_idx, right_idx, missing_idx = self.split_data(
+                X, self.best_split, self.best_threshold
+            )
+
+            if len(left_idx) > 0:
+                self.children[0] = _TreeNode(random_state=self.random_state)
+                self.children[0].build_tree(
+                    X[left_idx],
+                    y[left_idx],
+                    thresholds,
+                    best_entropies[0],
+                    best_distributions[0],
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    False,
+                )
+            else:
+                self.children[0] = _TreeNode(random_state=self.random_state)
+                self.children[0].build_tree(
+                    X,
+                    y,
+                    thresholds,
+                    entropy,
+                    distribution,
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    True,
+                )
+
+            if len(right_idx) > 0:
+                self.children[1] = _TreeNode(random_state=self.random_state)
+                self.children[1].build_tree(
+                    X[right_idx],
+                    y[right_idx],
+                    thresholds,
+                    best_entropies[1],
+                    best_distributions[1],
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    False,
+                )
+            else:
+                self.children[1] = _TreeNode(random_state=self.random_state)
+                self.children[1].build_tree(
+                    X,
+                    y,
+                    thresholds,
+                    entropy,
+                    distribution,
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    True,
+                )
+
+            if len(missing_idx) > 0:
+                self.children[2] = _TreeNode(random_state=self.random_state)
+                self.children[2].build_tree(
+                    X[missing_idx],
+                    y[missing_idx],
+                    thresholds,
+                    best_entropies[2],
+                    best_distributions[2],
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    False,
+                )
+            else:
+                self.children[2] = _TreeNode(random_state=self.random_state)
+                self.children[2].build_tree(
+                    X,
+                    y,
+                    thresholds,
+                    entropy,
+                    distribution,
+                    depth + 1,
+                    max_depth,
+                    n_classes,
+                    True,
+                )
+        else:
+            self.leaf_distribution = distribution / np.sum(distribution)
+
+        return self
+
+    def predict_proba(self, X, n_classes: int):
+        if self.best_split > -1:
+            if X[self.best_split] <= self.best_threshold:
+                return self.children[0].predict_proba(X, n_classes)
+            elif X[self.best_split] > self.best_threshold:
+                return self.children[1].predict_proba(X, n_classes)
+            else:
+                return self.children[2].predict_proba(X, n_classes)
+        else:
+            return self.leaf_distribution
+
+    @staticmethod
+    @njit(fastmath=True, cache=True)
+    def information_gain(
+        X, y, attribute: int, threshold: int, parent_entropy: float, n_classes: int
+    ):
+        dist_left = np.zeros(n_classes)
+        dist_right = np.zeros(n_classes)
+        dist_missing = np.zeros(n_classes)
+        for i, case in enumerate(X):
+            if case[attribute] <= threshold:
+                dist_left[y[i]] += 1
+            elif case[attribute] > threshold:
+                dist_right[y[i]] += 1
+            else:
+                dist_missing[y[i]] += 1
+
+        sum_missing = 0
+        for v in dist_missing:
+            sum_missing += v
+        sum_left = 0
+        for v in dist_left:
+            sum_left += v
+        sum_right = 0
+        for v in dist_right:
+            sum_right += v
+
+        entropy_left = _entropy(dist_left, sum_left)
+        entropy_right = _entropy(dist_right, sum_right)
+        entropy_missing = _entropy(dist_missing, sum_missing)
+
+        n_cases = X.shape[0]
+        info_gain = (
+            parent_entropy
+            - sum_left / n_cases * entropy_left
+            - sum_right / n_cases * entropy_right
+            - sum_missing / n_cases * entropy_missing
+        )
+
+        return (
+            info_gain,
+            [dist_left, dist_right, dist_missing],
+            [entropy_left, entropy_right, entropy_missing],
+        )
+
+    @staticmethod
+    @njit(fastmath=True, cache=True)
+    def margin_gain(X, attribute: int, threshold: int):
+        margins = np.abs(X[:, attribute] - threshold)
+        return np.min(margins)
+
+    @staticmethod
+    @njit(fastmath=True, cache=True)
+    def split_data(X, best_split: int, best_threshold: int):
+        left_idx = np.zeros(len(X), dtype=np.int_)
+        left_count = 0
+        right_idx = np.zeros(len(X), dtype=np.int_)
+        right_count = 0
+        missing_idx = np.zeros(len(X), dtype=np.int_)
+        missing_count = 0
+        for i, case in enumerate(X):
+            if case[best_split] <= best_threshold:
+                left_idx[left_count] = i
+                left_count += 1
+            elif case[best_split] > best_threshold:
+                right_idx[right_count] = i
+                right_count += 1
+            else:
+                missing_idx[missing_count] = i
+                missing_count += 1
+
+        return (
+            left_idx[:left_count],
+            right_idx[:right_count],
+            missing_idx[:missing_count],
+        )
+
+    @staticmethod
+    @njit(fastmath=True, cache=True)
+    def remaining_classes(distribution) -> bool:
+        remaining_classes = 0
+        for d in distribution:
+            if d > 0:
+                remaining_classes += 1
+        return remaining_classes > 1
 
 
 class ContinuousIntervalTree(BaseEstimator):
@@ -83,10 +337,10 @@ class ContinuousIntervalTree(BaseEstimator):
 
     def __init__(
         self,
-        max_depth=sys.maxsize,
-        thresholds=20,
-        random_state=None,
-    ):
+        max_depth: int = sys.maxsize,
+        thresholds: int = 20,
+        random_state: Union[int, Type[np.random.RandomState], None] = None,
+    ) -> None:
         self.max_depth = max_depth
         self.thresholds = thresholds
         self.random_state = random_state
@@ -228,7 +482,7 @@ class ContinuousIntervalTree(BaseEstimator):
             dists[i] = self._root.predict_proba(X[i], self.n_classes_)
         return dists
 
-    def tree_node_splits_and_gain(self):
+    def tree_node_splits_and_gain(self) -> Tuple[List[int], List[float]]:
         """Recursively find the split and information gain for each tree node."""
         splits = []
         gains = []
@@ -238,7 +492,7 @@ class ContinuousIntervalTree(BaseEstimator):
 
         return splits, gains
 
-    def _find_splits_gain(self, node, splits, gains):
+    def _find_splits_gain(self, node: Type[_TreeNode], splits: list, gains: list):
         """Recursively find the split and information gain for each tree node."""
         splits.append(node.best_split)
         gains.append(node.best_gain)
@@ -248,260 +502,8 @@ class ContinuousIntervalTree(BaseEstimator):
                 self._find_splits_gain(next_node, splits, gains)
 
 
-class _TreeNode:
-    """ContinuousIntervalTree tree node."""
-
-    def __init__(
-        self,
-        random_state=None,
-    ):
-        self.random_state = random_state
-
-        self.best_split = -1
-        self.best_threshold = 0
-        self.best_gain = 0.000001
-        self.best_margin = -1
-        self.children = []
-        self.leaf_distribution = []
-        self.depth = -1
-
-    def build_tree(
-        self,
-        X,
-        y,
-        thresholds,
-        entropy,
-        distribution,
-        depth,
-        max_depth,
-        n_classes,
-        leaf,
-    ):
-        self.depth = depth
-        best_distributions = []
-        best_entropies = []
-
-        if leaf is False and self.remaining_classes(distribution) and depth < max_depth:
-            for (_, att), threshold in np.ndenumerate(thresholds):
-                (
-                    info_gain,
-                    distributions,
-                    entropies,
-                ) = self.information_gain(X, y, att, threshold, entropy, n_classes)
-
-                if info_gain > self.best_gain:
-                    self.best_split = att
-                    self.best_threshold = threshold
-                    self.best_gain = info_gain
-                    self.best_margin = -1
-                    best_distributions = distributions
-                    best_entropies = entropies
-                elif info_gain == self.best_gain and info_gain > 0.000001:
-                    margin = self.margin_gain(X, att, threshold)
-                    if self.best_margin == -1:
-                        self.best_margin = self.margin_gain(
-                            X, self.best_split, self.best_threshold
-                        )
-
-                    if margin > self.best_margin or (
-                        margin == self.best_margin
-                        and self.random_state.choice([True, False])
-                    ):
-                        self.best_split = att
-                        self.best_threshold = threshold
-                        self.best_margin = margin
-                        best_distributions = distributions
-                        best_entropies = entropies
-
-        if self.best_split > -1:
-            self.children = [None, None, None]
-
-            left_idx, right_idx, missing_idx = self.split_data(
-                X, self.best_split, self.best_threshold
-            )
-
-            if len(left_idx) > 0:
-                self.children[0] = _TreeNode(random_state=self.random_state)
-                self.children[0].build_tree(
-                    X[left_idx],
-                    y[left_idx],
-                    thresholds,
-                    best_entropies[0],
-                    best_distributions[0],
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    False,
-                )
-            else:
-                self.children[0] = _TreeNode(random_state=self.random_state)
-                self.children[0].build_tree(
-                    X,
-                    y,
-                    thresholds,
-                    entropy,
-                    distribution,
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    True,
-                )
-
-            if len(right_idx) > 0:
-                self.children[1] = _TreeNode(random_state=self.random_state)
-                self.children[1].build_tree(
-                    X[right_idx],
-                    y[right_idx],
-                    thresholds,
-                    best_entropies[1],
-                    best_distributions[1],
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    False,
-                )
-            else:
-                self.children[1] = _TreeNode(random_state=self.random_state)
-                self.children[1].build_tree(
-                    X,
-                    y,
-                    thresholds,
-                    entropy,
-                    distribution,
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    True,
-                )
-
-            if len(missing_idx) > 0:
-                self.children[2] = _TreeNode(random_state=self.random_state)
-                self.children[2].build_tree(
-                    X[missing_idx],
-                    y[missing_idx],
-                    thresholds,
-                    best_entropies[2],
-                    best_distributions[2],
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    False,
-                )
-            else:
-                self.children[2] = _TreeNode(random_state=self.random_state)
-                self.children[2].build_tree(
-                    X,
-                    y,
-                    thresholds,
-                    entropy,
-                    distribution,
-                    depth + 1,
-                    max_depth,
-                    n_classes,
-                    True,
-                )
-        else:
-            self.leaf_distribution = distribution / np.sum(distribution)
-
-        return self
-
-    def predict_proba(self, X, n_classes):
-        if self.best_split > -1:
-            if X[self.best_split] <= self.best_threshold:
-                return self.children[0].predict_proba(X, n_classes)
-            elif X[self.best_split] > self.best_threshold:
-                return self.children[1].predict_proba(X, n_classes)
-            else:
-                return self.children[2].predict_proba(X, n_classes)
-        else:
-            return self.leaf_distribution
-
-    @staticmethod
-    @njit(fastmath=True, cache=True)
-    def information_gain(X, y, attribute, threshold, parent_entropy, n_classes):
-        dist_left = np.zeros(n_classes)
-        dist_right = np.zeros(n_classes)
-        dist_missing = np.zeros(n_classes)
-        for i, case in enumerate(X):
-            if case[attribute] <= threshold:
-                dist_left[y[i]] += 1
-            elif case[attribute] > threshold:
-                dist_right[y[i]] += 1
-            else:
-                dist_missing[y[i]] += 1
-
-        sum_missing = 0
-        for v in dist_missing:
-            sum_missing += v
-        sum_left = 0
-        for v in dist_left:
-            sum_left += v
-        sum_right = 0
-        for v in dist_right:
-            sum_right += v
-
-        entropy_left = _entropy(dist_left, sum_left)
-        entropy_right = _entropy(dist_right, sum_right)
-        entropy_missing = _entropy(dist_missing, sum_missing)
-
-        n_cases = X.shape[0]
-        info_gain = (
-            parent_entropy
-            - sum_left / n_cases * entropy_left
-            - sum_right / n_cases * entropy_right
-            - sum_missing / n_cases * entropy_missing
-        )
-
-        return (
-            info_gain,
-            [dist_left, dist_right, dist_missing],
-            [entropy_left, entropy_right, entropy_missing],
-        )
-
-    @staticmethod
-    @njit(fastmath=True, cache=True)
-    def margin_gain(X, attribute, threshold):
-        margins = np.abs(X[:, attribute] - threshold)
-        return np.min(margins)
-
-    @staticmethod
-    @njit(fastmath=True, cache=True)
-    def split_data(X, best_split, best_threshold):
-        left_idx = np.zeros(len(X), dtype=np.int_)
-        left_count = 0
-        right_idx = np.zeros(len(X), dtype=np.int_)
-        right_count = 0
-        missing_idx = np.zeros(len(X), dtype=np.int_)
-        missing_count = 0
-        for i, case in enumerate(X):
-            if case[best_split] <= best_threshold:
-                left_idx[left_count] = i
-                left_count += 1
-            elif case[best_split] > best_threshold:
-                right_idx[right_count] = i
-                right_count += 1
-            else:
-                missing_idx[missing_count] = i
-                missing_count += 1
-
-        return (
-            left_idx[:left_count],
-            right_idx[:right_count],
-            missing_idx[:missing_count],
-        )
-
-    @staticmethod
-    @njit(fastmath=True, cache=True)
-    def remaining_classes(distribution):
-        remaining_classes = 0
-        for d in distribution:
-            if d > 0:
-                remaining_classes += 1
-        return remaining_classes > 1
-
-
 @njit(fastmath=True, cache=True)
-def _entropy(x, s):
+def _entropy(x, s: int) -> float:
     e = 0
     for i in x:
         p = i / s if s > 0 else 0


### PR DESCRIPTION
Reference Issues/PRs
Part of https://github.com/aeon-toolkit/aeon/issues/1454

What does this implement/fix? Explain your changes.
Adding type hints to remaining scripts in : aeon/classification/sklearn/_continuous_interval_tree.py ( Existing class _TreeNode, has been moved above ContinuousIntervalTree, in order to include the type[_TreeNode] in the type hints)  

aeon/classification/shapelet_based scripts. 

Does your contribution introduce a new dependency? If yes, which one?
None

Any other comments?
Type hints are NOT added in other methods since they were not primitive types.