### PR TITLE
[ENH] add type hints to _shapelet_transform.py __init__ method

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -12,7 +12,7 @@ import time
 from typing import Optional, Union
 
 import numpy as np
-from joblib import Parallel, delayed, ParallelBackendBase
+from joblib import Parallel, ParallelBackendBase, delayed
 from numba import njit
 from numba.typed.typedlist import List
 from sklearn import preprocessing
@@ -160,7 +160,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
         time_limit_in_minutes: Union[int, float] = 0.0,
         contract_max_n_shapelet_samples: Union[int, float] = np.inf,
         n_jobs: int = 1,
-        parallel_backend: Union[str, ParallelBackendBase, None] = None,
+        parallel_backend = None,
         batch_size: Optional[int] = 100,
         random_state: Optional[int] = None,
     ) -> None:

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -9,9 +9,10 @@ __all__ = ["RandomShapeletTransform"]
 import heapq
 import math
 import time
+from typing import Optional, Union
 
 import numpy as np
-from joblib import Parallel, delayed
+from joblib import Parallel, delayed, ParallelBackendBase
 from numba import njit
 from numba.typed.typedlist import List
 from sklearn import preprocessing
@@ -63,10 +64,10 @@ class RandomShapeletTransform(BaseCollectionTransformer):
         Upper bound on candidate shapelet lengths. If None no max length is used.
     remove_self_similar : boolean, default=True
         Remove overlapping "self-similar" shapelets when merging candidate shapelets.
-    time_limit_in_minutes : int, default=0
+    time_limit_in_minutes : int or float, default=0.0
         Time contract to limit build time in minutes, overriding n_shapelet_samples.
         Default of 0 means n_shapelet_samples is used.
-    contract_max_n_shapelet_samples : int, default=np.inf
+    contract_max_n_shapelet_samples : int or float, default=np.inf
         Max number of shapelets to extract when time_limit_in_minutes is set.
     n_jobs : int, default=1
         The number of jobs to run in parallel for both `fit` and `transform`.
@@ -151,18 +152,18 @@ class RandomShapeletTransform(BaseCollectionTransformer):
 
     def __init__(
         self,
-        n_shapelet_samples=10000,
-        max_shapelets=None,
-        min_shapelet_length=3,
-        max_shapelet_length=None,
-        remove_self_similar=True,
-        time_limit_in_minutes=0.0,
-        contract_max_n_shapelet_samples=np.inf,
-        n_jobs=1,
-        parallel_backend=None,
-        batch_size=100,
-        random_state=None,
-    ):
+        n_shapelet_samples: int = 10000,
+        max_shapelets: Optional[int] = None,
+        min_shapelet_length: int = 3,
+        max_shapelet_length: Optional[int] = None,
+        remove_self_similar: bool = True,
+        time_limit_in_minutes: Union[int, float] = 0.0,
+        contract_max_n_shapelet_samples: Union[int, float] = np.inf,
+        n_jobs: int = 1,
+        parallel_backend: Union[str, ParallelBackendBase, None] = None,
+        batch_size: Optional[int] = 100,
+        random_state: Optional[int] = None,
+    ) -> None:
         self.n_shapelet_samples = n_shapelet_samples
         self.max_shapelets = max_shapelets
         self.min_shapelet_length = min_shapelet_length

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -160,7 +160,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
         time_limit_in_minutes: Union[int, float] = 0.0,
         contract_max_n_shapelet_samples: Union[int, float] = np.inf,
         n_jobs: int = 1,
-        parallel_backend = None,
+        parallel_backend=None,
         batch_size: Optional[int] = 100,
         random_state: Optional[int] = None,
     ) -> None:


### PR DESCRIPTION
#### Reference Issues/PRs
- Part of #1910
- References #1454

#### What does this implement/fix? Explain your changes.
- Add type hints to `__init__` method in _shapelet_transform.py

#### Does your contribution introduce a new dependency? If yes, which one?
- New dependency added: "typing" library

#### Any other comments?
1) "contract_max_n_shapelet_samples" type -> Union[int, float] because np.inf (float type) is a default
2) "time_limit_in_minutes" type -> Union[int, float] for flexibility. Documentation had int, but default value was 0.0 originally. 
