### PR TITLE
[MNT] Drop Python 3.8

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macOS-13, windows-2022 ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macOS-13, windows-2022 ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         # skip python versions unless the PR has the 'full pytest actions' label
         pr-testing:
           - ${{ (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'full pytest actions')) }}

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -62,9 +62,7 @@ jobs:
           - ${{ (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'full pytest actions')) }}
         exclude:
           - pr-testing: true
-            python-version: "3.9"
-          - pr-testing: true
-            python-version: "3.11"
+            python-version: "3.10"
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, macOS-13, windows-2022 ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ does not apply:
 
 ## ⚙️ Installation
 
-`aeon` requires a Python version of 3.8 or greater. Our full installation guide is
+`aeon` requires a Python version of 3.9 or greater. Our full installation guide is
 available in our [documentation](https://www.aeon-toolkit.org/en/stable/installation.html).
 
 The easiest way to install `aeon` is via pip:

--- a/aeon/testing/test_all_estimators.py
+++ b/aeon/testing/test_all_estimators.py
@@ -60,16 +60,16 @@ def subsample_by_version_os(x):
     Ensures each estimator is tested at least once on every OS and python version,
     if combined with a matrix of OS/versions.
 
-    Currently assumes that matrix includes py3.8-3.12, and win/ubuntu/mac.
+    Currently assumes that matrix includes py3.9-3.12, and win/ubuntu/mac.
     """
     import platform
     import sys
 
     # only use 3 Python versions in PR
     ix = sys.version_info.minor
-    if ix == 8:
+    if ix == 9:
         ix = 0
-    elif ix == 10:
+    elif ix == 11:
         ix = 1
     elif ix == 12:
         ix = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,12 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 dependencies = [
     "deprecated>=1.2.13",
     "numba>=0.55,<0.60.0",
@@ -76,8 +75,8 @@ all_extras = [
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tbats>=1.1.0",
-    "tensorflow>=2.12; python_version < '3.12' and python_version >= '3.9'",
-    "tensorflow-addons; python_version < '3.12' and python_version >= '3.9'",
+    "tensorflow>=2.12; python_version < '3.12'",
+    "tensorflow-addons; python_version < '3.12'",
     "torch>=1.13.1",
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",
@@ -91,8 +90,8 @@ all_extras = [
 ]
 dl = [
     "keras-self-attention",
-    "tensorflow>=2.12; python_version < '3.12' and python_version >= '3.9'",
-    "tensorflow-addons; python_version < '3.12' and python_version >= '3.9'",
+    "tensorflow>=2.12; python_version < '3.12'",
+    "tensorflow-addons; python_version < '3.12'",
 ]
 unstable_extras = [
     "mrsqm>=0.0.1,<0.1.0 ; platform_system == 'Darwin' and python_version < '3.12'",  # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Drops support for Python 3.8. This is near its end of life soon, and is causing some issues with `tensorflow`.

I would give this a bit of time for discussion before merging.
