### PR TITLE
[MNT] Disable `pytest` threading by default for local runs

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -114,7 +114,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest
+        run: python -m pytest -n logical
 
       - name: Save new cache
         uses: actions/cache/save@v4
@@ -160,7 +160,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest
+        run: python -m pytest -n logical
 
       - name: Save new cache
         uses: actions/cache/save@v4
@@ -195,7 +195,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --cov=aeon --cov-report=xml --timeout 1800
+        run: python -m pytest -n logical --cov=aeon --cov-report=xml --timeout 1800
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -47,7 +47,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -k 'not TestAll'
+        run: python -m pytest -n logical -k 'not TestAll'
 
   pytest:
     runs-on: ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: python -m pytest --prtesting ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
+        run: python -m pytest -n logical --prtesting ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   codecov:
     # run the code coverage job if a PR has the 'codecov actions' label
@@ -125,7 +125,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --cov=aeon --cov-report=xml --timeout 1800
+        run: python -m pytest -n logical --cov=aeon --cov-report=xml --timeout 1800
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           command: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Tests
-        run: python -m pytest
+        run: python -m pytest -n logical
 
   upload-wheels:
     needs: test-wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ addopts = '''
     --durations 20
     --timeout 600
     --showlocals
-    --numprocesses logical
     --dist worksteal
     --reruns 2
     --only-rerun "crashed while running"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

From discussion in Slack. Threading removes defaults and does other things which can make debugging more complicated, which is usually the purpose of local `pytest` runs.

Removes the default configuration for threading and adds it manually to `pytest` calls in the CI.

The CI can still be threaded locally but now need an argument to do so.
