### PR TITLE
[DOC] Typo correction in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -73,7 +73,7 @@ Quarter
 ```
 
 We commonly refer to the number of observations for a time series as `n_timepoints` or
-`n_timepoints`. If a series is multivariate, we refer to the dimensions as channels
+`m_timepoints`. If a series is multivariate, we refer to the dimensions as channels
 (to avoid confusion with the dimensions of array) and in code use `n_channels`.
 Dimensions may also be referred to as variables.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -72,8 +72,7 @@ Quarter
 1971 Q1     1.897371  1.987154    1.909734  3.657771          -0.1
 ```
 
-We commonly refer to the number of observations for a time series as `n_timepoints` or
-`m_timepoints`. If a series is multivariate, we refer to the dimensions as channels
+We commonly refer to the number of observations for a time series as `n_timepoints`. If a series is multivariate, we refer to the dimensions as channels
 (to avoid confusion with the dimensions of array) and in code use `n_channels`.
 Dimensions may also be referred to as variables.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,7 +80,7 @@ Dimensions may also be referred to as variables.
 Different parts of `aeon` work with single series or collections of series. The
 `anomaly detection` and `segmentation` modules will commonly use single series input, while
 `classification`, `regression` and `clustering` modules will use collections of time
-series. Collections of time series may also be referred to a Panels. Collections of
+series. Collections of time series may also be referred to as Panels. Collections of
 time series will often be accompanied by an array of target variables.
 
 ```{code-block} python


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #11841.
<!--
 

#### What does this implement/fix? Explain your changes.
Corrected mistakes within the getting started guide under the Tim Series Data section.
<!--

-->

#### Does your contribution introduce a new dependency? If yes, which one?
No additional dependencies.
<!--

-->

#### Any other comments?
The decision for removing the redundant 'n_timepoints'  was supported by Antoine.
