### PR TITLE
[MNT] Raise tensorflow bound to >2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all_extras = [
     "stumpy>=1.5.1",
     "ruptures>=1.1.9",
     "tbats>=1.1.0",
-    "tensorflow>=2.12; python_version < '3.12'",
+    "tensorflow>2.13; python_version < '3.12'",
     "torch>=1.13.1",
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all_extras = [
     "stumpy>=1.5.1",
     "ruptures>=1.1.9",
     "tbats>=1.1.0",
-    "tensorflow>2.13; python_version < '3.12'",
+    "tensorflow>=2.14; python_version < '3.12'",
     "torch>=1.13.1",
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",


### PR DESCRIPTION
aeon does not work properly with tensorflow 2.13, see https://github.com/aeon-toolkit/aeon/issues/1477. The current version is 2.16. Conversations with @hadifawaz1999 suggest it is not worth the effort to make things work as the signatures keeps changing. In my experience tensorflow is notoriously bad at backward compatibility, so it makes sense just to enforce a bound I think. Interaction with python 3.12 is still an issue!

Closes https://github.com/aeon-toolkit/aeon/issues/1477