### PR TITLE
[BUG] Convert rockets to only use 32 bit floats internally

### DIFF
--- a/aeon/transformations/collection/convolution_based/_minirocket.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket.py
@@ -92,8 +92,8 @@ class MiniRocket(BaseCollectionTransformer):
         random_state = (
             np.int32(self.random_state) if isinstance(self.random_state, int) else None
         )
-
-        X = X[:, 0, :].astype(np.float32)
+        X = X.squeeze()
+        X = X.astype(np.float32)
         _, n_timepoints = X.shape
         if n_timepoints < 9:
             raise ValueError(
@@ -118,7 +118,8 @@ class MiniRocket(BaseCollectionTransformer):
         -------
         pandas DataFrame, transformed features
         """
-        X = X[:, 0, :].astype(np.float32)
+        X = X.squeeze()
+        X = X.astype(np.float32)
 
         # change n_jobs dependend on value and existing cores
         prev_threads = get_num_threads()

--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -112,8 +112,8 @@ class MultiRocket(BaseCollectionTransformer):
         -------
         self
         """
-        X = X.astype(np.float64)
         X = X.squeeze()
+        X = X.astype(np.float32)
         if self.normalise:
             X = (X - X.mean(axis=-1, keepdims=True)) / (
                 X.std(axis=-1, keepdims=True) + 1e-8
@@ -139,8 +139,8 @@ class MultiRocket(BaseCollectionTransformer):
         -------
         pandas DataFrame, transformed features
         """
-        X = X.astype(np.float32)
         X = X.squeeze()
+        X = X.astype(np.float32)
         if self.normalise:
             X = (X - X.mean(axis=-1, keepdims=True)) / (
                 X.std(axis=-1, keepdims=True) + 1e-8
@@ -725,7 +725,7 @@ def _transform(X, X1, parameters, parameters1, n_features_per_kernel):
 
 
 @njit(
-    "float32[:](float64[:,:],int32[:],int32[:],float32[:],optional(int64))",
+    "float32[:](float32[:,:],int32[:],int32[:],float32[:],optional(int64))",
     fastmath=True,
     parallel=False,
     cache=True,

--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -139,7 +139,7 @@ class MultiRocket(BaseCollectionTransformer):
         -------
         pandas DataFrame, transformed features
         """
-        X = X.astype(np.float64)
+        X = X.astype(np.float32)
         X = X.squeeze()
         if self.normalise:
             X = (X - X.mean(axis=-1, keepdims=True)) / (
@@ -191,7 +191,7 @@ class MultiRocket(BaseCollectionTransformer):
 
 
 @njit(
-    "float32[:,:](float64[:,:],float64[:,:],Tuple((int32[:],int32[:],float32[:])),"
+    "float32[:,:](float32[:,:],float32[:,:],Tuple((int32[:],int32[:],float32[:])),"
     "Tuple((int32[:],int32[:],float32[:])),int32)",
     fastmath=True,
     parallel=True,

--- a/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket_multivariate.py
@@ -128,7 +128,7 @@ class MultiRocketMultivariate(BaseCollectionTransformer):
             X = _X1
             del _X1
 
-        X = X.astype(np.float64)
+        X = X.astype(np.float32)
 
         self.parameter = self._get_parameter(X)
         _X1 = np.diff(X, 1)
@@ -154,7 +154,7 @@ class MultiRocketMultivariate(BaseCollectionTransformer):
             X = (X - X.mean(axis=-1, keepdims=True)) / (
                 X.std(axis=-1, keepdims=True) + 1e-8
             )
-
+        X = X.astype(np.float32)
         _X1 = np.diff(X, 1)
 
         # change n_jobs dependend on value and existing cores
@@ -235,7 +235,7 @@ class MultiRocketMultivariate(BaseCollectionTransformer):
 
 
 @njit(
-    "float32[:](float64[:,:,:],int32[:],int32[:],int32[:],int32[:],float32[:],"
+    "float32[:](float32[:,:,:],int32[:],int32[:],int32[:],int32[:],float32[:],"
     "optional(int64))",
     fastmath=True,
     parallel=False,
@@ -633,7 +633,7 @@ def _quantiles(n):
 
 
 @njit(
-    "float32[:,:](float64[:,:,:],float64[:,:,:],"
+    "float32[:,:](float32[:,:,:],float32[:,:,:],"
     "Tuple((int32[:],int32[:],int32[:],int32[:],float32[:])),"
     "Tuple((int32[:],int32[:],int32[:],int32[:],float32[:])),int32)",
     fastmath=True,

--- a/aeon/transformations/collection/convolution_based/tests/test_all_rockets.py
+++ b/aeon/transformations/collection/convolution_based/tests/test_all_rockets.py
@@ -1,0 +1,40 @@
+"""Rocket test code."""
+
+import numpy as np
+
+from aeon.transformations.collection.convolution_based import (
+    MiniRocket,
+    MiniRocketMultivariate,
+    MultiRocket,
+    MultiRocketMultivariate,
+    Rocket,
+)
+
+
+def test_datatype_input():
+    """Test rocket variants accept all input types."""
+    uni_rockets = [
+        Rocket(num_kernels=100),
+        MiniRocket(num_kernels=100),
+        MultiRocket(num_kernels=100),
+    ]
+
+    shape = (10, 1, 20)
+    types = [np.float32, np.float64, np.int32, np.int64]
+    for r in uni_rockets:
+        for t in types:
+            X = np.random.rand(*shape).astype(t)
+            r.fit_transform(X)
+            r.fit(X)
+            r.transform(X)
+    multi_rockets = [
+        MiniRocketMultivariate(num_kernels=100),
+        MultiRocketMultivariate(num_kernels=100),
+    ]
+    shape = (10, 3, 20)
+    for r in multi_rockets:
+        for t in types:
+            X = np.random.rand(*shape).astype(t)
+            r.fit_transform(X)
+            r.fit(X)
+            r.transform(X)


### PR DESCRIPTION
See #1606 

Currently some rocket transforms convert to 32 bit, some convert to 64 bit, some do not conversion at all. This PR makes them all 32 bit

1. MultiRocket
currently converts 64 bit in fit, does nothing in transform but expects 64 bit
fit:        X = X.astype(np.float64)
transform: nothing
**now**
fit and transform to 32, number decorator in _transform now
@njit(
    "float32[:,:](float32[:,:],float32[:,:],Tuple((int32[:],int32[:],float32[:])),"

2.  MultiRocketMultivariate
fit:   X = X.astype(np.float64)
transform: nothing
**now**
fit and transform to 32, number decorator in _transform now
@njit(
    "float32[:,:](float32[:,:],float32[:,:],Tuple((int32[:],int32[:],float32[:])),"

3. MiniRocket
fit and transform:         X = X[:, 0, :].astype(np.float32)
now squeeze for same as others

4. MiniRocketMultivariate already converts to 32

5. MiniRocketMultivariateVariable, does some weird shit, seems 32 bit
6. Hydra: not numba afaik
