### PR TITLE
[BUG] Mapped input index to class index for shapelet viz 

### DIFF
--- a/aeon/visualisation/estimator/_shapelets.py
+++ b/aeon/visualisation/estimator/_shapelets.py
@@ -817,10 +817,11 @@ class ShapeletClassifierVisualizer:
             Number of plots to output, one per shapelet (i.e. the n_shp best shapelets
             for class_id). The default is 1.
         id_example_other : int
-            Sample ID to use for sample of other class. If None, a random one is
-            selected.
+            Sample ID to use for sample of other class. If None, a random one from that
+            class is selected.
         id_example_class : int
-            Sample ID to use for sample of class_id. If None, a random one is selected.
+            Sample ID to use for sample of class_id.If None, a random one from that
+            class is selected.
         scatter_options : dict
             Dictionnary of options passed to the scatter plot of the shapelet values.
         x_plot_options : dict

--- a/aeon/visualisation/estimator/_shapelets.py
+++ b/aeon/visualisation/estimator/_shapelets.py
@@ -869,8 +869,12 @@ class ShapeletClassifierVisualizer:
         mask_other_class_id = np.where(y != class_id)[0]
         if id_example_class is None:
             id_example_class = np.random.choice(mask_class_id)
+        else: 
+            id_example_class = mask_class_id[id_example_class]
         if id_example_other is None:
             id_example_other = np.random.choice(mask_other_class_id)
+        else: 
+            id_example_other = mask_other_class_id[id_example_other]
         figures = []
         for i_shp in shp_ids:
             fig, ax = plt.subplots(**figure_options)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Fixes #1942 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This stops accidental calls to the wrong class.
<!--
A clear and concise description of what you have implemented.
-->
I added a condition where the input param is not None to map the input to the index of time series of the given class. 
#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->
No.
#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->



<!--
Thanks for contributing!
-->
