### PR TITLE
[ENH] Improve deep learning networks test coverage

### DIFF
--- a/aeon/networks/tests/test_all_networks.py
+++ b/aeon/networks/tests/test_all_networks.py
@@ -35,7 +35,7 @@ def test_all_networks_functionality(network):
     """Test the functionality of all networks."""
     input_shape = (100, 2)
 
-    if not (network.__name__ in ["BaseDeepLearningNetwork", "EncoderNetwork"]):
+    if not (network.__name__ in ["BaseDeepLearningNetwork"]):
         if _check_soft_dependencies(
             network._config["python_dependencies"], severity="none"
         ) and _check_python_version(network._config["python_version"], severity="none"):

--- a/aeon/networks/tests/test_cnn.py
+++ b/aeon/networks/tests/test_cnn.py
@@ -1,0 +1,22 @@
+"""Tests for the CNN Model."""
+
+import pytest
+
+from aeon.networks import TimeCNNNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+__maintainer__ = []
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_cnn_input_shape_padding():
+    """Test of CNN network with input_shape < 60."""
+    input_shape = (40, 2)
+    network = TimeCNNNetwork()
+    input_layer, output_layer = network.build_network(input_shape=input_shape)
+
+    assert input_layer is not None
+    assert output_layer is not None

--- a/aeon/networks/tests/test_inception.py
+++ b/aeon/networks/tests/test_inception.py
@@ -1,0 +1,74 @@
+"""Tests for the Inception Model."""
+
+import pytest
+
+from aeon.networks import InceptionNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+__maintainer__ = []
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_inceptionnetwork_bottleneck():
+    """Test of Inception network without bottleneck."""
+    input_shape = (100, 2)
+    inception = InceptionNetwork(use_bottleneck=False)
+    input_layer, output_layer = inception.build_network(input_shape=input_shape)
+
+    assert input_layer is not None
+    assert output_layer is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_inceptionnetwork_max_pooling():
+    """Test of Inception network without max pooling."""
+    input_shape = (100, 2)
+    inception = InceptionNetwork(use_max_pooling=False)
+    input_layer, output_layer = inception.build_network(input_shape=input_shape)
+
+    assert input_layer is not None
+    assert output_layer is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_inceptionnetwork_custom_filters():
+    """Test of Inception network with custom filters."""
+    input_shape = (100, 2)
+    inception = InceptionNetwork(use_custom_filters=True)
+    input_layer, output_layer = inception.build_network(input_shape=input_shape)
+
+    assert input_layer is not None
+    assert output_layer is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_inceptionnetwork_list_parameters():
+    """Test of Inception network with list parameters not in test_all_networks."""
+    input_shape = (100, 2)
+    depth = 6
+    n_conv_per_layer = [3] * depth
+    use_max_pooling = [True] * depth
+    max_pool_size = [3] * depth
+
+    inception = InceptionNetwork(
+        depth=depth,
+        n_conv_per_layer=n_conv_per_layer,
+        use_max_pooling=use_max_pooling,
+        max_pool_size=max_pool_size,
+    )
+    input_layer, output_layer = inception.build_network(input_shape=input_shape)
+
+    assert input_layer is not None
+    assert output_layer is not None


### PR DESCRIPTION
#### Reference Issues/PRs

Improves #1233

#### What does this implement/fix? Explain your changes.

Add network specific tests to improve coverage of DL networks :
* inception network coverage 67% -> 100%
* encoder network coverage 13% -> 100%
* cnn network coverage 98% -> 99% (last percent is from a deprecated class)

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Any other comments?

AE networks have been ignored as they already have someone working on it with specific tests [ref](https://github.com/aeon-toolkit/aeon/pull/1851#discussion_r1694029339).

There are also 2 networks that can have a better coverage (lite and tapnet) but that have been ignored as they are already skipped in test_all_networks, see #1867.

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
