### PR TITLE
[BUG] lcss bounded below to 0

### DIFF
--- a/aeon/distances/_lcss.py
+++ b/aeon/distances/_lcss.py
@@ -194,7 +194,10 @@ def _lcss_distance(
     x: np.ndarray, y: np.ndarray, bounding_matrix: np.ndarray, epsilon: float
 ) -> float:
     distance = _lcss_cost_matrix(x, y, bounding_matrix, epsilon)[x.shape[1], y.shape[1]]
-    return 1 - (float(distance / min(x.shape[1], y.shape[1])))
+    distance = 1 - (float(distance / min(x.shape[1], y.shape[1])))
+    if distance < 0.0:
+        return 0.0
+    return distance
 
 
 @njit(cache=True, fastmath=True)

--- a/aeon/distances/tests/test_pairwise.py
+++ b/aeon/distances/tests/test_pairwise.py
@@ -513,3 +513,18 @@ def test_single_to_multiple_distances(dist):
             dist["distance"],
             dist["pairwise_distance"],
         )
+
+
+@pytest.mark.parametrize("seed", [1, 10, 42, 52, 100])
+@pytest.mark.parametrize("dist", DISTANCES)
+def test_pairwise_distance_non_negative(dist, seed):
+    """Most estimators require distances to be non-negative."""
+    X = make_example_3d_numpy(
+        n_cases=5, n_channels=1, n_timepoints=10, random_state=seed, return_y=False
+    )
+    X2 = make_example_3d_numpy(
+        n_cases=10, n_channels=1, n_timepoints=10, random_state=seed + 1, return_y=False
+    )
+    pairwise = dist["pairwise_distance"]
+    Xt2 = pairwise(X2, X)
+    assert Xt2.min() >= 0, f"Distance {dist['name']} is negative"


### PR DESCRIPTION
fixes #761 by just lower bounding LCSS to zero to avoid numba numerics, adds a test for all distances >=0