### PR TITLE
[BUG] Adding modelcheckpoint callback by default to deep learners when user chooses their own callbacks list

### DIFF
--- a/aeon/classification/deep_learning/_cnn.py
+++ b/aeon/classification/deep_learning/_cnn.py
@@ -259,12 +259,10 @@ class CNNClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/classification/deep_learning/_cnn.py
+++ b/aeon/classification/deep_learning/_cnn.py
@@ -250,17 +250,22 @@ class CNNClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ModelCheckpoint(
                     filepath=self.file_path + self.file_name_ + ".keras",
                     monitor="loss",
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/classification/deep_learning/_encoder.py
+++ b/aeon/classification/deep_learning/_encoder.py
@@ -232,17 +232,22 @@ class EncoderClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ModelCheckpoint(
                     filepath=self.file_path + self.file_name_ + ".keras",
                     monitor="loss",
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/classification/deep_learning/_encoder.py
+++ b/aeon/classification/deep_learning/_encoder.py
@@ -241,12 +241,10 @@ class EncoderClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/classification/deep_learning/_fcn.py
+++ b/aeon/classification/deep_learning/_fcn.py
@@ -250,8 +250,8 @@ class FCNClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -261,9 +261,14 @@ class FCNClassifier(BaseDeepClassifier):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/classification/deep_learning/_fcn.py
+++ b/aeon/classification/deep_learning/_fcn.py
@@ -262,12 +262,10 @@ class FCNClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/classification/deep_learning/_inception_time.py
+++ b/aeon/classification/deep_learning/_inception_time.py
@@ -659,8 +659,8 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -670,9 +670,14 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/classification/deep_learning/_inception_time.py
+++ b/aeon/classification/deep_learning/_inception_time.py
@@ -671,12 +671,10 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/classification/deep_learning/_lite_time.py
+++ b/aeon/classification/deep_learning/_lite_time.py
@@ -514,12 +514,10 @@ class IndividualLITEClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/classification/deep_learning/_lite_time.py
+++ b/aeon/classification/deep_learning/_lite_time.py
@@ -502,8 +502,8 @@ class IndividualLITEClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -513,9 +513,14 @@ class IndividualLITEClassifier(BaseDeepClassifier):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/classification/deep_learning/_mlp.py
+++ b/aeon/classification/deep_learning/_mlp.py
@@ -211,8 +211,8 @@ class MLPClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=200, min_lr=0.1
                 ),
@@ -222,9 +222,14 @@ class MLPClassifier(BaseDeepClassifier):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         if self.use_mini_batch_size:
             mini_batch_size = min(self.batch_size, X.shape[0] // 10)

--- a/aeon/classification/deep_learning/_mlp.py
+++ b/aeon/classification/deep_learning/_mlp.py
@@ -223,12 +223,10 @@ class MLPClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         if self.use_mini_batch_size:

--- a/aeon/classification/deep_learning/_resnet.py
+++ b/aeon/classification/deep_learning/_resnet.py
@@ -257,8 +257,8 @@ class ResNetClassifier(BaseDeepClassifier):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -268,9 +268,14 @@ class ResNetClassifier(BaseDeepClassifier):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         if self.use_mini_batch_size:
             mini_batch_size = min(self.batch_size, X.shape[0] // 10)

--- a/aeon/classification/deep_learning/_resnet.py
+++ b/aeon/classification/deep_learning/_resnet.py
@@ -269,12 +269,10 @@ class ResNetClassifier(BaseDeepClassifier):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         if self.use_mini_batch_size:

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -198,4 +198,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
             save_best_only=True,
         )
 
-        return callbacks + [model_checkpoint_]
+        if isinstance(callbacks, list):
+            return callbacks + [model_checkpoint_]
+        else:
+            return [callbacks] + [model_checkpoint_]

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -188,3 +188,14 @@ class BaseDeepClassifier(BaseClassifier, ABC):
 
         self.classes_ = classes
         self.n_classes_ = len(self.classes_)
+
+    def _get_model_checkpoint_callback(self, callbacks, file_path, file_name):
+        import tensorflow as tf
+
+        model_checkpoint_ = tf.keras.callbacks.ModelCheckpoint(
+            filepath=file_path + file_name + ".keras",
+            monitor="loss",
+            save_best_only=True,
+        )
+
+        return callbacks + [model_checkpoint_]

--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -267,12 +267,10 @@ class AEFCNClusterer(BaseDeepClusterer):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -255,8 +255,8 @@ class AEFCNClusterer(BaseDeepClusterer):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -266,9 +266,14 @@ class AEFCNClusterer(BaseDeepClusterer):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/clustering/deep_learning/_ae_resnet.py
+++ b/aeon/clustering/deep_learning/_ae_resnet.py
@@ -269,8 +269,8 @@ class AEResNetClusterer(BaseDeepClusterer):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -280,9 +280,14 @@ class AEResNetClusterer(BaseDeepClusterer):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         if self.use_mini_batch_size:
             mini_batch_size = min(self.batch_size, X.shape[0] // 10)

--- a/aeon/clustering/deep_learning/_ae_resnet.py
+++ b/aeon/clustering/deep_learning/_ae_resnet.py
@@ -281,12 +281,10 @@ class AEResNetClusterer(BaseDeepClusterer):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         if self.use_mini_batch_size:

--- a/aeon/clustering/deep_learning/base.py
+++ b/aeon/clustering/deep_learning/base.py
@@ -151,3 +151,14 @@ class BaseDeepClusterer(BaseClusterer, ABC):
         clusters_proba = self.clusterer.predict_proba(latent_space)
 
         return clusters_proba
+
+    def _get_model_checkpoint_callback(self, callbacks, file_path, file_name):
+        import tensorflow as tf
+
+        model_checkpoint_ = tf.keras.callbacks.ModelCheckpoint(
+            filepath=file_path + file_name + ".keras",
+            monitor="loss",
+            save_best_only=True,
+        )
+
+        return callbacks + [model_checkpoint_]

--- a/aeon/clustering/deep_learning/base.py
+++ b/aeon/clustering/deep_learning/base.py
@@ -161,4 +161,7 @@ class BaseDeepClusterer(BaseClusterer, ABC):
             save_best_only=True,
         )
 
-        return callbacks + [model_checkpoint_]
+        if isinstance(callbacks, list):
+            return callbacks + [model_checkpoint_]
+        else:
+            return [callbacks] + [model_checkpoint_]

--- a/aeon/regression/deep_learning/_cnn.py
+++ b/aeon/regression/deep_learning/_cnn.py
@@ -269,12 +269,10 @@ class CNNRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_cnn.py
+++ b/aeon/regression/deep_learning/_cnn.py
@@ -260,17 +260,22 @@ class CNNRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ModelCheckpoint(
                     filepath=self.file_path + self.file_name_ + ".keras",
                     monitor="loss",
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_encoder.py
+++ b/aeon/regression/deep_learning/_encoder.py
@@ -246,17 +246,22 @@ class EncoderRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ModelCheckpoint(
                     filepath=self.file_path + self.file_name_ + ".keras",
                     monitor="loss",
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_encoder.py
+++ b/aeon/regression/deep_learning/_encoder.py
@@ -255,12 +255,10 @@ class EncoderRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_fcn.py
+++ b/aeon/regression/deep_learning/_fcn.py
@@ -251,8 +251,8 @@ class FCNRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -262,9 +262,14 @@ class FCNRegressor(BaseDeepRegressor):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_fcn.py
+++ b/aeon/regression/deep_learning/_fcn.py
@@ -263,12 +263,10 @@ class FCNRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_inception_time.py
+++ b/aeon/regression/deep_learning/_inception_time.py
@@ -645,12 +645,10 @@ class IndividualInceptionRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_inception_time.py
+++ b/aeon/regression/deep_learning/_inception_time.py
@@ -633,8 +633,8 @@ class IndividualInceptionRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -644,9 +644,14 @@ class IndividualInceptionRegressor(BaseDeepRegressor):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_lite_time.py
+++ b/aeon/regression/deep_learning/_lite_time.py
@@ -483,8 +483,8 @@ class IndividualLITERegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -494,9 +494,14 @@ class IndividualLITERegressor(BaseDeepRegressor):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_lite_time.py
+++ b/aeon/regression/deep_learning/_lite_time.py
@@ -495,12 +495,10 @@ class IndividualLITERegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_mlp.py
+++ b/aeon/regression/deep_learning/_mlp.py
@@ -221,12 +221,10 @@ class MLPRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         self.history = self.training_model_.fit(

--- a/aeon/regression/deep_learning/_mlp.py
+++ b/aeon/regression/deep_learning/_mlp.py
@@ -209,8 +209,8 @@ class MLPRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=200, min_lr=0.1
                 ),
@@ -220,9 +220,14 @@ class MLPRegressor(BaseDeepRegressor):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         self.history = self.training_model_.fit(
             X,

--- a/aeon/regression/deep_learning/_resnet.py
+++ b/aeon/regression/deep_learning/_resnet.py
@@ -268,8 +268,8 @@ class ResNetRegressor(BaseDeepRegressor):
             self.best_file_name if self.save_best_model else str(time.time_ns())
         )
 
-        self.callbacks_ = (
-            [
+        if self.callbacks is None:
+            self.callbacks_ = [
                 tf.keras.callbacks.ReduceLROnPlateau(
                     monitor="loss", factor=0.5, patience=50, min_lr=0.0001
                 ),
@@ -279,9 +279,14 @@ class ResNetRegressor(BaseDeepRegressor):
                     save_best_only=True,
                 ),
             ]
-            if self.callbacks is None
-            else self.callbacks
-        )
+        else:
+            self.callbacks_, self.model_checkpoint_added_ = (
+                self._get_model_checkpoint_callback(
+                    callbacks=self.callbacks,
+                    file_path=self.file_path,
+                    file_name=self.file_name_,
+                )
+            )
 
         if self.use_mini_batch_size:
             mini_batch_size = min(self.batch_size, X.shape[0] // 10)

--- a/aeon/regression/deep_learning/_resnet.py
+++ b/aeon/regression/deep_learning/_resnet.py
@@ -280,12 +280,10 @@ class ResNetRegressor(BaseDeepRegressor):
                 ),
             ]
         else:
-            self.callbacks_, self.model_checkpoint_added_ = (
-                self._get_model_checkpoint_callback(
-                    callbacks=self.callbacks,
-                    file_path=self.file_path,
-                    file_name=self.file_name_,
-                )
+            self.callbacks_ = self._get_model_checkpoint_callback(
+                callbacks=self.callbacks,
+                file_path=self.file_path,
+                file_name=self.file_name_,
             )
 
         if self.use_mini_batch_size:

--- a/aeon/regression/deep_learning/base.py
+++ b/aeon/regression/deep_learning/base.py
@@ -130,3 +130,14 @@ class BaseDeepRegressor(BaseRegressor, ABC):
 
         self.model_ = tf.keras.models.load_model(model_path)
         self._is_fitted = True
+
+    def _get_model_checkpoint_callback(self, callbacks, file_path, file_name):
+        import tensorflow as tf
+
+        model_checkpoint_ = tf.keras.callbacks.ModelCheckpoint(
+            filepath=file_path + file_name + ".keras",
+            monitor="loss",
+            save_best_only=True,
+        )
+
+        return callbacks + [model_checkpoint_]

--- a/aeon/regression/deep_learning/base.py
+++ b/aeon/regression/deep_learning/base.py
@@ -140,4 +140,7 @@ class BaseDeepRegressor(BaseRegressor, ABC):
             save_best_only=True,
         )
 
-        return callbacks + [model_checkpoint_]
+        if isinstance(callbacks, list):
+            return callbacks + [model_checkpoint_]
+        else:
+            return [callbacks] + [model_checkpoint_]


### PR DESCRIPTION
Fix #1098 
Adds a function to base to append a modelcheckpoint whenever the user does not use the default callbacks
the reason to insist on using modelcheckpoint is because not using the best model for predict simply doesnt make sense :)

Tried the code of the above issue, its working now