### PR TITLE
Added type hints for rsast and sast files

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_rsast.py
+++ b/aeon/transformations/collection/shapelet_based/_rsast.py
@@ -1,3 +1,6 @@
+from typing import List as TypingList
+from typing import Optional, Union
+
 import numpy as np
 import pandas as pd
 from numba import get_num_threads, njit, prange, set_num_threads
@@ -8,7 +11,7 @@ from aeon.utils.validation import check_n_jobs
 
 
 @njit(fastmath=False)
-def _apply_kernel(ts, arr):
+def _apply_kernel(ts: np.ndarray, arr: np.ndarray) -> float:
     d_best = np.inf  # sdist
     m = ts.shape[0]
     kernel = arr[~np.isnan(arr)]  # ignore nan
@@ -22,7 +25,7 @@ def _apply_kernel(ts, arr):
 
 
 @njit(parallel=True, fastmath=True)
-def _apply_kernels(X, kernels):
+def _apply_kernels(X: np.ndarray, kernels: np.ndarray) -> np.ndarray:
     nbk = len(kernels)
     out = np.zeros((X.shape[0], nbk), dtype=np.float32)
     for i in prange(nbk):
@@ -96,11 +99,11 @@ class RSAST(BaseCollectionTransformer):
 
     def __init__(
         self,
-        n_random_points=10,
-        len_method="both",
-        nb_inst_per_class=10,
-        seed=None,
-        n_jobs=-1,
+        n_random_points: int = 10,
+        len_method: str = "both",
+        nb_inst_per_class: int = 10,
+        seed: int = None,
+        n_jobs: int = -1,
     ):
         self.n_random_points = n_random_points
         self.len_method = len_method
@@ -113,7 +116,7 @@ class RSAST(BaseCollectionTransformer):
         self._kernels_generators = {}  # Reference time series
         super().__init__()
 
-    def _fit(self, X, y):
+    def _fit(self, X: np.ndarray, y: Union[np.ndarray, TypingList]) -> "RSAST":
         from scipy.stats import ConstantInputWarning, DegenerateDataWarning, f_oneway
         from statsmodels.tsa.stattools import acf, pacf
 
@@ -300,7 +303,9 @@ class RSAST(BaseCollectionTransformer):
 
         return self
 
-    def _transform(self, X, y=None):
+    def _transform(
+        self, X: np.ndarray, y: Optional[Union[np.ndarray, TypingList]] = None
+    ) -> np.ndarray:
         """Transform the input X using the generated subsequences.
 
         Parameters

--- a/aeon/transformations/collection/shapelet_based/_rsast.py
+++ b/aeon/transformations/collection/shapelet_based/_rsast.py
@@ -1,4 +1,4 @@
-from typing import List as TypingList
+from typing import List 
 from typing import Optional, Union
 
 import numpy as np
@@ -103,7 +103,7 @@ class RSAST(BaseCollectionTransformer):
         len_method: str = "both",
         nb_inst_per_class: int = 10,
         seed: int = None,
-        n_jobs: int = -1,
+        n_jobs: int = 1 # Parllel Processing
     ):
         self.n_random_points = n_random_points
         self.len_method = len_method
@@ -116,7 +116,7 @@ class RSAST(BaseCollectionTransformer):
         self._kernels_generators = {}  # Reference time series
         super().__init__()
 
-    def _fit(self, X: np.ndarray, y: Union[np.ndarray, TypingList]) -> "RSAST":
+    def _fit(self, X: np.ndarray, y: Union[np.ndarray, List]) -> "RSAST":
         from scipy.stats import ConstantInputWarning, DegenerateDataWarning, f_oneway
         from statsmodels.tsa.stattools import acf, pacf
 
@@ -304,7 +304,7 @@ class RSAST(BaseCollectionTransformer):
         return self
 
     def _transform(
-        self, X: np.ndarray, y: Optional[Union[np.ndarray, TypingList]] = None
+        self, X: np.ndarray, y: Optional[Union[np.ndarray, List]] = None
     ) -> np.ndarray:
         """Transform the input X using the generated subsequences.
 

--- a/aeon/transformations/collection/shapelet_based/_sast.py
+++ b/aeon/transformations/collection/shapelet_based/_sast.py
@@ -1,5 +1,4 @@
-from typing import List 
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 from numba import get_num_threads, njit, prange, set_num_threads
@@ -95,7 +94,7 @@ class SAST(BaseCollectionTransformer):
         stride: int = 1,
         nb_inst_per_class: int = 1,
         seed: Optional[int] = None,
