### PR TITLE
[MNT] Fast release workflow

### DIFF
--- a/.github/workflows/fast_release.yml
+++ b/.github/workflows/fast_release.yml
@@ -1,0 +1,44 @@
+# Makes a release without testing. Don't run this unless you have to.
+name: Fast release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-project:
+    needs: check-manifest
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Build project
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Store build files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          retention-days: 5
+
+  upload-wheels:
+    needs: test-wheels
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/fast_release.yml
+++ b/.github/workflows/fast_release.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build-project:
-    needs: check-manifest
     runs-on: ubuntu-22.04
 
     steps:
@@ -29,7 +28,6 @@ jobs:
           retention-days: 5
 
   upload-wheels:
-    needs: test-wheels
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
A workflow to make releases without running tests. Should not be used in regular circumstances. Adding now because we need a release for ECML and the old Ubuntu runner bug for extended testing has reappeared.