### PR TITLE
[BUG] Add names to create steps_ in CollectionPipeline

### DIFF
--- a/aeon/base/estimator/compose/collection_pipeline.py
+++ b/aeon/base/estimator/compose/collection_pipeline.py
@@ -232,6 +232,9 @@ class BaseCollectionPipeline(_HeterogenousMetaEstimator, BaseCollectionEstimator
         Xt : transformed data
         """
         # transform
+        self.steps_ = self._check_estimators(
+            self._steps, attr_name="steps_", cls_type=SklearnBaseEstimator
+        )
         Xt = X
         for i in range(len(self.steps_)):
             Xt = self.steps_[i][1].fit_transform(X=Xt)


### PR DESCRIPTION
Fixes #1748 
adds this to fit_transform to make sure the attribute in self._steps is stored in self.steps_ in (name,estimator) pairs, as is the convention it seems

```python
    def _fit_transform(self, X, y=None) -> np.ndarray:
        self.steps_ = self._check_estimators(
            self._steps, attr_name="steps_", cls_type=SklearnBaseEstimator
        )
        Xt = X
        for i in range(len(self.steps_)):
            Xt = self.steps_[i][1].fit_transform(X=Xt)
        return Xt
```