-        n_jobs: int = 1, # Parallel processing
+        n_jobs: int = 1,  # Parallel processing
     ):
         super().__init__()
         self.lengths = lengths

--- a/aeon/transformations/collection/shapelet_based/_sast.py
+++ b/aeon/transformations/collection/shapelet_based/_sast.py
@@ -1,4 +1,4 @@
-from typing import List as TypingList
+from typing import List 
 from typing import Optional, Union
 
 import numpy as np
@@ -95,7 +95,7 @@ class SAST(BaseCollectionTransformer):
         stride: int = 1,
         nb_inst_per_class: int = 1,
         seed: Optional[int] = None,
-        n_jobs: int = -1,
+        n_jobs: int = 1, # Parallel processing
     ):
         super().__init__()
         self.lengths = lengths
@@ -107,7 +107,7 @@ class SAST(BaseCollectionTransformer):
         self.n_jobs = n_jobs
         self.seed = seed
 
-    def _fit(self, X: np.ndarray, y: Union[np.ndarray, TypingList]) -> "SAST":
+    def _fit(self, X: np.ndarray, y: Union[np.ndarray, List]) -> "SAST":
         """Select reference time series and generate subsequences from them.
 
         Parameters
@@ -175,7 +175,7 @@ class SAST(BaseCollectionTransformer):
         return self
 
     def _transform(
-        self, X: np.ndarray, y: Optional[Union[np.ndarray, TypingList]] = None
+        self, X: np.ndarray, y: Optional[Union[np.ndarray, List]] = None
     ) -> np.ndarray:
         """Transform the input X using the generated subsequences.
 

--- a/aeon/transformations/collection/shapelet_based/_sast.py
+++ b/aeon/transformations/collection/shapelet_based/_sast.py
@@ -1,3 +1,6 @@
+from typing import List as TypingList
+from typing import Optional, Union
+
 import numpy as np
 from numba import get_num_threads, njit, prange, set_num_threads
 
@@ -7,7 +10,7 @@ from aeon.utils.validation import check_n_jobs
 
 
 @njit(fastmath=False)
-def _apply_kernel(ts, arr):
+def _apply_kernel(ts: np.ndarray, arr: np.ndarray) -> float:
     d_best = np.inf  # sdist
     m = ts.shape[0]
     kernel = arr[~np.isnan(arr)]  # ignore nan
@@ -22,7 +25,7 @@ def _apply_kernel(ts, arr):
 
 
 @njit(parallel=True, fastmath=True)
-def _apply_kernels(X, kernels):
+def _apply_kernels(X: np.ndarray, kernels: np.ndarray) -> np.ndarray:
     nbk = len(kernels)
     out = np.zeros((X.shape[0], nbk), dtype=np.float32)
     for i in prange(nbk):
@@ -88,11 +91,11 @@ class SAST(BaseCollectionTransformer):
 
     def __init__(
         self,
-        lengths=None,
-        stride=1,
-        nb_inst_per_class=1,
-        seed=None,
-        n_jobs=-1,
+        lengths: Optional[np.ndarray] = None,
+        stride: int = 1,
+        nb_inst_per_class: int = 1,
+        seed: Optional[int] = None,
+        n_jobs: int = -1,
     ):
         super().__init__()
         self.lengths = lengths
@@ -104,7 +107,7 @@ class SAST(BaseCollectionTransformer):
         self.n_jobs = n_jobs
         self.seed = seed
 
-    def _fit(self, X, y):
+    def _fit(self, X: np.ndarray, y: Union[np.ndarray, TypingList]) -> "SAST":
         """Select reference time series and generate subsequences from them.
 
         Parameters
@@ -171,7 +174,9 @@ class SAST(BaseCollectionTransformer):
                     k += 1
         return self
 
-    def _transform(self, X, y=None):
+    def _transform(
+        self, X: np.ndarray, y: Optional[Union[np.ndarray, TypingList]] = None
+    ) -> np.ndarray:
         """Transform the input X using the generated subsequences.
 
         Parameters


### PR DESCRIPTION

 What does this implement/fix? Explain your changes.

Added type hints for rsast and sast files under shapelet based collection transformation.

#1910 








