### PR TITLE
[BUG] Fix TSAD data loading tests and example notebooks

### DIFF
--- a/examples/datasets/load_data_from_web.ipynb
+++ b/examples/datasets/load_data_from_web.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "outputs": [],
    "source": [
     "from aeon.datasets import (\n",
@@ -44,8 +44,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:35.937391Z",
-     "start_time": "2024-06-03T13:57:35.932399Z"
+     "end_time": "2024-06-17T13:07:18.978527Z",
+     "start_time": "2024-06-17T13:07:18.453465Z"
     }
    }
   },
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "outputs": [
     {
      "name": "stdout",
@@ -89,8 +89,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:35.990038Z",
-     "start_time": "2024-06-03T13:57:35.985188Z"
+     "end_time": "2024-06-17T13:07:18.985584Z",
+     "start_time": "2024-06-17T13:07:18.980660Z"
     }
    }
   },
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "outputs": [
     {
      "name": "stdout",
@@ -136,8 +136,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:36.020721Z",
-     "start_time": "2024-06-03T13:57:36.006084Z"
+     "end_time": "2024-06-17T13:07:19.007332Z",
+     "start_time": "2024-06-17T13:07:18.987354Z"
     }
    }
   },
@@ -184,13 +184,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "outputs": [
     {
      "data": {
       "text/plain": "['AcousticContaminationMadrid',\n 'AluminiumConcentration',\n 'AppliancesEnergy',\n 'AustraliaRainfall',\n 'BIDMC32HR',\n 'BIDMC32RR',\n 'BIDMC32SpO2',\n 'BarCrawl6min',\n 'BeijingIntAirportPM25Quality',\n 'BeijingPM10Quality',\n 'BeijingPM25Quality',\n 'BenzeneConcentration',\n 'BinanceCoinSentiment',\n 'BitcoinSentiment',\n 'BoronConcentration',\n 'CalciumConcentration',\n 'CardanoSentiment',\n 'ChilledWaterPredictor',\n 'CopperConcentration',\n 'Covid19Andalusia',\n 'Covid3Month',\n 'DailyOilGasPrices',\n 'DailyTemperatureLatitude',\n 'DhakaHourlyAirQuality',\n 'ElectricMotorTemperature',\n 'ElectricityPredictor',\n 'EthereumSentiment',\n 'FloodModeling1',\n 'FloodModeling2',\n 'FloodModeling3',\n 'GasSensorArrayAcetone',\n 'GasSensorArrayEthanol',\n 'HotwaterPredictor',\n 'HouseholdPowerConsumption1',\n 'HouseholdPowerConsumption2',\n 'IEEEPPG',\n 'IronConcentration',\n 'LPGasMonitoringHomeActivity',\n 'LiveFuelMoistureContent',\n 'MadridPM10Quality',\n 'MagnesiumConcentration',\n 'ManganeseConcentration',\n 'MethaneMonitoringHomeActivity',\n 'MetroInterstateTrafficVolume',\n 'NaturalGasPricesSentiment',\n 'NewsHeadlineSentiment',\n 'NewsTitleSentiment',\n 'OccupancyDetectionLight',\n 'PPGDalia',\n 'ParkingBirmingham',\n 'PhosphorusConcentration',\n 'PotassiumConcentration',\n 'PrecipitationAndalusia',\n 'SierraNevadaMountainsSnow',\n 'SodiumConcentration',\n 'SolarRadiationAndalusia',\n 'SteamPredictor',\n 'SulphurConcentration',\n 'TetuanEnergyConsumption',\n 'VentilatorPressure',\n 'WaveDataTension',\n 'WindTurbinePower',\n 'ZincConcentration']"
      },
-     "execution_count": 13,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -203,14 +203,14 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:36.034825Z",
-     "start_time": "2024-06-03T13:57:36.029160Z"
+     "end_time": "2024-06-17T13:07:19.018724Z",
+     "start_time": "2024-06-17T13:07:19.010510Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "outputs": [
     {
      "name": "stdout",
@@ -227,8 +227,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:36.129102Z",
-     "start_time": "2024-06-03T13:57:36.049794Z"
+     "end_time": "2024-06-17T13:07:19.115945Z",
+     "start_time": "2024-06-17T13:07:19.020208Z"
     }
    }
   },
