### PR TITLE
[ENH] Add sliding window utils for anomaly detection module

### DIFF
--- a/aeon/utils/sampling.py
+++ b/aeon/utils/sampling.py
@@ -27,9 +27,9 @@ def random_partition(n, k=2, seed=42):
         elements of elements of `parts` are in no particular order
         `parts` is sampled uniformly at random, subject to the above properties
     """
-    random.seed(seed)
+    rng = random.Random(seed)
     idx = list(range(n))
-    random.shuffle(idx)
+    rng.shuffle(idx)
 
     parts = []
     for i in range(k):

--- a/aeon/utils/tests/test_windowing.py
+++ b/aeon/utils/tests/test_windowing.py
@@ -1,0 +1,267 @@
+"""Tests for the windowing module."""
+
+import numpy as np
+import pytest
+
+from aeon.utils.windowing import reverse_windowing, sliding_windows
+
+_DATA = np.random.default_rng(42).integers(0, 10, (10,))
+_MULTIVARIATE_DATA = np.random.default_rng(42).integers(0, 10, (10, 2))
+_REVERSE_FIXTURES = [
+    # ws, stride, padding, results, expected
+    (
+        1,
+        1,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6, 0.5, 0.8, 0.3, 0.4]),
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6, 0.5, 0.8, 0.3, 0.4]),
+    ),
+    (
+        1,
+        2,
+        1,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5]),
+        np.array([0.5, 0.0, 0.6, 0.0, 0.5, 0.0, 0.8, 0.0, 0.5, 0.0]),
+    ),
+    (
+        1,
+        3,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8]),
+        np.array([0.5, 0.0, 0.0, 0.6, 0.0, 0.0, 0.5, 0.0, 0.0, 0.8]),
+    ),
+    (
+        1,
+        4,
+        1,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.0, 0.0, 0.0, 0.6, 0.0, 0.0, 0.0, 0.5, 0.0]),
+    ),
+    (
+        1,
+        5,
+        4,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.6, 0.0, 0.0, 0.0, 0.0]),
+    ),
+    (
+        2,
+        1,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6, 0.5, 0.8, 0.3]),
+        np.array([0.5, 0.55, 0.55, 0.65, 0.65, 0.55, 0.55, 0.65, 0.55, 0.3]),
+    ),
+    (
+        2,
+        2,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5]),
+        np.array([0.5, 0.5, 0.6, 0.6, 0.5, 0.5, 0.8, 0.8, 0.5, 0.5]),
+    ),
+    (
+        2,
+        3,
+        2,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.5, 0.0, 0.6, 0.6, 0.0, 0.5, 0.5, 0.0, 0.0]),
+    ),
+    (
+        2,
+        4,
+        0,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.5, 0.0, 0.0, 0.6, 0.6, 0.0, 0.0, 0.5, 0.5]),
+    ),
+    (
+        2,
+        5,
+        3,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.0, 0.0, 0.0, 0.6, 0.6, 0.0, 0.0, 0.0]),
+    ),
+    (
+        3,
+        1,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6, 0.5, 0.8]),
+        np.array([0.5, 0.55, 0.53, 0.63, 0.6, 0.63, 0.53, 0.63, 0.65, 0.8]),
+    ),
+    (
+        3,
+        2,
+        1,
+        np.array([0.5, 0.6, 0.5, 0.8]),
+        np.array([0.5, 0.5, 0.55, 0.6, 0.55, 0.5, 0.65, 0.8, 0.8, 0.0]),
+    ),
+    (
+        3,
+        3,
+        1,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.5, 0.5, 0.6, 0.6, 0.6, 0.5, 0.5, 0.5, 0.0]),
+    ),
+    (
+        3,
+        4,
+        3,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.0, 0.6, 0.6, 0.6, 0.0, 0.0, 0.0]),
+    ),
+    (
+        3,
+        5,
+        2,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.0, 0.0, 0.6, 0.6, 0.6, 0.0, 0.0]),
+    ),
+    (
+        4,
+        1,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6, 0.5]),
+        np.array([0.5, 0.55, 0.53, 0.6, 0.6, 0.6, 0.6, 0.53, 0.55, 0.5]),
+    ),
+    (
+        4,
+        2,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8]),
+        np.array([0.5, 0.5, 0.55, 0.55, 0.55, 0.55, 0.65, 0.65, 0.8, 0.8]),
+    ),
+    (
+        4,
+        3,
+        0,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.5, 0.5, 0.55, 0.6, 0.6, 0.55, 0.5, 0.5, 0.5]),
+    ),
+    (
+        4,
+        4,
+        2,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, 0.6, 0.0, 0.0]),
+    ),
+    (
+        4,
+        5,
+        1,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.5, 0.0, 0.6, 0.6, 0.6, 0.6, 0.0]),
+    ),
+    (
+        5,
+        1,
+        0,
+        np.array([0.5, 0.6, 0.5, 0.8, 0.5, 0.6]),
+        np.array([0.5, 0.55, 0.53, 0.6, 0.58, 0.6, 0.6, 0.63, 0.55, 0.6]),
+    ),
+    (
+        5,
+        2,
+        1,
+        np.array([0.5, 0.6, 0.5]),
+        np.array([0.5, 0.5, 0.55, 0.55, 0.53, 0.55, 0.55, 0.5, 0.5, 0.0]),
+    ),
+    (
+        5,
+        3,
+        2,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.55, 0.55, 0.6, 0.6, 0.6, 0.0, 0.0]),
+    ),
+    (
+        5,
+        4,
+        1,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.5, 0.55, 0.6, 0.6, 0.6, 0.6, 0.0]),
+    ),
+    (
+        5,
+        5,
+        0,
+        np.array([0.5, 0.6]),
+        np.array([0.5, 0.5, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, 0.6, 0.6]),
+    ),
+]
+
+
+def _padding(n: int, ws: int, stride: int) -> int:
+    return n - int(np.floor((n - ws) / stride)) * stride - ws
+
+
+def _n_windows(n: int, ws: int, stride: int) -> int:
+    return int(np.floor((n - ws) / stride) + 1)
+
+
+@pytest.mark.parametrize("ws", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("stride", [1, 2, 3, 4, 5])
+def test_sliding_windows_univariate(ws, stride):
+    """Test the sliding window function with univariate data."""
+    windows, padding = sliding_windows(_DATA, window_size=ws, stride=stride)
+    assert windows.shape[1] == ws
+    assert windows.shape[0] == _n_windows(_DATA.shape[0], ws, stride)
+    assert padding == _padding(_DATA.shape[0], ws, stride)
+
+
+@pytest.mark.parametrize("ws", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("stride", [1, 2, 3, 4, 5])
+def test_sliding_windows_multivariate(ws, stride):
+    """Test the sliding window function with multivariate data."""
+    windows, padding = sliding_windows(
+        _MULTIVARIATE_DATA, window_size=ws, stride=stride
+    )
+    assert windows.shape[1] == ws * _MULTIVARIATE_DATA.shape[1]
+    assert windows.shape[0] == _n_windows(_MULTIVARIATE_DATA.shape[0], ws, stride)
+    assert padding == _padding(_MULTIVARIATE_DATA.shape[0], ws, stride)
+
+
+@pytest.mark.parametrize("ws, stride, padding, results, expected", _REVERSE_FIXTURES)
+def test_reverse_windowing(ws, stride, padding, results, expected):
+    """Test the reverse windowing function."""
+    scores = reverse_windowing(
+        results,
+        window_size=ws,
+        reduction=np.nanmean,
+        stride=stride,
+        padding_length=padding,
+    )
+    assert scores.shape[0] == 10
+    np.testing.assert_array_almost_equal(scores, expected, decimal=2)
+
+
+@pytest.mark.parametrize(
+    "reduction", [np.nanmean, np.nanmedian, np.nanmax, np.mean, np.median, np.average]
+)
+def test_reverse_windowing_reductions(reduction):
+    """Test the reverse windowing function with different reduction functions."""
+    scores = reverse_windowing(_DATA[:9], window_size=2, reduction=reduction)
+    assert scores.shape[0] == 10
+
+
+def test_reverse_windowing_custom_reduction():
+    """Test the reverse windowing function with a custom reduction function."""
+
+    def reduce(x, axis=0):
+        return np.sum(x, axis=axis) - np.min(x, axis=axis)
+
+    scores = reverse_windowing(_DATA[:9], window_size=2, reduction=reduce)
+    assert scores.shape[0] == 10
+
+
+def test_combined():
+    """Test sliding window and reverse windowing together."""
+    ws = 3
+    stride = 2
+    windows, padding = sliding_windows(_DATA, window_size=ws, stride=stride)
+    results = np.random.default_rng(42).random(windows.shape[0])
+    mapped = reverse_windowing(
+        results,
+        window_size=ws,
+        reduction=np.nanmedian,
+        stride=stride,
+        padding_length=padding,
+    )
+    assert mapped.shape[0] == _DATA.shape[0]
+    assert mapped[2] == np.nanmedian(results[:2])

--- a/aeon/utils/tests/test_windowing.py
+++ b/aeon/utils/tests/test_windowing.py
@@ -216,10 +216,22 @@ def test_sliding_windows_univariate(ws, stride):
 def test_sliding_windows_multivariate(ws, stride):
     """Test the sliding window function with multivariate data."""
     windows, padding = sliding_windows(
-        _MULTIVARIATE_DATA, window_size=ws, stride=stride
+        _MULTIVARIATE_DATA, window_size=ws, stride=stride, axis=0
     )
     assert windows.shape[1] == ws * _MULTIVARIATE_DATA.shape[1]
     assert windows.shape[0] == _n_windows(_MULTIVARIATE_DATA.shape[0], ws, stride)
+    assert padding == _padding(_MULTIVARIATE_DATA.shape[0], ws, stride)
+
+
+@pytest.mark.parametrize("ws", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("stride", [1, 2, 3, 4, 5])
+def test_sliding_windows_multivariate_axis(ws, stride):
+    """Test the sliding window function with multivariate data."""
+    windows, padding = sliding_windows(
+        _MULTIVARIATE_DATA.T, window_size=ws, stride=stride, axis=1
+    )
+    assert windows.shape[0] == ws * _MULTIVARIATE_DATA.shape[1]
+    assert windows.shape[1] == _n_windows(_MULTIVARIATE_DATA.shape[0], ws, stride)
     assert padding == _padding(_MULTIVARIATE_DATA.shape[0], ws, stride)
 
 

--- a/aeon/utils/windowing.py
+++ b/aeon/utils/windowing.py
@@ -67,17 +67,17 @@ def sliding_windows(
     >>> X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     >>> windows, _ = sliding_windows(X, window_size=4)
     >>> print(windows)
-    [[1, 2, 3, 4],
-     [2, 3, 4, 5],
-     [3, 4, 5, 6],
-     [4, 5, 6, 7],
-     [5, 6, 7, 8],
-     [6, 7, 8, 9],
-     [7, 8, 9, 10]]
-    >>> window_size, padding = sliding_windows(X, window_size=4, stride=4)
+    [[ 1  2  3  4]
+     [ 2  3  4  5]
+     [ 3  4  5  6]
+     [ 4  5  6  7]
+     [ 5  6  7  8]
+     [ 6  7  8  9]
+     [ 7  8  9 10]]
+    >>> windows, padding = sliding_windows(X, window_size=4, stride=4)
     >>> print(windows)
-    [[1, 2, 3, 4],
-     [5, 6, 7, 8]]
+    [[1 2 3 4]
+     [5 6 7 8]]
     >>> print(padding)
     2
 
@@ -160,7 +160,7 @@ def reverse_windowing(
     >>> windows, padding_length = sliding_windows(X, window_size=3, stride=2)
     >>> y = np.array([0.5, 0.6, 0.5, 0.8])
     >>> reverse_windowing(y, window_size=3, stride=2, padding_length=padding_length)
-    array([0.5, 0.5, 0.55, 0.6, 0.55, 0.5, 0.65, 0.8, 0.8, 0.])
+    array([0.5 , 0.5 , 0.55, 0.6 , 0.55, 0.5 , 0.65, 0.8 , 0.8 , 0.  ])
     """
     if stride != 1:
         if padding_length is None:

