### PR TITLE
[BUG] Fixed CLARA issue

### DIFF
--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -10,6 +10,7 @@ from sklearn.utils import check_random_state
 
 from aeon.clustering._k_medoids import TimeSeriesKMedoids
 from aeon.clustering.base import BaseClusterer
+from aeon.distances import pairwise_distance
 
 
 class TimeSeriesCLARA(BaseClusterer):
@@ -158,8 +159,9 @@ class TimeSeriesCLARA(BaseClusterer):
         else:
             n_samples = self.n_samples
 
-        best_score = np.inf
+        best_inertia = np.inf
         best_pam = None
+        best_labels = None
         for _ in range(self.n_sampling_iters):
             sample_idxs = np.arange(n_samples)
             if n_samples < n_cases:
@@ -181,11 +183,24 @@ class TimeSeriesCLARA(BaseClusterer):
                 method="pam",
             )
             pam.fit(X[sample_idxs])
-            if pam.inertia_ < best_score:
-                best_pam = pam
+            curr_centers = pam.cluster_centers_
+            if isinstance(pam.distance, str):
+                pairwise_matrix = pairwise_distance(
+                    X, curr_centers, metric=self.distance, **pam._distance_params
+                )
+            else:
+                pairwise_matrix = pairwise_distance(
+                    X, curr_centers, pam._distance_callable, **pam._distance_params
+                )
+            curr_td = pairwise_matrix.min(axis=1).sum()
 
-        self.labels_ = best_pam.labels_
-        self.inertia_ = best_pam.inertia_
+            if curr_td < best_inertia:
+                best_pam = pam
+                best_inertia = curr_td
+                best_labels = pairwise_matrix.argmin(axis=1)
+
+        self.labels_ = best_labels
+        self.inertia_ = best_inertia
         self.cluster_centers_ = best_pam.cluster_centers_
         self.n_iter_ = best_pam.n_iter_
         self._kmedoids_instance = best_pam

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -34,17 +34,19 @@ def test_clara_uni():
     proba = clara.predict_proba(X_test)
     assert np.array_equal(
         test_medoids_result,
-        [0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1],
+        [1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0],
     )
     assert np.array_equal(
         train_medoids_result,
-        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0],
+        [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1],
     )
-    assert test_score == 0.4789473684210526
-    assert train_score == 0.4789473684210526
-    assert np.isclose(clara.inertia_, 44.156819900725814)
+    assert test_score == 0.5210526315789473
+    assert train_score == 0.5578947368421052
+    assert np.isclose(clara.inertia_, 78.79839208236065)
     assert clara.n_iter_ == 2
-    assert np.array_equal(clara.labels_, [0, 0, 1, 0, 1, 1, 1, 0, 1, 1])
+    assert np.array_equal(
+        clara.labels_, [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1]
+    )
     assert isinstance(clara.cluster_centers_, np.ndarray)
     for val in proba:
         assert np.count_nonzero(val == 1.0) == 1
@@ -77,17 +79,19 @@ def test_clara_multi():
     proba = clara.predict_proba(X_test)
     assert np.array_equal(
         test_medoids_result,
-        [0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+        [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
     )
     assert np.array_equal(
         train_medoids_result,
-        [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1],
     )
     assert test_score == 0.4789473684210526
     assert train_score == 0.5578947368421052
-    assert np.isclose(clara.inertia_, 95.91411895660636)
+    assert np.isclose(clara.inertia_, 1900.6752544011563)
     assert clara.n_iter_ == 3
-    assert np.array_equal(clara.labels_, [1, 1, 1, 1, 1, 1, 0, 1, 1, 1])
+    assert np.array_equal(
+        clara.labels_, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1]
+    )
     assert isinstance(clara.cluster_centers_, np.ndarray)
     for val in proba:
         assert np.count_nonzero(val == 1.0) == 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR fixes a bug with the CLARA clusterer where it was using the inertia of the subset of time series rather than across the whole dataset to determine the best version.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
