### PR TITLE
[BUG] fix training data check for TSDA dataset loader

### DIFF
--- a/aeon/datasets/_tsad_data_loaders.py
+++ b/aeon/datasets/_tsad_data_loaders.py
@@ -147,12 +147,15 @@ def load_anomaly_detection(
     df_meta = df_meta.set_index(["collection_name", "dataset_name"])
     metadata = df_meta.loc[name]
     if split.lower() == "train":
-        if metadata["train_path"] is None or np.isnan(metadata["train_path"]):
+        train_path = metadata["train_path"]
+        if train_path is None or (
+            isinstance(train_path, np.number) and np.isnan(train_path)
+        ):
             raise ValueError(
                 f"Dataset {name} does not have a training partition. Only "
                 "`split='test'` is supported."
             )
-        dataset_path = data_folder / metadata["train_path"]
+        dataset_path = data_folder / train_path
     else:
         dataset_path = data_folder / metadata["test_path"]
 


### PR DESCRIPTION
#### Reference Issues/PRs

none

#### What does this implement/fix? Explain your changes.

This PR resolves an issue with the dataset loader for anomaly detection datasets. The loader was not correctly checking for the absence of a training split using `np.isnan` (on potential `str`-type).

#### Does your contribution introduce a new dependency? If yes, which one?

no

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

