### PR TITLE
[MNT] Update TSC Datasets

### DIFF
--- a/aeon/datasets/tsc_datasets.py
+++ b/aeon/datasets/tsc_datasets.py
@@ -27,6 +27,10 @@ Ensembles Version 1.0 (HIVE-COTE v1.0). Lecture Notes in Computer Science. in pr
     The great multivariate time series classification bake off: a review and
     experimental evaluation of recent algorithmic advances,
     Data Mining and Knowledge Discovery, 2020.
+[5] Middlehurst, M., Schäfer, P. & Bagnall, A.
+    Bake off redux: a review and experimental evaluation of recent time series
+    classification algorithms. Data Min Knowl Disc 38, 1958–2031 (2024).
+    https://doi.org/10.1007/s10618-024-01022-1
 
 """
 

--- a/aeon/datasets/tsc_datasets.py
+++ b/aeon/datasets/tsc_datasets.py
@@ -632,11 +632,38 @@ tsc_zenodo = {
     "UWaveGestureLibrary": 11206282,
 }
 
-
-# TODO: Add the following datasets:
 # 30 new univariate classification problems used in the bake off [5]. Some are new,
 # some are discrete versions of regression problems, some are equal length versions
 # of the current UCR problems and some are no missing versions of the current 128 UCR.
-# All can be loaded from the timeseriesclassification.com archive directly using the
-# function load_classification. This will download all available versions of the
-# problem in one directory. You can then set which version through function arguments.
+univariate_bake_off_2024 = {
+    "AconityMINIPrinterLarge",  # AconityMINIPrinterLarge_eq
+    "AconityMINIPrinterSmall",  # AconityMINIPrinterSmall_eq
+    "AllGestureWiimoteX",  # AllGestureWiimoteX_eq
+    "AllGestureWiimoteY",  # AllGestureWiimoteY_eq
+    "AllGestureWiimoteZ",  # AllGestureWiimoteZ_eq
+    "AsphaltObstacles",  # AsphaltObstaclesUni_eq
+    "AsphaltPavementType",  # AsphaltPavementTypeUni_eq
+    "AsphaltRegularity",  # AsphaltRegularityUni_eq
+    "Colposcopy",  # Colposcopy
+    "Covid3Month",  # Covid3Month_disc
+    "DodgerLoopDay",  # DodgerLoopDay_nmv
+    "DodgerLoopGame",  # DodgerLoopGame_nmv
+    "DodgerLoopWeekend",  # DodgerLoopWeekend_nmv
+    "ElectricDeviceDetection",  # ElectricDeviceDetection
+    "FloodModeling1",  # FloodModeling1_disc
+    "FloodModeling2",  # FloodModeling2_disc
+    "FloodModeling3",  # FloodModeling3_disc
+    "GestureMidAirD1",  # GestureMidAirD1_eq
+    "GestureMidAirD2",  # GestureMidAirD2_eq
+    "GestureMidAirD3",  # GestureMidAirD3_eq
+    "GesturePebbleZ1",  # GesturePebbleZ1_eq
+    "GesturePebbleZ2",  # GesturePebbleZ2_eq
+    "KeplerLightCurves",  # KeplerLightCurves
+    "MelbournePedestrian",  # MelbournePedestrian_nmv
+    "PhoneHeartbeatSound",  # PhoneHeartbeatSound
+    "PickupGestureWiimoteZ",  # PickupGestureWiimoteZ_eq
+    "PLAID",  # PLAID_eq
+    "ShakeGestureWiimoteZ",  # ShakeGestureWiimoteZ_eq
+    "SharePriceIncrease",  # SharePriceIncrease
+    "Tools",  # Tools
+}


### PR DESCRIPTION
#### Reference Issues/PRs

See also #1828

#### What does this implement/fix? Explain your changes.

Add  `univariate_bake_off_2024` to tsc_datasets with the 30 new univariate classification problems used in the bake off.
Also add the missing reference the the bake off paper.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Choice was to create a "new 30 problem" collection, but we may want to add the new (not all the 30) problems to the 128 UCR univariate collection.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
-> I will use the bot when the PR is considered as ok.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
