### PR TITLE
[DOC] Change order of build and install instructions for clarity

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -315,6 +315,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="12.5%"><a href="https://github.com/xiaopu222"><img src="https://avatars.githubusercontent.com/u/118000577?v=4?s=80" width="80px;" alt="xiaopu222"/><br /><sub><b>xiaopu222</b></sub></a><br /><a href="https://github.com/aeon-toolkit/aeon/commits?author=xiaopu222" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="12.5%"><a href="https://github.com/phershbe"><img src="https://avatars2.githubusercontent.com/u/25594870?v=4?s=80" width="80px;" alt="phershbe"/><br /><sub><b>phershbe</b></sub></a><br /><a href="https://github.com/aeon-toolkit/aeon/commits?author=phershbe" title="Documentation">📖</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -41,6 +41,13 @@ and type:
 pip install --editable .[dev]
 ```
 
+**If this results in a "no matches found" error**, it may be due to how your shell
+handles special characters. Try surrounding the dependency portion with quotes:
+
+```{code-block} powershell
+pip install --editable ."[dev]"
+```
+
 Alternatively, the `.` may be replaced with a full or relative path to the root
 directory.
 
@@ -53,13 +60,6 @@ If you need to work with optional dependencies, it you can also install the
 
 ```{code-block} powershell
 pip install --editable .[dev,all_extras]
-```
-
-**If this results in a "no matches found" error**, it may be due to how your shell
-handles special characters. Try surrounding the dependency portion with quotes:
-
-```{code-block} powershell
-pip install --editable ."[dev]"
 ```
 
 ## Step 3 - Install pre-commit


### PR DESCRIPTION
Issue #1914

There is a problem where `pip install --editable .[dev]` needs to have quotation marks `pip install --editable ."[dev]"` because of how your shell handles special characters.

It was explained in the documentation, but the solution was at the bottom of the section not so close to the issue that it was explaining, so the solution was moved in order to be immediately after the issue.