### PR TITLE
[BUG] get_n_channels check channels consistent

### DIFF
--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -109,7 +109,7 @@ class BaseCollectionEstimator(BaseEstimator):
         Parameters
         ----------
         X : data structure
-           See aeon.registry.COLLECTIONS_DATA_TYPES for details
+           See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details
            on aeon supported data structures.
 
         Returns

--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -57,7 +57,7 @@ class BaseCollectionEstimator(BaseEstimator):
         Parameters
         ----------
         X : collection
-            See aeon.registry.COLLECTIONS_DATA_TYPES for details
+            See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details
             on aeon supported data structures.
         store_metadata : bool, default=True
             Whether to store metadata about X in self.metadata_.
@@ -176,7 +176,7 @@ class BaseCollectionEstimator(BaseEstimator):
         Parameters
         ----------
         X : data structure
-            Must be of type aeon.registry.COLLECTIONS_DATA_TYPES.
+            Must be of type aeon.utils.registry.COLLECTIONS_DATA_TYPES.
 
         Returns
         -------

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -68,7 +68,7 @@ def is_nested_univ_dataframe(X):
     Parameters
     ----------
     X: collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details
         on aeon supported data structures.
 
     Returns
@@ -140,7 +140,7 @@ def get_n_cases(X):
     Parameters
     ----------
     X : collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details.
 
     Returns
     -------
@@ -161,7 +161,7 @@ def get_n_timepoints(X):
     Parameters
     ----------
     X : collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details.
 
     Returns
     -------
@@ -182,14 +182,14 @@ def get_n_timepoints(X):
 
 
 def get_n_channels(X):
-    """Return the number of timepoints in the first element of a collectiom.
+    """Return the number of channels in the first element of a collectiom.
 
     Handle the single exception of multi index DataFrame.
 
     Parameters
     ----------
     X : collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details.
 
     Returns
     -------
@@ -215,7 +215,7 @@ def get_type(X):
     Parameters
     ----------
     X : collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details.
 
     Returns
     -------
@@ -287,7 +287,7 @@ def is_equal_length(X):
     Parameters
     ----------
     X : collection
-        See aeon.registry.COLLECTIONS_DATA_TYPES for details.
+        See aeon.utils.registry.COLLECTIONS_DATA_TYPES for details.
 
     Returns
     -------

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -197,11 +197,23 @@ def get_n_channels(X):
         Number of time points in the first case.
     """
     t = get_type(X)
-    if t in ["numpy3D", "np-list"]:
+    if t == "numpy3D":
+        return X[0].shape[0]
+    if t == "np-list":
+        if not all(arr.shape[0] == X[0].shape[0] for arr in X):
+            raise ValueError(
+                f"ERROR: number of channels is not consistent. "
+                f"Found values: {np.unique([arr.shape[0] for arr in X])}."
+            )
         return X[0].shape[0]
     if t in ["numpy2D", "pd-wide"]:
         return 1
     if t == "df-list":
+        if not all(arr.shape[1] == X[0].shape[1] for arr in X):
+            raise ValueError(
+                f"ERROR: number of channels is not consistent. "
+                f"Found values: {np.unique([arr.shape[1] for arr in X])}."
+            )
         return X[0].shape[1]
     if t == "pd-multiindex":
         return len(X.columns)

--- a/aeon/utils/validation/collection.py
+++ b/aeon/utils/validation/collection.py
@@ -194,7 +194,13 @@ def get_n_channels(X):
     Returns
     -------
     int
-        Number of time points in the first case.
+        Number of channels in the first case.
+
+    Raises
+    ------
+    ValueError
+        X is list of 2D numpy but number of channels is not consistent.
+        X is list of 2D pd.DataFrames but number of channels is not consistent.
     """
     t = get_type(X)
     if t == "numpy3D":


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #1888

#### What does this implement/fix? Explain your changes.

1. Add exceptions in `get_n_channels` to be raised if list of 2D numpy/pandas don't have consistent channels.
2. Replace some `aeon.registry.COLLECTIONS_DATA_TYPES` in doc with `aeon.utils.registry.COLLECTIONS_DATA_TYPES` to have correct path.
3. Fix `get_n_channels` doc (was copied and pasted from `get_n_timepoints`)

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

In `get_n_timepoints` doc : 
```
    Handles the single exception of multi index DataFrames. If unequal length series,
    returns the length of the first series.
```
`get_n_cases` and `get_n_channels` have the doc : 
```
    Handle the single exception of multi index DataFrame.
```

I don't get the doc, so I would like another opinion for what it means in `get_n_cases` and `get_n_channels`.

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
