### PR TITLE
[MNT] Move haar wavelet transform to aeon.utils.numba package

### DIFF
--- a/aeon/transformations/collection/dwt.py
+++ b/aeon/transformations/collection/dwt.py
@@ -2,11 +2,10 @@
 
 __maintainer__ = []
 
-import math
-
 import numpy as np
 
 from aeon.transformations.collection import BaseCollectionTransformer
+from aeon.utils.numba.wavelets import haar_transform
 
 
 class DWTTransformer(BaseCollectionTransformer):
@@ -52,8 +51,9 @@ class DWTTransformer(BaseCollectionTransformer):
         Xt : 3D np.ndarray of shape = [n_cases, n_channels, n_timepoints]
             collection of transformed time series
         """
-        n_cases, n_channels, n_timepoints = X.shape
-        _X = np.swapaxes(X, 0, 1)
+        _X = np.array(X, dtype=np.float_)
+        n_cases, n_channels, n_timepoints = _X.shape
+        _X = np.swapaxes(_X, 0, 1)
         self._check_parameters()
 
         # On each dimension, perform PAA
@@ -83,13 +83,10 @@ class DWTTransformer(BaseCollectionTransformer):
                 current = x
                 approx = None
                 for _ in range(num_levels):
-                    approx = self._get_approx_coefficients(current)
-                    wav_coeffs = self._get_wavelet_coefficients(current)
+                    approx, wav_coeffs = haar_transform(current)
                     current = approx
-                    wav_coeffs.reverse()
-                    coeffs.extend(wav_coeffs)
-                approx.reverse()
-                coeffs.extend(approx)
+                    coeffs.extend(wav_coeffs[::-1])
+                coeffs.extend(approx[::-1])
                 coeffs.reverse()
                 res.append(coeffs)
 
@@ -112,22 +109,3 @@ class DWTTransformer(BaseCollectionTransformer):
                 + type(self.n_levels).__name__
                 + "' instead."
             )
-
-    def _get_approx_coefficients(self, arr):
-        """Get the approximate coefficients at a given level."""
-        new = []
-        if len(arr) == 1:
-            return [arr[0]]
-        for x in range(math.floor(len(arr) / 2)):
-            new.append((arr[2 * x] + arr[2 * x + 1]) / math.sqrt(2))
-        return new
-
-    def _get_wavelet_coefficients(self, arr):
-        """Get the wavelet coefficients at a given level."""
-        new = []
-        # if length is 1, just return the list back
-        if len(arr) == 1:
-            return [arr[0]]
-        for x in range(math.floor(len(arr) / 2)):
-            new.append((arr[2 * x] - arr[2 * x + 1]) / math.sqrt(2))
-        return new

--- a/aeon/utils/numba/tests/test_wavelets.py
+++ b/aeon/utils/numba/tests/test_wavelets.py
@@ -1,0 +1,88 @@
+"""Tests for numba utils functions related to wavelet transformations."""
+
+__maintainer__ = []
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+from aeon.utils.numba.wavelets import haar_transform, multilevel_haar_transform
+
+# Test data was generated using pywt library (PyWavelets) using the following code:
+#     import numpy as np
+#     import pywt as wt
+#
+#     x = np.random.default_rng(42).random(16)
+#     print(x)
+#     pywt_res = wt.dwt(x, "haar", mode="periodic")
+#     print(pywt_res[0])
+#     print(pywt_res[1])
+#     pywt_res2 = wt.dwt(pywt_res[0], "haar", mode="periodic")
+#     print(pywt_res2[0])
+#     print(pywt_res2[1])
+x = np.array(
+    [
+        0.77395605,
+        0.43887844,
+        0.85859792,
+        0.69736803,
+        0.09417735,
+        0.97562235,
+        0.7611397,
+        0.78606431,
+        0.12811363,
+        0.45038594,
+        0.37079802,
+        0.92676499,
+        0.64386512,
+        0.82276161,
+        0.4434142,
+        0.22723872,
+    ]
+)
+expected_approx = [
+    x,
+    np.array(
+        [
+            0.85760349,
+            1.10023407,
+            0.75646262,
+            1.09403845,
+            0.40906097,
+            0.91751561,
+            1.03706171,
+            0.47422323,
+        ]
+    ),
+    np.array([1.38440022, 1.30850185, 0.93803129, 1.06863983]),
+]
+expected_detail = [
+    np.array(
+        [
+            0.23693565,
+            0.11400675,
+            -0.62327574,
+            -0.01762436,
+            -0.22788093,
+            -0.39312801,
+            -0.12649892,
+            0.15285915,
+        ]
+    ),
+    np.array([-0.17156573, -0.23870215, -0.35953172, 0.39798691]),
+]
+
+
+def test_haar_transform():
+    """Test the Haar wavelet transform."""
+    approx, detail = haar_transform(x)
+    assert_array_almost_equal(approx, expected_approx[1])
+    assert_array_almost_equal(detail, expected_detail[0])
+
+
+def test_multilevel_haar_transform():
+    """Test the multilevel Haar wavelet transform."""
+    approx, detail = multilevel_haar_transform(x, levels=2)
+    assert_array_almost_equal(approx[0], expected_approx[0])
+    for i in range(2):
+        assert_array_almost_equal(approx[i + 1], expected_approx[i + 1])
+        assert_array_almost_equal(detail[i], expected_detail[i])

--- a/aeon/utils/numba/wavelets.py
+++ b/aeon/utils/numba/wavelets.py
@@ -1,0 +1,105 @@
+"""Numba-accelerated discrete wavelet transformations (DFTs)."""
+
+from typing import Tuple
+
+import numpy as np
+from numba import njit
+from numba.typed import List
+
+__maintainer__ = []
+__all__ = [
+    "haar_transform",
+    "multilevel_haar_transform",
+]
+
+
+def multilevel_haar_transform(
+    x: np.ndarray, levels: int = 1
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    """Perform the multilevel discrete Haar wavelet transform on a given signal.
+
+    Captures the approximate and detail coefficients per level. The approximate
+    coefficients contain one more element than the detail coefficients.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The input signal.
+    levels : int
+        The number of levels to perform the Haar wavelet transform.
+
+    Returns
+    -------
+    Tuple[List[np.ndarray], List[np.ndarray]]
+        The approximate and detail coefficients per level.
+    """
+    N = len(x)
+    max_levels = np.floor(np.log2(N))
+    if levels > max_levels:
+        raise ValueError(
+            f"The level ({levels}) must be less than log_2(N) ({max_levels})."
+        )
+
+    res_approx, res_detail = _haar_transform_iterative(x, levels)
+    return res_approx, res_detail
+
+
+@njit(cache=True, fastmath=True)
+def haar_transform(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Perform the discrete Haar wavelet transform on a given signal.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The input signal.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        The approximate and detail coefficients.
+    """
+    approx, detail = _haar_transform_iterative(x, levels=1)
+    return approx[-1], detail[-1]
+
+
+@njit(cache=True, fastmath=True)
+def _haar_transform_iterative(
+    x: np.ndarray, levels: int
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    # initialize
+    l_approx = List()
+    l_approx.append(x)
+    l_detail = List()
+
+    for _ in range(1, levels + 1):
+        approx = l_approx[-1]
+        l_approx.append(_haar_approx_coefficients(approx))
+        l_detail.append(_haar_detail_coefficients(approx))
+
+    return l_approx, l_detail
+
+
+@njit(cache=True, fastmath=True)
+def _haar_approx_coefficients(arr: np.ndarray) -> np.ndarray:
+    """Get the approximate coefficients at a given level."""
+    if len(arr) == 1:
+        return np.array([arr[0]])
+
+    N = int(np.floor(len(arr) / 2))
+    new = np.empty(N, dtype=arr.dtype)
+    for i in range(N):
+        new[i] = (arr[2 * i] + arr[2 * i + 1]) / np.sqrt(2)
+    return new
+
+
+@njit(cache=True, fastmath=True)
+def _haar_detail_coefficients(arr: np.ndarray) -> np.ndarray:
+    """Get the detail coefficients at a given level."""
+    if len(arr) == 1:
+        return np.array([arr[0]])
+
+    N = int(np.floor(len(arr) / 2))
+    new = np.empty(N, dtype=arr.dtype)
+    for i in range(N):
+        new[i] = (arr[2 * i] - arr[2 * i + 1]) / np.sqrt(2)
+    return new


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

In preparation of adding the DWT-MLEAD anomaly detection method, I moved the DFT implementation for `aeon.transformations.collections.DWTTransformer` to a common place in `aeon.utils`.

- Moves the implementation of the Haar wavelet to a separate module `aeon.utils.numba.wavelets`
- Applies `@njit` to the implementation
- Replaces `DWTTransformer`-code with a call to the util-method.

#### Does your contribution introduce a new dependency? If yes, which one?

Nope

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For developers with write access

- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.  
  ⬆️  **should I do this?**
