### PR TITLE
[DOC] Grammar corrections to developer installation and installation

### DIFF
--- a/docs/developer_guide/dev_installation.md
+++ b/docs/developer_guide/dev_installation.md
@@ -41,11 +41,11 @@ and type:
 pip install --editable .[dev]
 ```
 
-**If this results in a "no matches found" error**, it may be due to how your shell
-handles special characters. Try surrounding the dependency portion with quotes:
+```{note}
+    If this results in a "no matches found" error, it may be due to how your shell
+    handles special characters. Try surrounding the dependency portion with quotes i.e.
 
-```{code-block} powershell
-pip install --editable ."[dev]"
+    pip install --editable ."[dev]"
 ```
 
 Alternatively, the `.` may be replaced with a full or relative path to the root

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,8 @@ develop the `aeon` codebase and for most other contributions to the project. [Ou
 developer installation guide is available here](../developer_guide/dev_installation).
 
 ```{note}
-    While we try to keep output similar between OS and Python version, we cannot guarantee estimators will output the same results for macOS ARM
-    processors.
+    While we try to keep output similar between OS and Python version, we cannot
+    guarantee estimators will output the same results for macOS ARM processors.
 ```
 
 ## Optional Dependencies

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ develop the `aeon` codebase and for most other contributions to the project. [Ou
 developer installation guide is available here](../developer_guide/dev_installation).
 
 ```{note}
-    While we try to keep output similar between OS and Python version, we cannot guarantee estimators will output the same results for macOS ARM        
+    While we try to keep output similar between OS and Python version, we cannot guarantee estimators will output the same results for macOS ARM
     processors.
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,8 @@ develop the `aeon` codebase and for most other contributions to the project. [Ou
 developer installation guide is available here](../developer_guide/dev_installation).
 
 ```{note}
-    While we try to keep output similar between OS and Python version, we cannot
-    guarantee the estimators will output the same results for macOS ARM processors.
+    While we try to keep output similar between OS and Python version, we cannot guarantee estimators will output the same results for macOS ARM        
+    processors.
 ```
 
 ## Optional Dependencies

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,8 @@ develop the `aeon` codebase and for most other contributions to the project. [Ou
 developer installation guide is available here](../developer_guide/dev_installation).
 
 ```{note}
-    While we try to keep output similar between OS and Python version. We cannot
-    guarentee the estimators will output the same results for macOS ARM processors.
+    While we try to keep output similar between OS and Python version, we cannot
+    guarantee the estimators will output the same results for macOS ARM processors.
 ```
 
 ## Optional Dependencies


### PR DESCRIPTION
Issue #1914

The second pull request for the issue above as more improvements were found during the discussion.

dev-installation.md got an error solution turned into a note

installation.md got grammar and spelling corrected