### PR TITLE
[MNT] Remove test exclusions

### DIFF
--- a/aeon/testing/test_config.py
+++ b/aeon/testing/test_config.py
@@ -44,13 +44,8 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
-    # test fails several variants of inversion, see
-    # https://github.com/aeon-toolkit/aeon/issues/700
-    "Differencer": ["test_transform_inverse_transform_equivalent"],
-    # Test fails, see https://github.com/aeon-toolkit/aeon/issues/1067
-    "MockUnivariateForecasterLogger": ["test_non_state_changing_method_contract"],
     # has a keras fail, unknown reason
-    "LearningShapeletClassifier": ["test_fit_deterministic"],
+    # "LearningShapeletClassifier": ["test_fit_deterministic"],
 }
 
 # We use estimator tags in addition to class hierarchies to further distinguish

--- a/aeon/testing/test_config.py
+++ b/aeon/testing/test_config.py
@@ -44,6 +44,8 @@ EXCLUDED_TESTS = {
         "test_persistence_via_pickle",
         "test_save_estimators_to_file",
     ],
+    # Test fails, see https://github.com/aeon-toolkit/aeon/issues/1067
+    # "MockUnivariateForecasterLogger": ["test_non_state_changing_method_contract"],
     # has a keras fail, unknown reason
     # "LearningShapeletClassifier": ["test_fit_deterministic"],
 }

--- a/aeon/testing/test_config.py
+++ b/aeon/testing/test_config.py
@@ -22,9 +22,9 @@ if os.environ.get("CICD_RUNNING") == "1":
 
 EXCLUDE_ESTIMATORS = []
 
-# the test currently fails when numba is disabled. See issue #622
-if os.environ.get("NUMBA_DISABLE_JIT") == "1":
-    EXCLUDE_ESTIMATORS.append("StatsForecastAutoARIMA")
+# the test currently fails when numba is disabled. See issue #622 and #625
+# if os.environ.get("NUMBA_DISABLE_JIT") == "1":
+#    EXCLUDE_ESTIMATORS.append("StatsForecastAutoARIMA")
 
 EXCLUDED_TESTS = {
     # Early classifiers (EC) intentionally retain information from previous predict


### PR DESCRIPTION
removing test exclusions to see what happens

#700 already closed
#1067 needs fixing and 
"LearningShapeletClassifier": ["test_fit_deterministic"],
no issue
the test currently fails when numba is disabled. See issue #622, #625
if os.environ.get("NUMBA_DISABLE_JIT") == "1":
 EXCLUDE_ESTIMATORS.append("StatsForecastAutoARIMA")
