### PR TITLE
[MNT] Change pre-commit trigger type

### DIFF
--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
#### Reference Issues/PRs

The current trigger for PRs in the pre-commit workflow does not give sufficient permissions to use repository secrets in forks. We don't actually install or execute any user code in this workflow, so I don't see the issue with giving it said permissions.
