### PR TITLE
[BUG] Cluster predict proba edge cases

### DIFF
--- a/aeon/clustering/base.py
+++ b/aeon/clustering/base.py
@@ -186,6 +186,9 @@ class BaseClusterer(BaseCollectionEstimator, ABC):
             (i, j)-th entry is predictive probability that i-th instance is of class j
         """
         preds = self._predict(X)
+        unique = np.unique(preds)
+        for i, u in enumerate(unique):
+            preds[preds == u] = i
         n_cases = len(preds)
         n_clusters = self.n_clusters
         if n_clusters is None:

--- a/aeon/clustering/feature_based/_catch22.py
+++ b/aeon/clustering/feature_based/_catch22.py
@@ -202,8 +202,15 @@ class Catch22Clusterer(BaseClusterer):
             return self._estimator.predict_proba(self._transformer.transform(X))
         else:
             preds = self._estimator.predict(self._transformer.transform(X))
-            dists = np.zeros((X.shape[0], np.unique(preds).shape[0]))
-            for i in range(0, X.shape[0]):
+            unique = np.unique(preds)
+            for i, u in enumerate(unique):
+                preds[preds == u] = i
+            n_cases = len(preds)
+            n_clusters = self.n_clusters
+            if n_clusters is None:
+                n_clusters = int(max(preds)) + 1
+            dists = np.zeros((X.shape[0], n_clusters))
+            for i in range(n_cases):
                 dists[i, preds[i]] = 1
             return dists
 

--- a/aeon/clustering/feature_based/_summary.py
+++ b/aeon/clustering/feature_based/_summary.py
@@ -158,8 +158,15 @@ class SummaryClusterer(BaseClusterer):
             return self._estimator.predict_proba(self._transformer.transform(X))
         else:
             preds = self._estimator.predict(self._transformer.transform(X))
-            dists = np.zeros((X.shape[0], np.unique(preds).shape[0]))
-            for i in range(0, X.shape[0]):
+            unique = np.unique(preds)
+            for i, u in enumerate(unique):
+                preds[preds == u] = i
+            n_cases = len(preds)
+            n_clusters = self.n_clusters
+            if n_clusters is None:
+                n_clusters = int(max(preds)) + 1
+            dists = np.zeros((X.shape[0], n_clusters))
+            for i in range(n_cases):
                 dists[i, preds[i]] = 1
             return dists
 

--- a/aeon/clustering/feature_based/_tsfresh.py
+++ b/aeon/clustering/feature_based/_tsfresh.py
@@ -182,8 +182,15 @@ class TSFreshClusterer(BaseClusterer):
             return self._estimator.predict_proba(self._transformer.transform(X))
         else:
             preds = self._estimator.predict(self._transformer.transform(X))
-            dists = np.zeros((X.shape[0], np.unique(preds).shape[0]))
-            for i in range(0, X.shape[0]):
+            unique = np.unique(preds)
+            for i, u in enumerate(unique):
+                preds[preds == u] = i
+            n_cases = len(preds)
+            n_clusters = self.n_clusters
+            if n_clusters is None:
+                n_clusters = int(max(preds)) + 1
+            dists = np.zeros((X.shape[0], n_clusters))
+            for i in range(n_cases):
                 dists[i, preds[i]] = 1
             return dists
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

There were two edge cases with the clustering predict_proba function that would cause crashes.

1) If there wasn't at least 1 prediction in every cluster
2) If the prediction didn't use cluster values of 0-n_clusters. For example I used a k-medoids package that when predict was called returned [22, 22, 32, 3, 32, 22] where instead of the cluster values being a value from 0-n_clusters it was referring to the index of the cluster centre that each value was assigned to. 

<!--
A clear and concise description of what you have implemented.
-->

This PR makes two main changes to address the above.
1) Instead of using .shape[0] to create the dist array n_clusters is used (when available isn't required):

```
            n_clusters = self.n_clusters
            if n_clusters is None:
                n_clusters = int(max(preds)) + 1
            dists = np.zeros((X.shape[0], n_clusters))
```

2) A additional sanitisation of the predict result is done to convert predictions value to 0-n_clusters. This allows the other logic to work if the predictions doesn't return 0-n_clusters:

```
  unique = np.unique(preds)
  for i, u in enumerate(unique):
      preds[preds == u] = i
```


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
