### PR TITLE
[ENH] Results lists and loading

### DIFF
--- a/aeon/benchmarking/results_loaders.py
+++ b/aeon/benchmarking/results_loaders.py
@@ -275,7 +275,7 @@ def get_estimator_results(
     default_only=True,
     task="classification",
     measure="accuracy",
-    path="https://timeseriesclassification.com/results/ReferenceResults",
+    path="http://timeseriesclassification.com/results/ReferenceResults",
 ):
     """Look for results for given estimators for a list of datasets.
 
@@ -346,7 +346,7 @@ def get_estimator_results_as_array(
     task="Classification",
     measure="accuracy",
     include_missing=False,
-    path="https://timeseriesclassification.com/results/ReferenceResults",
+    path="http://timeseriesclassification.com/results/ReferenceResults",
 ):
     """Look for results for given estimators for a list of datasets.
 

--- a/aeon/datasets/tsc_datasets.py
+++ b/aeon/datasets/tsc_datasets.py
@@ -97,7 +97,7 @@ univariate2015 = {
     "SmallKitchenAppliances",
     "SonyAIBORobotSurface1",
     "SonyAIBORobotSurface2",
-    "StarlightCurves",
+    "StarLightCurves",
     "Strawberry",
     "SwedishLeaf",
     "Symbols",


### PR DESCRIPTION
this changes the results loaders to use http://timeseriesclassification.com because there is a current issue with the security certificate after website transfer. Also corrects a typo in the univariate2015 list. 