### PR TITLE
[ENH/DOC] Unsupervised and semi-supervised usage of PyODAdapter

### DIFF
--- a/aeon/anomaly_detection/base.py
+++ b/aeon/anomaly_detection/base.py
@@ -46,19 +46,23 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
         Unsupervised (default):
             Unsupervised detectors do not require any training data and can directly be
             used on the target time series. Their tags are set to ``fit_is_empty=True``
-            and ``requires_y=False``.
+            and ``requires_y=False``. You would usually call the ``fit_predict`` method
+            on these detectors.
         Semi-supervised:
             Semi-supervised detectors require a training step on a time series without
             anomalies (normal behaving time series). The target value ``y`` would
             consist of only zeros. Thus, these algorithms have logic in the ``fit``
             method, but do not require the target values. Their tags are set to
-            ``fit_is_empty=False`` and ``requires_y=False``.
+            ``fit_is_empty=False`` and ``requires_y=False``. You would usually first
+            call the ``fit`` method on the training data and then the ``predict``
+            method for your target time series.
         Supervised:
             Supervised detectors require a training step on a time series with known
             anomalies (anomalies should be present and must be annotated). The detector
             implements the ``fit`` method, and the target value ``y`` consists of zeros
             and ones. Their tags are, thus, set to ``fit_is_empty=False`` and
-            ``requires_y=True``.
+            ``requires_y=True``. You would usually first call the ``fit`` method on the
+            training data and then the ``predict`` method for your target time series.
 
     Parameters
     ----------

--- a/aeon/datasets/dataset_collections.py
+++ b/aeon/datasets/dataset_collections.py
@@ -1,7 +1,7 @@
 """
 List of datasets available for classification, regression and forecasting archives.
 
-The data can also be used for clustering.
+The classification and regression data can also be used for clustering.
 
 Classification data can be downloaded directly from the timeseriesclassification.com
 archive.

--- a/docs/api_reference/anomaly_detection.rst
+++ b/docs/api_reference/anomaly_detection.rst
@@ -4,9 +4,64 @@ Anomaly Detection
 =================
 
 Time Series Anomaly Detection aims at discovering regions of a time series that in
-some way not representative of the underlying generative process.
+some way are not representative of the underlying generative process.
 The :mod:`aeon.anomaly_detection` module contains algorithms and tools
-for time series anomaly detection.
+for time series anomaly detection. The detectors have different capabilities that can
+be grouped into the following categories, where ``m`` is the number of time points and
+``d`` is the number of channels for a time series:
+
+Input data format (one of the following):
+    Univariate series (default):
+        Example: :class:`~aeon.anomaly_detection.MERLIN`.
+
+        - np.ndarray, shape ``(m,)``, ``(m, 1)`` or ``(1, m)`` depending on axis.
+        - pd.DataFrame, shape ``(m, 1)`` or ``(1, m)`` depending on axis.
+        - pd.Series, shape ``(m,)``.
+    Multivariate series:
+        Example: :class:`~aeon.anomaly_detection.KMeansAD`.
+
+        - np.ndarray array, shape ``(m, d)`` or ``(d, m)`` depending on axis.
+        - pd.DataFrame ``(m, d)`` or ``(d, m)`` depending on axis.
+
+Output data format (one of the following):
+    Anomaly scores (default):
+        np.ndarray, shape ``(m,)`` of type float. For each point of the input time
+        series, the anomaly score is a float value indicating the degree of
+        anomalousness. The higher the score, the more anomalous the point. The
+        detectors return raw anomaly scores that are not normalized.
+        Example: :class:`~aeon.anomaly_detection.PyODAdapter`.
+    Binary classification:
+        np.ndarray, shape ``(m,)`` of type bool or int. For each point of the input
+        time series, the output is a boolean or integer value indicating whether the
+        point is anomalous (``True``/``1``) or not (``False``/``0``).
+        Example: :class:`~aeon.anomaly_detection.STRAY`.
+
+Detector learning types:
+    Unsupervised (default):
+        Unsupervised detectors do not require any training data and can directly be
+        used on the target time series. You would usually call the ``fit_predict``
+        method on these detectors.
+        Example: :class:`~aeon.anomaly_detection.DWT_MLEAD`.
+    Semi-supervised:
+        Semi-supervised detectors require a training step on a time series without
+        anomalies (normal behaving time series). The target value ``y`` would
+        consist of only zeros. You would usually first call the ``fit`` method on the
+        training time series and then the ``predict`` method on your target time series.
+        Example: :class:`~aeon.anomaly_detection.KMeansAD`.
+    Supervised:
+        Supervised detectors require a training step on a time series with known
+        anomalies (anomalies should be present and must be annotated). The detector
+        implements the ``fit`` method, and the target value ``y`` consists of zeros
+        and ones; ones indicating points of an anomaly. You would usually first call
+        the ``fit`` method on the training data and then the ``predict`` method on your
+        target time series.
+
+Each detector in this module specifies its supported input data format, output data
+format, and learning type as an overview table in its documentation. Some detectors
+support multiple learning types.
+
+Detectors
+---------
 
 .. currentmodule:: aeon.anomaly_detection
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1837

#### What does this implement/fix? Explain your changes.

- Code cleanup in KMeansAD
- Document different detector categories in docs
- Enhance PyODAdapter to support both `fit_predict` and `fit`-and-`predict` usage

#### Does your contribution introduce a new dependency? If yes, which one?

no

### PR checklist


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.
