### PR TITLE
[BUG] Use almost equal in random state testing of deep learning

### DIFF
--- a/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
+++ b/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_cls():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.array_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2)

--- a/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
+++ b/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_cls():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)
+                np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
+++ b/aeon/classification/deep_learning/tests/test_random_state_deep_learning.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_cls():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
+++ b/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_clr():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.array_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2)

--- a/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
+++ b/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_clr():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)
+                np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
+++ b/aeon/clustering/deep_learning/tests/test_random_state_deep_learning_cluster.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_clr():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
+++ b/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_rgs():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
+++ b/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_rgs():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.testing.assert_almost_equal(_weight1, _weight2, 4)
+                np.testing.assert_almost_equal(_weight1, _weight2, 4)

--- a/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
+++ b/aeon/regression/deep_learning/tests/test_random_state_deep_regressor.py
@@ -57,4 +57,4 @@ def test_random_state_deep_learning_rgs():
                 _weight1 = np.asarray(weights1[j])
                 _weight2 = np.asarray(weights2[j])
 
-                assert np.array_equal(_weight1, _weight2)
+                assert np.testing.assert_almost_equal(_weight1, _weight2)


### PR DESCRIPTION
same issue we had with LCSS failing, should use almost equal and not equal, random fails on CI even when arrays are equal (floating point issues)