### PR TITLE
[BUG] Store n_timepoints and n_channels in fit to check in transform

### DIFF
--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -10,6 +10,7 @@ from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation._dependencies import _check_estimator_deps
 from aeon.utils.validation.collection import (
     get_n_cases,
+    get_n_timepoints,
     has_missing,
     is_equal_length,
     is_univariate,
@@ -216,5 +217,7 @@ class BaseCollectionEstimator(BaseEstimator):
         metadata["missing_values"] = has_missing(X)
         metadata["unequal_length"] = not is_equal_length(X)
         metadata["n_cases"] = get_n_cases(X)
+        # Length of first series, used if equal length is True
+        metadata["n_timepoints"] = get_n_timepoints(X)
 
         return metadata

--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -10,6 +10,7 @@ from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation._dependencies import _check_estimator_deps
 from aeon.utils.validation.collection import (
     get_n_cases,
+    get_n_channels,
     get_n_timepoints,
     has_missing,
     is_equal_length,
@@ -219,5 +220,6 @@ class BaseCollectionEstimator(BaseEstimator):
         metadata["n_cases"] = get_n_cases(X)
         # Length of first series, used if equal length is True
         metadata["n_timepoints"] = get_n_timepoints(X)
+        metadata["n_channels"] = get_n_channels(X)
 
         return metadata

--- a/aeon/base/tests/test_base_collection.py
+++ b/aeon/base/tests/test_base_collection.py
@@ -17,6 +17,8 @@ def test__get_metadata(data):
     assert not meta["multivariate"]
     assert not meta["missing_values"]
     assert not meta["unequal_length"]
+    assert meta["n_channels"] == 1
+    assert meta["n_timepoints"] == 20
     assert meta["n_cases"] == 10
 
 
@@ -102,7 +104,7 @@ def test_preprocess_collection(data):
     cls = BaseCollectionEstimator()
     X = cls._preprocess_collection(data)
     assert cls._n_jobs == 1
-    assert len(cls.metadata_) == 4
+    assert len(cls.metadata_) == 6
     assert get_type(X) == "numpy3D"
     tags = {"capability:multithreading": True}
     cls = BaseCollectionEstimator()

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -36,7 +36,7 @@ from sklearn.utils.multiclass import type_of_target
 from aeon.base import BaseCollectionEstimator
 from aeon.base._base import _clone_estimator
 from aeon.utils.validation._dependencies import _check_estimator_deps
-from aeon.utils.validation.collection import get_n_cases
+from aeon.utils.validation.collection import get_n_cases, get_n_timepoints
 
 
 class BaseClassifier(BaseCollectionEstimator, ABC):
@@ -541,7 +541,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
 
     def _check_n_timepoints(self, X):
         if not self.get_tag("capability:unequal_length"):
-            if X[0].shape[1] != self.metadata_["n_timepoints"]:
+            if get_n_timepoints(X) != self.metadata_["n_timepoints"]:
                 raise ValueError(
                     "X has different length to the data seen in fit but "
                     "this classifier cannot handle unequal length series."

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -172,6 +172,8 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             return np.repeat(list(self._class_dictionary.keys()), n_cases)
 
         X = self._preprocess_collection(X)
+        # Check if X is equal length but that is different to the length seen in fit
+        self._check_n_timepoints(X)
         return self._predict(X)
 
     @final
@@ -215,6 +217,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             return np.repeat([[1]], n_cases, axis=0)
 
         X = self._preprocess_collection(X)
+        self._check_n_timepoints(X)
         return self._predict_proba(X)
 
     @final
@@ -535,6 +538,18 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             estimated probability that i-th instance is of class j
         """
         return self._fit_predict_default(X, y, "predict_proba")
+
+    def _check_n_timepoints(self, X):
+        if not self.get_tag("capability:unequal_length"):
+            if X[0].shape[1] != self.metadata_["n_timepoints"]:
+                raise ValueError(
+                    "X has different length to the data seen in fit but "
+                    "this classifier cannot handle unequal length series."
+                    "length of train set was",
+                    self.metadata_["n_timepoints"],
+                    " length in predict is ",
+                    X[0].shape[1],
+                )
 
     def _fit_setup(self, X, y):
         # reset estimator at the start of fit

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -36,7 +36,11 @@ from sklearn.utils.multiclass import type_of_target
 from aeon.base import BaseCollectionEstimator
 from aeon.base._base import _clone_estimator
 from aeon.utils.validation._dependencies import _check_estimator_deps
-from aeon.utils.validation.collection import get_n_cases, get_n_timepoints
+from aeon.utils.validation.collection import (
+    get_n_cases,
+    get_n_channels,
+    get_n_timepoints,
+)
 
 
 class BaseClassifier(BaseCollectionEstimator, ABC):
@@ -173,7 +177,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
 
         X = self._preprocess_collection(X)
         # Check if X is equal length but that is different to the length seen in fit
-        self._check_n_timepoints(X)
+        self._check_shape(X)
         return self._predict(X)
 
     @final
@@ -217,7 +221,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             return np.repeat([[1]], n_cases, axis=0)
 
         X = self._preprocess_collection(X)
-        self._check_n_timepoints(X)
+        self._check_shape(X)
         return self._predict_proba(X)
 
     @final
@@ -539,18 +543,6 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
         """
         return self._fit_predict_default(X, y, "predict_proba")
 
-    def _check_n_timepoints(self, X):
-        if not self.get_tag("capability:unequal_length"):
-            if get_n_timepoints(X) != self.metadata_["n_timepoints"]:
-                raise ValueError(
-                    "X has different length to the data seen in fit but "
-                    "this classifier cannot handle unequal length series."
-                    "length of train set was",
-                    self.metadata_["n_timepoints"],
-                    " length in predict is ",
-                    X[0].shape[1],
-                )
-
     def _fit_setup(self, X, y):
         # reset estimator at the start of fit
         self.reset()
@@ -625,3 +617,23 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             method=method,
             n_jobs=self._n_jobs,
         )
+
+    def _check_shape(self, X):
+        if not self.get_tag("capability:unequal_length"):
+            if get_n_timepoints(X) != self.metadata_["n_timepoints"]:
+                raise ValueError(
+                    "X has different length to the data seen in fit but "
+                    "this classifier cannot handle unequal length series."
+                    "length of train set was",
+                    self.metadata_["n_timepoints"],
+                    " length in predict is ",
+                )
+        if self.get_tag("capability:multivariate"):
+            if get_n_channels(X) != self.metadata_["n_channels"]:
+                raise ValueError(
+                    "X has different number of channels to the data seen in fit "
+                    "number of channels in train set was",
+                    self.metadata_["n_channels"],
+                    "but in predict it is ",
+                    get_n_timepoints(X),
+                )

--- a/aeon/classification/tests/test_base.py
+++ b/aeon/classification/tests/test_base.py
@@ -87,6 +87,26 @@ def test_incorrect_input():
     with pytest.raises(ValueError, match=m6):
         dummy.fit(X, y)
 
+    # Train and test both equal length, but different lengthd
+    X2 = np.random.random(size=(5, 1, 20))
+    X3 = np.random.random(size=(5, 1, 5))
+    y = np.array([0, 0, 1, 1, 1])
+    dummy.fit(X, y)
+    with pytest.raises(
+        ValueError, match="X has different length to the data seen in fit"
+    ):
+        dummy.predict(X2)
+    with pytest.raises(
+        ValueError, match="X has different length to the data seen in fit"
+    ):
+        dummy.predict_proba(X3)
+    m2 = MockClassifierFullTags()
+    m2.fit(X, y)
+    y_pred = m2.predict(X2)
+    assert len(y_pred) == 5
+    y_pred = m2.predict_proba(X3)
+    assert y_pred.shape == (5, 2)
+
 
 def _assert_incorrect_X_input(dummy, correctX, correcty, X, y, msg):
     with pytest.raises(TypeError, match=msg):

--- a/aeon/classification/tests/test_base.py
+++ b/aeon/classification/tests/test_base.py
@@ -304,7 +304,7 @@ def test_fit_predict_default():
 
 
 def test_different_shape_fit_predict():
-    """Test train and test X wehn both differing lengths."""
+    """Test train and test X when they differ in series length."""
     dummy = MockClassifier()
     X = np.random.random(size=(5, 1, 10))
     X2 = np.random.random(size=(5, 1, 20))
@@ -336,3 +336,29 @@ def test_different_shape_fit_predict():
     assert len(y_pred) == 5
     y_pred = m2.predict_proba(X3)
     assert y_pred.shape == (5, 2)
+
+
+def test_different_channels_fit_predict():
+    """Test train and test X when they differ in numbero of lengths."""
+    dummy = MockClassifierFullTags()
+    X = np.random.random(size=(5, 4, 10))
+    X2 = np.random.random(size=(5, 4, 10))
+    X3 = np.random.random(size=(5, 3, 10))
+    X4 = np.random.random(size=(5, 10))
+    X5 = np.random.random(size=(5, 5, 10))
+    y = np.array([0, 0, 1, 1, 1])
+    dummy.fit(X, y)
+    preds = dummy.predict(X2)
+    assert len(preds) == 5
+    with pytest.raises(
+        ValueError, match="X has different number of channels to the data seen in fit"
+    ):
+        dummy.predict(X3)
+    with pytest.raises(
+        ValueError, match="X has different number of channels to the data seen in fit"
+    ):
+        dummy.predict(X4)
+    with pytest.raises(
+        ValueError, match="X has different number of channels to the data seen in fit"
+    ):
+        dummy.predict(X5)

--- a/aeon/classification/tests/test_base.py
+++ b/aeon/classification/tests/test_base.py
@@ -87,26 +87,6 @@ def test_incorrect_input():
     with pytest.raises(ValueError, match=m6):
         dummy.fit(X, y)
 
-    # Train and test both equal length, but different lengthd
-    X2 = np.random.random(size=(5, 1, 20))
-    X3 = np.random.random(size=(5, 1, 5))
-    y = np.array([0, 0, 1, 1, 1])
-    dummy.fit(X, y)
-    with pytest.raises(
-        ValueError, match="X has different length to the data seen in fit"
-    ):
-        dummy.predict(X2)
-    with pytest.raises(
-        ValueError, match="X has different length to the data seen in fit"
-    ):
-        dummy.predict_proba(X3)
-    m2 = MockClassifierFullTags()
-    m2.fit(X, y)
-    y_pred = m2.predict(X2)
-    assert len(y_pred) == 5
-    y_pred = m2.predict_proba(X3)
-    assert y_pred.shape == (5, 2)
-
 
 def _assert_incorrect_X_input(dummy, correctX, correcty, X, y, msg):
     with pytest.raises(TypeError, match=msg):
@@ -321,3 +301,38 @@ def test_fit_predict_default():
 
     with pytest.raises(ValueError, match=r"All classes must have at least 2 values"):
         cls._fit_predict_default(X, y, "predict")
+
+
+def test_different_shape_fit_predict():
+    """Test train and test X wehn both differing lengths."""
+    dummy = MockClassifier()
+    X = np.random.random(size=(5, 1, 10))
+    X2 = np.random.random(size=(5, 1, 20))
+    X3 = np.random.random(size=(5, 1, 5))
+    X4 = np.random.random(size=(5, 10))
+    X5 = np.random.random(size=(5, 20))
+    y = np.array([0, 0, 1, 1, 1])
+    dummy.fit(X, y)
+    with pytest.raises(
+        ValueError, match="X has different length to the data seen in fit"
+    ):
+        dummy.predict(X2)
+    with pytest.raises(
+        ValueError, match="X has different length to the data seen in fit"
+    ):
+        dummy.predict_proba(X3)
+    with pytest.raises(
+        ValueError, match="X has different length to the data seen in fit"
+    ):
+        dummy.predict(X5)
+    # Should not raise error
+    preds = dummy.predict(X)
+    assert len(preds) == 5
+    preds2 = dummy.predict(X4)
+    assert len(preds2) == 5
+    m2 = MockClassifierFullTags()
+    m2.fit(X, y)
+    y_pred = m2.predict(X2)
+    assert len(y_pred) == 5
+    y_pred = m2.predict_proba(X3)
+    assert y_pred.shape == (5, 2)

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -152,6 +152,26 @@ def get_n_cases(X):
     return len(X)
 
 
+def get_n_timepoints(X):
+    """Return the number of timepoints in the first element of a collectiom.
+
+    Handle the single exception of multi index DataFrame.
+
+    Parameters
+    ----------
+    X : collection
+        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+
+    Returns
+    -------
+    int
+        Number of time points in the first case.
+    """
+    # if isinstance(X, pd.DataFrame) and isinstance(X.index, pd.MultiIndex):
+    #     return len(X.index.get_level_values(0).unique())
+    return X[0].shape[1]
+
+
 def get_type(X):
     """Get the string identifier associated with different data structures.
 

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -167,9 +167,17 @@ def get_n_timepoints(X):
     int
         Number of time points in the first case.
     """
-    # if isinstance(X, pd.DataFrame) and isinstance(X.index, pd.MultiIndex):
-    #     return len(X.index.get_level_values(0).unique())
-    return X[0].shape[1]
+    t = get_type(X)
+    if t in ["numpy3D", "np-list"]:
+        return X[0].shape[1]
+    if t in ["numpy2D", "df-list"]:
+        return X[0].shape[0]
+    if t == "pd-multiindex":
+        return len(X.index.get_level_values(1).unique())
+    if t == "nested_univ":
+        return X.iloc[0, 0].size
+    if t == "pd-wide":
+        return len(X.iloc[0])
 
 
 def get_type(X):

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -180,6 +180,34 @@ def get_n_timepoints(X):
         return len(X.iloc[0])
 
 
+def get_n_channels(X):
+    """Return the number of timepoints in the first element of a collectiom.
+
+    Handle the single exception of multi index DataFrame.
+
+    Parameters
+    ----------
+    X : collection
+        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+
+    Returns
+    -------
+    int
+        Number of time points in the first case.
+    """
+    t = get_type(X)
+    if t in ["numpy3D", "np-list"]:
+        return X[0].shape[0]
+    if t in ["numpy2D", "pd-wide"]:
+        return 1
+    if t == "df-list":
+        return X[0].shape[1]
+    if t == "pd-multiindex":
+        return len(X.columns)
+    if t == "nested_univ":
+        return X.shape[1]
+
+
 def get_type(X):
     """Get the string identifier associated with different data structures.
 


### PR DESCRIPTION
fixes #1712 

Stores the length of the first series and number of channe;ls in the metadata in fit, which is then checked against the series length/number of channels  in predict and predict proba. Note

1. Because of the number of supported data types, best way is to call a method get_n_timepoints/n_timepoints in validation
2. For variable length data structures it just looks at the length of the first element, and does not do the test if the classifier has unequal_length capability. If the collection is in fact unequal length, then it fails before here. Only case is where it is in an np-list but they are all in fact equal length. This tests if that common length is different to that seen in train 
3. n_channels only checked for multivariate capable classifiers
4. will move the checking function up to base collection estimator because it is common to all collection estimators