### PR TITLE
[ENH] Tidy, deprecation actions and testing for sklearn estimators

### DIFF
--- a/aeon/classification/feature_based/_fresh_prince.py
+++ b/aeon/classification/feature_based/_fresh_prince.py
@@ -4,9 +4,8 @@ Pipeline classifier using the full set of TSFresh features and a
 RotationForestClassifier.
 """
 
-__maintainer__ = []
+__maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["FreshPRINCEClassifier"]
-
 
 import numpy as np
 
@@ -98,7 +97,6 @@ class FreshPRINCEClassifier(BaseClassifier):
         self.n_cases_ = 0
         self.n_channels_ = 0
         self.n_timepoints_ = 0
-        self.transformed_data_ = []
 
         self._rotf = None
         self._tsfresh = None

--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -232,7 +232,10 @@ class RotationForestClassifier(ClassifierMixin, BaseEstimator):
         Changes state by creating a fitted model that updates attributes ending in "_".
         """
         return np.array(
-            [self.classes_[int(np.argmax(prob))] for prob in self.fit_predict_proba(X)]
+            [
+                self.classes_[int(np.argmax(prob))]
+                for prob in self.fit_predict_proba(X, y)
+            ]
         )
 
     def fit_predict_proba(self, X, y) -> np.ndarray:

--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -8,13 +8,12 @@ __maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["RotationForestClassifier"]
 
 import time
-import warnings
-from typing import Type, Union
+from typing import Optional, Type, Union
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.decomposition import PCA
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils import check_random_state
@@ -23,7 +22,7 @@ from aeon.base._base import _clone_estimator
 from aeon.utils.validation import check_n_jobs
 
 
-class RotationForestClassifier(BaseEstimator):
+class RotationForestClassifier(ClassifierMixin, BaseEstimator):
     """
     A rotation forest (RotF) vector classifier.
 
@@ -52,11 +51,6 @@ class RotationForestClassifier(BaseEstimator):
         Default of `0` means ``n_estimators`` is used.
     contract_max_n_estimators : int, default=500
         Max number of estimators to build when ``time_limit_in_minutes`` is set.
-    save_transformed_data : bool, default=False
-        Save the data transformed in fit.
-
-        Deprecated and will be removed in v0.10.0. Use fit_predict and fit_predict_proba
-        to generate train estimates instead. transformed_data_ will also be removed.
     n_jobs : int, default=1
         The number of jobs to run in parallel for both ``fit`` and ``predict``.
         `-1` means using all processors.
@@ -106,10 +100,9 @@ class RotationForestClassifier(BaseEstimator):
         min_group: int = 3,
         max_group: int = 3,
         remove_proportion: float = 0.5,
-        base_estimator: Union[Type[BaseEstimator], None] = None,
-        time_limit_in_minutes: int = 0.0,
+        base_estimator: Optional[Type[BaseEstimator]] = None,
+        time_limit_in_minutes: float = 0.0,
         contract_max_n_estimators: int = 500,
-        save_transformed_data: bool = "deprecated",
         n_jobs: int = 1,
         random_state: Union[int, Type[np.random.RandomState], None] = None,
     ):
@@ -122,15 +115,6 @@ class RotationForestClassifier(BaseEstimator):
         self.contract_max_n_estimators = contract_max_n_estimators
         self.n_jobs = n_jobs
         self.random_state = random_state
-
-        # TODO remove 'save_transformed_data' and 'transformed_data_' in v0.10.0
-        self.save_transformed_data = save_transformed_data
-        if save_transformed_data != "deprecated":
-            warnings.warn(
-                "the save_transformed_data parameter is deprecated and will be"
-                "removed in v0.10.0. transformed_data_ will also be removed.",
-                stacklevel=2,
-            )
 
         super().__init__()
 

--- a/aeon/regression/feature_based/_fresh_prince.py
+++ b/aeon/regression/feature_based/_fresh_prince.py
@@ -37,8 +37,11 @@ class FreshPRINCERegressor(BaseRegressor):
     chunksize : int or None, default=None
         Number of series processed in each parallel TSFresh job, should be optimised
         for efficient parallelisation.
-    random_state : int or None, default=None
-        Seed for random, integer.
+    random_state : int, RandomState instance or None, default=None
+        If `int`, random_state is the seed used by the random number generator;
+        If `RandomState` instance, random_state is the random number generator;
+        If `None`, the random number generator is the `RandomState` instance used
+        by `np.random`.
 
     See Also
     --------
@@ -50,6 +53,12 @@ class FreshPRINCERegressor(BaseRegressor):
         scalable hypothesis tests (tsfresh-a python package)." Neurocomputing 307
         (2018): 72-77.
         https://www.sciencedirect.com/science/article/pii/S0925231218304843
+    .. [2] Middlehurst, M., Bagnall, A. "The FreshPRINCE: A Simple Transformation
+        Based Pipeline Time Series Classifier." In: El Yacoubi, M., Granger, E.,
+        Yuen, P.C., Pal, U., Vincent, N. (eds) Pattern Recognition and Artificial
+        Intelligence. ICPRAI 2022. Lecture Notes in Computer Science, vol 13364.
+        Springer, Cham. (2022).
+        https://link.springer.com/chapter/10.1007/978-3-031-09282-4_13
 
     Examples
     --------
@@ -116,9 +125,8 @@ class FreshPRINCERegressor(BaseRegressor):
         Changes state by creating a fitted model that updates attributes
         ending in "_" and sets is_fitted flag to True.
         """
-        self.transformed_data_ = self._fit_fp_shared(X, y)
-        self._rotf.fit(self.transformed_data_, y)
-
+        X_t = self._fit_fp_shared(X, y)
+        self._rotf.fit(X_t, y)
         return self
 
     def _predict(self, X) -> np.ndarray:

--- a/aeon/regression/sklearn/tests/test_all_regressors.py
+++ b/aeon/regression/sklearn/tests/test_all_regressors.py
@@ -1,0 +1,13 @@
+"""Unit tests for sklearn classifiers."""
+
+__maintainer__ = ["MatthewMiddlehurst"]
+
+from sklearn.utils.estimator_checks import parametrize_with_checks
+
+from aeon.regression.sklearn import RotationForestRegressor
+
+
+@parametrize_with_checks([RotationForestRegressor(n_estimators=3)])
+def test_sklearn_compatible_estimator(estimator, check):
+    """Test that sklearn estimators adhere to sklearn conventions."""
+    check(estimator)

--- a/aeon/regression/sklearn/tests/test_rotation_forest_regressor.py
+++ b/aeon/regression/sklearn/tests/test_rotation_forest_regressor.py
@@ -1,5 +1,7 @@
 """Rotation Forest test code."""
 
+__maintainer__ = ["MatthewMiddlehurst"]
+
 import numpy as np
 from sklearn.metrics import mean_squared_error
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

- Adds `ClassifierMixin` and `RegressorMixin` to sklearn estimators
- Carries out some deprecation actions for the classifier
- Adds `sklearn` testing for regressor rotf
- Makes some changes to data processing to accommodate for the above