@@ -248,13 +248,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "outputs": [
     {
      "data": {
       "text/plain": "['australian_electricity_demand_dataset',\n 'car_parts_dataset_with_missing_values',\n 'car_parts_dataset_without_missing_values',\n 'cif_2016_dataset',\n 'covid_deaths_dataset',\n 'covid_mobility_dataset_with_missing_values',\n 'covid_mobility_dataset_without_missing_values',\n 'dominick_dataset',\n 'elecdemand_dataset',\n 'electricity_hourly_dataset',\n 'electricity_weekly_dataset',\n 'fred_md_dataset',\n 'hospital_dataset',\n 'kaggle_web_traffic_dataset_with_missing_values',\n 'kaggle_web_traffic_dataset_without_missing_values',\n 'kaggle_web_traffic_weekly_dataset',\n 'kdd_cup_2018_dataset_with_missing_values',\n 'kdd_cup_2018_dataset_without_missing_values',\n 'london_smart_meters_dataset_with_missing_values',\n 'london_smart_meters_dataset_without_missing_values',\n 'm1_monthly_dataset',\n 'm1_quarterly_dataset',\n 'm1_yearly_dataset',\n 'm3_monthly_dataset',\n 'm3_other_dataset',\n 'm3_quarterly_dataset',\n 'm3_yearly_dataset',\n 'm4_daily_dataset',\n 'm4_hourly_dataset',\n 'm4_monthly_dataset',\n 'm4_quarterly_dataset',\n 'm4_weekly_dataset',\n 'm4_yearly_dataset',\n 'nn5_daily_dataset_with_missing_values',\n 'nn5_daily_dataset_without_missing_values',\n 'nn5_weekly_dataset',\n 'pedestrian_counts_dataset',\n 'saugeenday_dataset',\n 'solar_10_minutes_dataset',\n 'solar_4_seconds_dataset',\n 'solar_weekly_dataset',\n 'sunspot_dataset_with_missing_values',\n 'sunspot_dataset_without_missing_values',\n 'tourism_monthly_dataset',\n 'tourism_quarterly_dataset',\n 'tourism_yearly_dataset',\n 'traffic_hourly_dataset',\n 'traffic_weekly_dataset',\n 'us_births_dataset',\n 'weather_dataset',\n 'wind_4_seconds_dataset',\n 'wind_farms_minutely_dataset_with_missing_values',\n 'wind_farms_minutely_dataset_without_missing_values']"
      },
-     "execution_count": 15,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,14 +267,14 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:36.138465Z",
-     "start_time": "2024-06-03T13:57:36.131935Z"
+     "end_time": "2024-06-17T13:07:19.124403Z",
+     "start_time": "2024-06-17T13:07:19.117901Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "outputs": [
     {
      "name": "stdout",
@@ -308,8 +308,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:38.963800Z",
-     "start_time": "2024-06-03T13:57:36.140381Z"
+     "end_time": "2024-06-17T13:07:21.595604Z",
+     "start_time": "2024-06-17T13:07:19.126358Z"
     }
    }
   },
@@ -345,17 +345,17 @@
     "from aeon.datasets.tsad_datasets import multivariate, univariate\n",
     "\n",
     "# This file also contains sub lists by learning type, e.g. semi-supervised, ...\n",
-    "print(\"Univariate length = \", len(univariate))\n",
-    "print(\"Multivariate length = \", len(multivariate))"
+    "print(\"Univariate length = \", len(univariate()))\n",
+    "print(\"Multivariate length = \", len(multivariate()))"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:38.971399Z",
-     "start_time": "2024-06-03T13:57:38.966037Z"
+     "end_time": "2024-06-17T13:07:21.771910Z",
+     "start_time": "2024-06-17T13:07:21.597146Z"
     }
    },
-   "execution_count": 17
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -397,11 +397,11 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:39.104489Z",
-     "start_time": "2024-06-03T13:57:38.973303Z"
+     "end_time": "2024-06-17T13:07:22.224850Z",
+     "start_time": "2024-06-17T13:07:21.773453Z"
     }
    },
-   "execution_count": 18
+   "execution_count": 9
   },
   {
    "cell_type": "markdown",
@@ -430,11 +430,11 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-06-03T13:57:39.109392Z",
-     "start_time": "2024-06-03T13:57:39.106462Z"
+     "end_time": "2024-06-17T13:07:22.231563Z",
+     "start_time": "2024-06-17T13:07:22.228483Z"
     }
    },
-   "execution_count": 18
+   "execution_count": 9
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "pytest-randomly",
     "pytest-timeout",
     "pytest-xdist[psutil]",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1677

#### What does this implement/fix? Explain your changes.

- uses `pytest-mock` to save local data to temporary directory in tests
- fix dataset example notebooks

#### Does your contribution introduce a new dependency? If yes, which one?

- `pytest-mock` in `[dev]`

#### Any other comments?

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

