### PR TITLE
[BUG] Bugfix MinDist doctests by setting word_length to 8

### DIFF
--- a/aeon/distances/_dft_sfa_mindist.py
+++ b/aeon/distances/_dft_sfa_mindist.py
@@ -45,7 +45,7 @@ def dft_sfa_mindist(
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
     >>> transform = SFAFast(
-    ...    word_length=16,
+    ...    word_length=8,
     ...    alphabet_size=8,
     ...    window_size=x.shape[-1],
     ...    norm=True,

--- a/aeon/distances/_paa_sax_mindist.py
+++ b/aeon/distances/_paa_sax_mindist.py
@@ -45,7 +45,7 @@ def paa_sax_mindist(
     >>> from aeon.transformations.collection.dictionary_based import SAX
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
-    >>> transform = SAX(n_segments=16, alphabet_size=8)
+    >>> transform = SAX(n_segments=8, alphabet_size=8)
     >>> x_sax = transform.fit_transform(x).squeeze()
     >>> x_paa = transform._get_paa(x).squeeze()
     >>> y_sax = transform.transform(y).squeeze()

--- a/aeon/distances/_sax_mindist.py
+++ b/aeon/distances/_sax_mindist.py
@@ -43,7 +43,7 @@ def sax_mindist(x: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n: int) -
     >>> from aeon.transformations.collection.dictionary_based import SAX
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
-    >>> transform = SAX(n_segments=16, alphabet_size=8)
+    >>> transform = SAX(n_segments=8, alphabet_size=8)
     >>> x_sax = transform.fit_transform(x).squeeze()
     >>> y_sax = transform.transform(y).squeeze()
     >>> dist = paa_sax_mindist(x_sax, y_sax, transform.breakpoints, x.shape[-1])

--- a/aeon/distances/_sfa_mindist.py
+++ b/aeon/distances/_sfa_mindist.py
@@ -43,7 +43,7 @@ def sfa_mindist(x: np.ndarray, y: np.ndarray, breakpoints: np.ndarray) -> float:
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
     >>> transform = SFAFast(
-    ...    word_length=16,
+    ...    word_length=8,
     ...    alphabet_size=8,
     ...    window_size=x.shape[-1],
     ...    norm=True,

--- a/aeon/transformations/collection/dictionary_based/_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa.py
@@ -221,6 +221,12 @@ class SFA(BaseCollectionTransformer):
                 "Class values must be provided for information gain binning"
             )
 
+        if self.word_length > X.shape[-1]:
+            raise ValueError(
+                "Please set the word-length to a value smaller than or equal to "
+                "the time series length."
+            )
+
         if self.binning_method not in binning_methods:
             raise TypeError("binning_method must be one of: ", binning_methods)
 

--- a/aeon/transformations/collection/dictionary_based/_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa.py
@@ -221,12 +221,6 @@ class SFA(BaseCollectionTransformer):
                 "Class values must be provided for information gain binning"
             )
 
-        if self.word_length > X.shape[-1]:
-            raise ValueError(
-                "Please set the word-length to a value smaller than or equal to "
-                "the time series length."
-            )
-
         if self.binning_method not in binning_methods:
             raise TypeError("binning_method must be one of: ", binning_methods)
 

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -237,6 +237,12 @@ class SFAFast(BaseCollectionTransformer):
                 "Please set either variance or anova Fourier coefficient selection"
             )
 
+        if self.word_length > X.shape[-1]:
+            raise ValueError(
+                "Please set the word-length to a value smaller than or equal to "
+                "the time series length."
+            )
+
         if self.binning_method not in binning_methods:
             raise TypeError("binning_method must be one of: ", binning_methods)
 

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -237,17 +237,18 @@ class SFAFast(BaseCollectionTransformer):
                 "Please set either variance or anova Fourier coefficient selection"
             )
 
-        if self.word_length > X.shape[-1]:
-            raise ValueError(
-                "Please set the word-length to a value smaller than or equal to "
-                "the time series length."
-            )
-
         if self.binning_method not in binning_methods:
             raise TypeError("binning_method must be one of: ", binning_methods)
 
         offset = 2 if self.norm else 0
         self.word_length_actual = min(self.window_size - offset, self.word_length)
+
+        if self.word_length > X.shape[-1] and self.word_length_actual > X.shape[-1]:
+            raise ValueError(
+                "Please set the word-length to a value smaller than or equal to "
+                "the time series length and window-length."
+            )
+
         self.dft_length = (
             self.window_size - offset
             if (self.anova or self.variance) is True


### PR DESCRIPTION
- This potentially fixes the following bug in doctests by setting the word length from 16 to 8.
- Adds a check for the word-length not to be larger than the TS length in SFA and SFA_FAST to avoid this error.


 
> [gw2] linux -- Python 3.10.14 /opt/hostedtoolcache/Python/3.10.14/x64/bin/python
> 045     >>> transform = SFAFast(
> 046     ...    word_length=16,
> 047     ...    alphabet_size=8,
> 048     ...    window_size=x.shape[-1],
> 049     ...    norm=True,
> 050     ...    lower_bounding_distances=True   # This must be set!
> 051     ... )
> 052     >>> transform.fit(x)
> 053     SFAFast(...)
> 054     >>> x_sfa = transform.transform_words(x).squeeze()
> UNEXPECTED EXCEPTION: IndexError('index 8 is out of bounds for axis 2 with size 8')