### PR TITLE
[ENH] Discrete Fourier Approximation Transformer

### DIFF
--- a/aeon/transformations/series/__init__.py
+++ b/aeon/transformations/series/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "BaseSeriesTransformer",
     "ClearSkyTransformer",
     "ClaSPTransformer",
+    "DFTSeriesTransformer",
     "Dobin",
     "MatrixProfileSeriesTransformer",
     "StatsModelsACF",
@@ -26,6 +27,7 @@ from aeon.transformations.series._bkfilter import BKFilter
 from aeon.transformations.series._boxcox import BoxCoxTransformer
 from aeon.transformations.series._clasp import ClaSPTransformer
 from aeon.transformations.series._clear_sky import ClearSkyTransformer
+from aeon.transformations.series._dft import DFTSeriesTransformer
 from aeon.transformations.series._dobin import Dobin
 from aeon.transformations.series._matrix_profile import MatrixProfileSeriesTransformer
 from aeon.transformations.series._pca import PCASeriesTransformer

--- a/aeon/transformations/series/_dft.py
+++ b/aeon/transformations/series/_dft.py
@@ -1,0 +1,88 @@
+"""Discrete Fourier Approximation filter transformation."""
+
+__maintainer__ = ["Cyril-Meyer"]
+__all__ = ["DFTSeriesTransformer"]
+
+
+import numpy as np
+
+from aeon.transformations.series.base import BaseSeriesTransformer
+
+
+class DFTSeriesTransformer(BaseSeriesTransformer):
+    """Filter a times series using Discrete Fourier Approximation (DFT).
+
+    Parameters
+    ----------
+    r : float
+        Proportion of Fourier terms to retain [0, 1]
+
+    sort : bool
+        Sort the Fourier terms by amplitude to keep most important terms
+
+    Notes
+    -----
+    More information of the NumPy FFT functions used
+    https://numpy.org/doc/stable/reference/routines.fft.html
+
+    References
+    ----------
+    .. [1] Cooley, J.W., & Tukey, J.W. (1965).
+       An algorithm for the machine calculation of complex Fourier series.
+       Mathematics of Computation, 19, 297-301.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.transformations.series._dft import DFTSeriesTransformer
+    >>> X = np.random.random((2, 100)) # Random series length 100
+    >>> dft = DFTSeriesTransformer()
+    >>> X_ = dft.fit_transform(X)
+    >>> X_.shape
+    (2, 100)
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "X_inner_type": "np.ndarray",
+        "fit_is_empty": True,
+    }
+
+    def __init__(self, r=0.5, sort=False):
+        self.r = r
+        self.sort = sort
+        super().__init__(axis=1)
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            time series in shape (n_channels, n_timepoints)
+        y : ignored argument for interface compatibility
+
+        Returns
+        -------
+        transformed version of X
+        """
+        # Compute DFT
+        dft = np.fft.fft(X)
+
+        # Mask array of terms to keep and number of terms to keep
+        mask = np.zeros_like(dft, dtype=bool)
+        keep = max(int(self.r * dft.shape[1]), 1)
+
+        # If sort is set, sort the indices by the decreasing dft amplitude
+        if self.sort:
+            sorted_indices = np.argsort(np.abs(dft))[:, ::-1]
+            for i in range(dft.shape[0]):
+                mask[i, sorted_indices[i, 0:keep]] = True
+        # Else, keep the first terms
+        else:
+            mask[:, 0:keep] = True
+
+        # Invert DFT with masked terms
+        X_ = np.fft.ifft(dft * mask).real
+
+        return X_

--- a/aeon/transformations/series/tests/test_dft.py
+++ b/aeon/transformations/series/tests/test_dft.py
@@ -27,7 +27,6 @@ def test_dft(r, sort):
 
     from aeon.transformations.series._dft import DFTSeriesTransformer
 
-    DFTSeriesTransformer
     dft = DFTSeriesTransformer(r=r, sort=sort)
     x_1 = dft.fit_transform(x1)
     x_2 = dft.fit_transform(x2)

--- a/aeon/transformations/series/tests/test_dft.py
+++ b/aeon/transformations/series/tests/test_dft.py
@@ -1,0 +1,38 @@
+"""Tests for DFT transformation."""
+
+__maintainer__ = []
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("r", [0.00, 0.25, 0.50, 0.75, 1.00])
+@pytest.mark.parametrize("sort", [True, False])
+def test_dft(r, sort):
+    """Test the functionality of DFT transformation."""
+    n_samples = 100
+    t = np.linspace(0, 10, n_samples)
+    x1 = (
+        0.5 * np.sin(2 * np.pi * 1 * t)
+        + 0.2 * np.sin(2 * np.pi * 5 * t)
+        + 0.1 * np.sin(2 * np.pi * 10 * t)
+    )
+    x2 = (
+        0.4 * np.sin(2 * np.pi * 1.5 * t)
+        + 0.3 * np.sin(2 * np.pi * 4 * t)
+        + 0.1 * np.sin(2 * np.pi * 8 * t)
+    )
+    x12 = np.array([x1, x2])
+    x12r = x12 + np.random.random((2, n_samples)) * 0.25
+
+    from aeon.transformations.series._dft import DFTSeriesTransformer
+
+    DFTSeriesTransformer
+    dft = DFTSeriesTransformer(r=r, sort=sort)
+    x_1 = dft.fit_transform(x1)
+    x_2 = dft.fit_transform(x2)
+    x_12 = dft.fit_transform(x12)
+    dft.fit_transform(x12r)
+
+    np.testing.assert_almost_equal(x_1[0], x_12[0], decimal=4)
+    np.testing.assert_almost_equal(x_2[0], x_12[1], decimal=4)

--- a/docs/api_reference/transformations.rst
+++ b/docs/api_reference/transformations.rst
@@ -186,6 +186,14 @@ Filtering and denoising
 
     BKFilter
 
+.. currentmodule:: aeon.transformations.series._dft
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DFTSeriesTransformer
+
 Slope
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Reference Issues/PRs

Implement DFT asked in #1920.

#### What does this implement/fix? Explain your changes.

Add a new transformation, named `DFTSeriesTransformer`.
The simplified algorithm is the following : 
1. Compute FFT
2. Remove a proportion of terms (r paramter)
3. Compute invert FFT

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Removed terms can be sorted by amplitude before removal to keep most important terms instead of first ones.

I based my code using `BKFilter` class as a template.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
-> I will use the bot when the PR is considered as ok.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.