--- a/aeon/utils/windowing.py
+++ b/aeon/utils/windowing.py
@@ -1,0 +1,270 @@
+"""Utility functions for creating and reversing sliding windows of time series data."""
+
+__maintainer__ = ["CodeLionX"]
+__all__ = ["sliding_windows", "reverse_windowing"]
+
+from typing import Callable, Optional, Tuple
+
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+
+
+def sliding_windows(
+    X: np.ndarray, window_size: int, stride: int = 1
+) -> Tuple[np.ndarray, int]:
+    """Create sliding windows of a time series.
+
+    Extracts sliding windows of a time series with a given window size and stride. The
+    windows are extracted along the first axis of the time series. If the time series is
+    multivariate, the channels of each window are stacked along the second axis.
+
+    ``stride == 1`` creates default sliding windows, where the window is moved one time
+    point at a time. If ``stride > 1``, the windows will skip over some time points.
+    If ``stride == window_size``, the windows are non-overlapping, also called tumbling
+    windows.
+
+    If the time series length minus the window size is not divisible by the stride, the
+    last window will not include the last time points of the time series. The number of
+    time points that are not covered by the windows is returned as padding length.
+
+    For a time series with 10 time points, a window size of 3, and a stride of 2, the
+    operation will create the following four windows:
+
+        0 7 6 4 4 8 0 6 2 0
+        0 7 6
+            6 4 4
+                4 8 0
+                    0 6 2
+
+    The last point at index 9 (0) is not covered by any window. Thus, the padding length
+    is 1.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Univariate (1d) or multivariate (2d) time series with the shape
+        (n_timepoints, n_channels).
+    window_size : int
+        Size of the sliding windows.
+    stride : int, optional, default=1
+        Stride of the sliding windows. If stride is greater than 1, the windows
+        will skip over some time points.
+
+    Returns
+    -------
+    windows : np.ndarray
+        Sliding windows of the time series with the shape
+        (n_windows, window_size) or (n_windows, window_size * n_channels) in
+        case of a multivariate time series.
+    padding_length : int
+        Number of time points that are not covered by the windows. The padding length
+        is always 0 for stride 1.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.utils.windowing import sliding_windows
+    >>> X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    >>> windows, _ = sliding_windows(X, window_size=4)
+    >>> print(windows)
+    [[1, 2, 3, 4],
+     [2, 3, 4, 5],
+     [3, 4, 5, 6],
+     [4, 5, 6, 7],
+     [5, 6, 7, 8],
+     [6, 7, 8, 9],
+     [7, 8, 9, 10]]
+    >>> window_size, padding = sliding_windows(X, window_size=4, stride=4)
+    >>> print(windows)
+    [[1, 2, 3, 4],
+     [5, 6, 7, 8]]
+    >>> print(padding)
+    2
+
+    See Also
+    --------
+    aeon.utils.windowing.reverse_windowing :
+        Reverse windowing of a time series.
+    """
+    windows = sliding_window_view(X, window_shape=window_size, axis=0, writeable=False)
+    # in case we have a multivariate TS
+    windows = windows.reshape((X.shape[0] - (window_size - 1), -1))
+    windows = windows[::stride, :]
+
+    padding_length = X.shape[0] - (windows.shape[0] * stride + window_size - stride)
+    return windows, padding_length
+
+
+def reverse_windowing(
+    y: np.ndarray,
+    window_size: int,
+    reduction: Callable[..., np.ndarray] = np.nanmean,
+    stride: int = 1,
+    padding_length: Optional[int] = None,
+    force_iterative: bool = False,
+) -> np.ndarray:
+    """Aggregate windowed results for each point of the original time series.
+
+    Reverse windowing is the inverse operation of sliding windows. It aggregates the
+    windowed results for each point of the original time series. The aggregation is
+    performed with a reduction function, e.g., np.nanmean, np.nanmedian, or np.nanmax.
+
+    The resulting time series has the same length as the original time series, namely
+    n_timepoints = (n_windows - 1) * stride + window_size + padding_length.
+
+    For a time series of length 10, a window size of 3, and a stride of 2, there are
+    four windows. Assuming the following result as input to this function
+    `y = np.array([1, 4, 8, 2])`, the example shows the aggregation of the windowed
+    results using the np.nanmean reduction function:
+
+        mapped = 1 1 2.5 4 6 8 5 2 2 0
+         y[0]  = 1 1  1
+         y[1]  =      4  4 4
+         y[2]  =           8 8 8
+         y[3]  =               2 2 2
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Array of windowed results with the shape (n_windows, window_size).
+    window_size : int
+        Size of the sliding windows.
+    reduction : callable, optional, default=np.nanmean
+        Reduction function to aggregate the windowed results.
+    stride : int, optional, default=1
+        Stride of the sliding windows. If stride is greater than 1, the windows
+        have skipped over some time points. If stride is unequal 1, ``padding_length``
+        must be provided as well.
+    padding_length : int, optional
+        Number of time points at the end of the time series that are not covered by any
+        windows. Must be provided if ``stride`` is not 1.
+    force_iterative : bool, optional, default=False
+        Force iterative reverse windowing function to limit memory usage. If False, the
+        function will choose the most efficient reverse windowing function based on the
+        available memory trading off between memory usage and speed.
+
+    Returns
+    -------
+    mapped : np.ndarray
+        Array of mapped results with the shape (n_timepoints,). The mapped results are
+        aggregated windowed results for each point of the original time series.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.utils.windowing import sliding_windows, reverse_windowing
+    >>> X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    >>> windows, padding_length = sliding_windows(X, window_size=3, stride=2)
+    >>> y = np.array([0.5, 0.6, 0.5, 0.8])
+    >>> reverse_windowing(y, window_size=3, stride=2, padding_length=padding_length)
+    array([0.5, 0.5, 0.55, 0.6, 0.55, 0.5, 0.65, 0.8, 0.8, 0.])
+    """
+    if stride != 1:
+        if padding_length is None:
+            raise ValueError("padding_length must be provided when stride is not 1")
+        return _reverse_windowing_strided(
+            y,
+            window_size=window_size,
+            stride=stride,
+            padding_length=padding_length,
+            reduction=reduction,
+        )
+
+    if force_iterative:
+        return _reverse_windowing_iterative(
+            y, window_size=window_size, reduction=reduction
+        )
+
+    if _has_enough_memory_for_vectorized_entire(window_size, len(y)):
+        return _reverse_windowing_vectorized(
+            y, window_size=window_size, reduction=reduction
+        )
+    else:
+        # Falling back to iterative reverse windowing function to limit memory usage!
+        return _reverse_windowing_iterative(
+            y, window_size=window_size, reduction=reduction
+        )
+
+
+def _has_enough_memory_for_vectorized_entire(window_size: int, n: int) -> bool:
+    import sys
+    from pathlib import Path
+
+    import psutil
+
+    memory_limit = psutil.virtual_memory().available
+    # 128 MB (for other objs) + size of scores array
+    memory_buffer = 128 * 1024**2 + sys.getsizeof(float()) * n
+
+    # if we are running within a container
+    container_limit_file = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+    if container_limit_file.exists():
+        with container_limit_file.open("r") as fh:
+            container_limit = int(fh.read())
+        if container_limit < 1 * 1024**4:
+            memory_limit = container_limit - memory_buffer
+
+    # if we are running within a dask worker
+    try:
+        import dask.distributed
+
+        dask_memory_limit = dask.distributed.get_worker().memory_limit
+        if dask_memory_limit is not None and dask_memory_limit < memory_limit:
+            memory_limit = dask_memory_limit - memory_buffer
+    except (ImportError, ValueError):
+        pass
+
+    estimated_mem_usage = sys.getsizeof(float()) * (n + window_size - 1) * window_size
+    return estimated_mem_usage <= memory_limit
+
+
+def _reverse_windowing_strided(
+    scores: np.ndarray,
+    window_size: int,
+    stride: int,
+    padding_length: int,
+    reduction: Callable[..., np.ndarray],
+) -> np.ndarray:
+    # compute begin and end indices of windows
+    begins = np.array([i * stride for i in range(scores.shape[0])], dtype=np.int_)
+    ends = begins + window_size
+
+    # prepare target array
+    unwindowed_length = stride * (scores.shape[0] - 1) + window_size + padding_length
+    mapped = np.full(unwindowed_length, fill_value=np.nan)
+
+    # only iterate over window intersections
+    indices = np.unique(np.r_[begins, ends])
+    for i, j in zip(indices[:-1], indices[1:]):
+        window_indices = np.flatnonzero((begins <= i) & (j - 1 < ends))
+        mapped[i:j] = reduction(scores[window_indices])
+
+    # replace untouched indices with 0 (especially for the padding at the end)
+    np.nan_to_num(mapped, copy=False)
+    return mapped
+
+
+def _reverse_windowing_vectorized(
+    y: np.ndarray, window_size: int, reduction: Callable[..., np.ndarray]
+) -> np.ndarray:
+    # create big matrix of n x window_size and put each window in its correct place
+    unwindowed_length = (window_size - 1) + len(y)
+    mapped = np.full(shape=(unwindowed_length, window_size), fill_value=np.nan)
+    mapped[: len(y), 0] = y
+
+    for w in range(1, window_size):
+        mapped[:, w] = np.roll(mapped[:, 0], w)
+
+    return reduction(mapped, axis=1)
+
+
+def _reverse_windowing_iterative(
+    y: np.ndarray, window_size: int, reduction: Callable[..., np.ndarray]
+) -> np.ndarray:
+    pad_n = (0, window_size - 1)
+    y = np.pad(y, pad_n, "constant", constant_values=(np.nan, np.nan))
+
+    for i in range(len(y) - (window_size - 1)):
+        y[i] = reduction(y[i : i + window_size]).item()
+
+    return y[~np.isnan(y)]

