### PR TITLE
[BUG] Fix broken import causing CI to fail

### DIFF
--- a/aeon/anomaly_detection/tests/test_pyod_adapter.py
+++ b/aeon/anomaly_detection/tests/test_pyod_adapter.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from aeon.anomaly_detection import PyODAdapter
-from aeon.testing.data_generation import make_series
+from aeon.testing.data_generation._legacy import make_series
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.

In the recent merges this conflict was not caught. Fixes this to use the correct `make_series` import.

While we could change this to not use `make_series` altogether, it would be better to just fix CI for now.
