### PR TITLE
[ENH,BUG] added weighted elastic barycenter and fix cache issue in subgradient method

### DIFF
--- a/aeon/clustering/averaging/_ba_petitjean.py
+++ b/aeon/clustering/averaging/_ba_petitjean.py
@@ -77,7 +77,7 @@ def petitjean_barycenter_average(
         _X = X.reshape((X.shape[0], 1, X.shape[1]))
     else:
         raise ValueError("X must be a 2D or 3D array")
-    
+
     if weights is None:
         weights = np.ones(len(_X))
 
@@ -96,11 +96,7 @@ def petitjean_barycenter_average(
             kwargs["g"] = 0.05
     for i in range(max_iters):
         barycenter, cost = _ba_one_iter_petitjean(
-            barycenter, 
-            _X, 
-            distance, 
-            weights, 
-            **kwargs
+            barycenter, _X, distance, weights, **kwargs
         )
         if abs(cost_prev - cost) < tol:
             break

--- a/aeon/clustering/averaging/_ba_petitjean.py
+++ b/aeon/clustering/averaging/_ba_petitjean.py
@@ -15,6 +15,7 @@ def petitjean_barycenter_average(
     max_iters: int = 30,
     tol=1e-5,
     init_barycenter: Union[np.ndarray, str] = "mean",
+    weights: Optional[np.ndarray] = None,
     precomputed_medoids_pairwise_distance: Optional[np.ndarray] = None,
     verbose: bool = False,
     random_state: Optional[int] = None,
@@ -43,6 +44,9 @@ def petitjean_barycenter_average(
         The initial barycenter to use for the minimisation. If a np.ndarray is provided
         it must be of shape ``(n_channels, n_timepoints)``. If a str is provided it must
         be one of the following: ['mean', 'medoids', 'random'].
+    weights: Optional[np.ndarray] of shape (n_cases,), default=None
+        The weights associated to each time series instance, if None a weight
+        of 1 will be associated to each instance.
     precomputed_medoids_pairwise_distance: np.ndarray (of shape (len(X), len(X)),
                 default=None
         Precomputed medoids pairwise.
@@ -73,6 +77,9 @@ def petitjean_barycenter_average(
         _X = X.reshape((X.shape[0], 1, X.shape[1]))
     else:
         raise ValueError("X must be a 2D or 3D array")
+    
+    if weights is None:
+        weights = np.ones((len(_X)))
 
     barycenter = _get_init_barycenter(
         _X,
@@ -88,7 +95,7 @@ def petitjean_barycenter_average(
         if "g" not in kwargs:
             kwargs["g"] = 0.05
     for i in range(max_iters):
-        barycenter, cost = _ba_one_iter_petitjean(barycenter, _X, distance, **kwargs)
+        barycenter, cost = _ba_one_iter_petitjean(barycenter, _X, distance, weights, **kwargs)
         if abs(cost_prev - cost) < tol:
             break
         elif cost_prev < cost:
@@ -106,6 +113,7 @@ def _ba_one_iter_petitjean(
     barycenter: np.ndarray,
     X: np.ndarray,
     distance: str = "dtw",
+    weights: Optional[np.ndarray] = None,
     window: Union[float, None] = None,
     g: float = 0.0,
     epsilon: Union[float, None] = None,
@@ -146,8 +154,8 @@ def _ba_one_iter_petitjean(
         )
 
         for j, k in curr_alignment:
-            alignment[:, k] += curr_ts[:, j]
-            sum[k] += 1
-        cost += curr_cost
+            alignment[:, k] += curr_ts[:, j] * weights[i]
+            sum[k] += 1 * weights[i]
+        cost += curr_cost * weights[i]
 
     return alignment / sum, cost

--- a/aeon/clustering/averaging/_ba_petitjean.py
+++ b/aeon/clustering/averaging/_ba_petitjean.py
@@ -79,7 +79,7 @@ def petitjean_barycenter_average(
         raise ValueError("X must be a 2D or 3D array")
     
     if weights is None:
-        weights = np.ones((len(_X)))
+        weights = np.ones(len(_X))
 
     barycenter = _get_init_barycenter(
         _X,
@@ -95,7 +95,13 @@ def petitjean_barycenter_average(
         if "g" not in kwargs:
             kwargs["g"] = 0.05
     for i in range(max_iters):
-        barycenter, cost = _ba_one_iter_petitjean(barycenter, _X, distance, weights, **kwargs)
+        barycenter, cost = _ba_one_iter_petitjean(
+            barycenter, 
+            _X, 
+            distance, 
+            weights, 
+            **kwargs
+        )
         if abs(cost_prev - cost) < tol:
             break
         elif cost_prev < cost:

--- a/aeon/clustering/averaging/_ba_subgradient.py
+++ b/aeon/clustering/averaging/_ba_subgradient.py
@@ -97,7 +97,7 @@ def subgradient_barycenter_average(
         raise ValueError("X must be a 2D or 3D array")
 
     if weights is None:
-        weights = np.ones((len(_X)))
+        weights = np.ones(len(_X))
     
     barycenter = _get_init_barycenter(
         _X,
@@ -167,7 +167,7 @@ def _ba_one_iter_subgradient(
     transformation_precomputed: bool = False,
     transformed_x: Optional[np.ndarray] = None,
     transformed_y: Optional[np.ndarray] = None,
-    ):
+):
 
     X_size, X_dims, X_timepoints = X.shape
     cost = 0.0
@@ -201,7 +201,7 @@ def _ba_one_iter_subgradient(
 
         new_ba = np.zeros((X_dims, X_timepoints))
         for j, k in curr_alignment:
-            new_ba[:, k] += (barycenter_copy[:, k] - curr_ts[:, j])
+            new_ba[:, k] += barycenter_copy[:, k] - curr_ts[:, j]
 
         barycenter_copy -= (2.0 * current_step_size) * new_ba * weights[i]
 

--- a/aeon/clustering/averaging/_ba_subgradient.py
+++ b/aeon/clustering/averaging/_ba_subgradient.py
@@ -196,14 +196,15 @@ def _ba_one_iter_subgradient(
             transformed_x,
             transformed_y,
         )
+        
+        barycenter_copy = np.copy(barycenter)
 
         new_ba = np.zeros((X_dims, X_timepoints))
         for j, k in curr_alignment:
-            new_ba[:, k] += (barycenter[:, k] - curr_ts[:, j]) * weights[i]
+            new_ba[:, k] += (barycenter_copy[:, k] - curr_ts[:, j])
 
-        barycenter -= (2.0 * current_step_size) * new_ba
+        barycenter_copy -= (2.0 * current_step_size) * new_ba * weights[i]
 
         current_step_size -= step_size_reduction
         cost = curr_cost * weights[i]
-        print(weights[i])
-    return barycenter, cost, current_step_size
+    return barycenter_copy, cost, current_step_size

--- a/aeon/clustering/averaging/_ba_subgradient.py
+++ b/aeon/clustering/averaging/_ba_subgradient.py
@@ -98,7 +98,7 @@ def subgradient_barycenter_average(
 
     if weights is None:
         weights = np.ones(len(_X))
-    
+
     barycenter = _get_init_barycenter(
         _X,
         init_barycenter,

--- a/aeon/clustering/averaging/_ba_subgradient.py
+++ b/aeon/clustering/averaging/_ba_subgradient.py
@@ -176,10 +176,12 @@ def _ba_one_iter_subgradient(
     if iteration == 0:
         step_size_reduction = (initial_step_size - final_step_size) / X_size
 
+    barycenter_copy = np.copy(barycenter)
+
     for i in shuffled_indices:
         curr_ts = X[i]
         curr_alignment, curr_cost = _get_alignment_path(
-            barycenter,
+            barycenter_copy,
             X[i],
             distance,
             window,
@@ -196,8 +198,6 @@ def _ba_one_iter_subgradient(
             transformed_x,
             transformed_y,
         )
-        
-        barycenter_copy = np.copy(barycenter)
 
         new_ba = np.zeros((X_dims, X_timepoints))
         for j, k in curr_alignment:

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -122,6 +122,7 @@ def elastic_barycenter_average(
             init_barycenter=init_barycenter,
             initial_step_size=initial_step_size,
             final_step_size=final_step_size,
+            weights=weights,
             precomputed_medoids_pairwise_distance=precomputed_medoids_pairwise_distance,
             verbose=verbose,
             random_state=random_state,

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -15,7 +15,7 @@ def elastic_barycenter_average(
     tol: float = 1e-5,
     init_barycenter: Union[np.ndarray, str] = "mean",
     method: str = "petitjean",
-    weights: np.ndarray = None,
+    weights: Optional[np.ndarray] = None,
     initial_step_size: float = 0.05,
     final_step_size: float = 0.005,
     precomputed_medoids_pairwise_distance: Optional[np.ndarray] = None,
@@ -73,7 +73,7 @@ def elastic_barycenter_average(
     method: str, default='petitjean'
         The method to use for the barycenter averaging. Valid strings are:
         ['petitjean', 'subgradient'].
-    weights: np.ndarray of shape (n_cases,), default=None
+    weights: Optional[np.ndarray] of shape (n_cases,), default=None
         The weights associated to each time series instance, if None a weight
         of 1 will be associated to each instance.
     precomputed_medoids_pairwise_distance: np.ndarray (of shape (len(X), len(X)),
@@ -107,6 +107,7 @@ def elastic_barycenter_average(
             max_iters=max_iters,
             tol=tol,
             init_barycenter=init_barycenter,
+            weights=weights,
             precomputed_medoids_pairwise_distance=precomputed_medoids_pairwise_distance,
             verbose=verbose,
             random_state=random_state,

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -15,6 +15,7 @@ def elastic_barycenter_average(
     tol: float = 1e-5,
     init_barycenter: Union[np.ndarray, str] = "mean",
     method: str = "petitjean",
+    weights: np.ndarray = None,
     initial_step_size: float = 0.05,
     final_step_size: float = 0.005,
     precomputed_medoids_pairwise_distance: Optional[np.ndarray] = None,
@@ -72,6 +73,9 @@ def elastic_barycenter_average(
     method: str, default='petitjean'
         The method to use for the barycenter averaging. Valid strings are:
         ['petitjean', 'subgradient'].
+    weights: np.ndarray of shape (n_cases,), default=None
+        The weights associated to each time series instance, if None a weight
+        of 1 will be associated to each instance.
     precomputed_medoids_pairwise_distance: np.ndarray (of shape (len(X), len(X)),
                 default=None
         Precomputed medoids pairwise.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Solve #1251 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

- Added weighted version of elastic barycenter by adding an optional parameter (weights, by default equals to ones)
- Fixed the cache issue in sub gradient method by making a copy of barycenter 

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
No
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