--- a/aeon/utils/windowing.py
+++ b/aeon/utils/windowing.py
@@ -69,6 +69,11 @@ def sliding_windows(
         Number of time points that are not covered by the windows. The padding length
         is always 0 for stride 1.
 
+    See Also
+    --------
+    aeon.utils.windowing.reverse_windowing :
+        Reverse windowing of a time series.
+
     Examples
     --------
     >>> import numpy as np
@@ -89,11 +94,6 @@ def sliding_windows(
      [5 6 7 8]]
     >>> print(padding)
     2
-
-    See Also
-    --------
-    aeon.utils.windowing.reverse_windowing :
-        Reverse windowing of a time series.
     """
     if X.ndim == 1:
         axis = 0

--- a/aeon/utils/windowing.py
+++ b/aeon/utils/windowing.py
@@ -10,13 +10,14 @@ from numpy.lib.stride_tricks import sliding_window_view
 
 
 def sliding_windows(
-    X: np.ndarray, window_size: int, stride: int = 1
+    X: np.ndarray, window_size: int, stride: int = 1, axis: int = 1
 ) -> Tuple[np.ndarray, int]:
     """Create sliding windows of a time series.
 
     Extracts sliding windows of a time series with a given window size and stride. The
-    windows are extracted along the first axis of the time series. If the time series is
-    multivariate, the channels of each window are stacked along the second axis.
+    windows are extracted along the specified axis of the time series. If the time
+    series is multivariate, the channels of each window are stacked along the
+    remaining axis.
 
     ``stride == 1`` creates default sliding windows, where the window is moved one time
     point at a time. If ``stride > 1``, the windows will skip over some time points.
@@ -49,13 +50,21 @@ def sliding_windows(
     stride : int, optional, default=1
         Stride of the sliding windows. If stride is greater than 1, the windows
         will skip over some time points.
+    axis : int, optional, default=1
+        Axis along which the sliding windows are extracted. The axis must be the
+        time axis of the time series. If ``axis == 1``, ``X`` is assumed to have the
+        shape (n_channels, n_timepoints). If ``axis == 0``, ``X`` is assumed to have
+        the shape (n_timepoints, n_channels).
 
     Returns
     -------
     windows : np.ndarray
-        Sliding windows of the time series with the shape
-        (n_windows, window_size) or (n_windows, window_size * n_channels) in
-        case of a multivariate time series.
+        Sliding windows of the time series. The return shape depends on the ``axis``
+        parameter. If ``axis == 0``, the windows have the shape
+        ``(n_windows, window_size)`` (univariate) or
+        ``(n_windows, window_size * n_channels)`` (multivariate). If ``axis == 1``, the
+        windows have the shape ``(window_size, n_windows)`` (univariate) or
+        ``(window_size * n_channels, n_windows)`` (multivariate).
     padding_length : int
         Number of time points that are not covered by the windows. The padding length
         is always 0 for stride 1.
@@ -86,12 +95,23 @@ def sliding_windows(
     aeon.utils.windowing.reverse_windowing :
         Reverse windowing of a time series.
     """
-    windows = sliding_window_view(X, window_shape=window_size, axis=0, writeable=False)
+    if X.ndim == 1:
+        axis = 0
+    windows = sliding_window_view(
+        X, window_shape=window_size, axis=axis, writeable=False
+    )
+    n_timepoints = X.shape[axis]
     # in case we have a multivariate TS
-    windows = windows.reshape((X.shape[0] - (window_size - 1), -1))
-    windows = windows[::stride, :]
+    if axis == 0:
+        windows = windows.reshape((n_timepoints - (window_size - 1), -1))
+        windows = windows[::stride, :]
+    else:
+        windows = windows.reshape((-1, n_timepoints - (window_size - 1)))
+        windows = windows[:, ::stride]
 
-    padding_length = X.shape[0] - (windows.shape[0] * stride + window_size - stride)
+    padding_length = n_timepoints - (
+        windows.shape[axis] * stride + window_size - stride
+    )
     return windows, padding_length
 
 
@@ -127,7 +147,7 @@ def reverse_windowing(
     Parameters
     ----------
     y : np.ndarray
-        Array of windowed results with the shape (n_windows, window_size).
+        Array of windowed results with the shape (n_windows,).
     window_size : int
         Size of the sliding windows.
     reduction : callable, optional, default=np.nanmean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ addopts = '''
     --dist worksteal
     --reruns 2
     --only-rerun "crashed while running"
+    --ignore-glob 'aeon/testing/utils/_*.py'
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ addopts = '''
     --dist worksteal
     --reruns 2
     --only-rerun "crashed while running"
-    --ignore-glob 'aeon/testing/utils/_*.py'
 '''
 filterwarnings = '''
     ignore::UserWarning


### PR DESCRIPTION
#### Reference Issues/PRs

none

#### What does this implement/fix? Explain your changes.

Adds two functions to a new utility module `aeon.utils.windowing`:

- `sliding_windows(X, window_size, stride, axis=1)` to create a sliding window view on a time series
- `reverse_windowing(y, window_size, reduction, stride, padding_length)` to reverse window anomaly scores to point anomaly scores

The windowing functions will be used in the implementation of `KMeansAnomalyDetector` and the `PyODAdapter` (#1586).

The new util functions are not added to the API reference.

#### Does your contribution introduce a new dependency? If yes, which one?

no

### PR checklist

##### For all contributions

- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.