### PR TITLE
Fixes : [MNT] Remove Reshape layer from Deep Learning Clusterers #1794

### DIFF
--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -229,9 +229,7 @@ class AEFCNClusterer(BaseDeepClusterer):
         input_layer = tf.keras.layers.Input(input_shape, name="input layer")
         encoder_output = encoder(input_layer)
         decoder_output = decoder(encoder_output)
-        output_layer = tf.keras.layers.Reshape(
-            target_shape=input_shape, name="outputlayer"
-        )(decoder_output)
+        # removed reshape function for output layer as it is already being tested in test_all_networks.py so no longer needed
 
         model = tf.keras.models.Model(inputs=input_layer, outputs=output_layer)
 

--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -229,9 +229,8 @@ class AEFCNClusterer(BaseDeepClusterer):
         input_layer = tf.keras.layers.Input(input_shape, name="input layer")
         encoder_output = encoder(input_layer)
         decoder_output = decoder(encoder_output)
-        # removed reshape function for output layer as it is already being tested in test_all_networks.py so no longer needed
-
-        model = tf.keras.models.Model(inputs=input_layer, outputs=output_layer)
+        # removed reshape function for output layer
+        model = tf.keras.models.Model(inputs=input_layer, outputs=decoder_output)
 
         self.optimizer_ = (
             tf.keras.optimizers.Adam() if self.optimizer is None else self.optimizer


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

removed reshape function on line 32 as it is not needed there anymore since reshape function is being tested in test_all_networks.py

Fixes : [MNT] Remove Reshape layer from Deep Learning Clusterers https://github.com/aeon-toolkit/aeon/issues/1794

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

The reshape function in _ae_fcn.py which makes input shape of encoder equal to output shape of the decoder is not needed there as that is already being tested in test_all_networks.py. So to optimize the code, It can be removed.


#### Does your contribution introduce a new dependency? If yes, which one?

no

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.



<!--
Thanks for contributing!
-->
