### PR TITLE
[MNT] remove redundant soft dependency checks

### DIFF
--- a/aeon/anomaly_detection/_pyodadapter.py
+++ b/aeon/anomaly_detection/_pyodadapter.py
@@ -81,7 +81,7 @@ class PyODAdapter(BaseAnomalyDetector):
         "capability:univariate": True,
         "capability:missing_values": False,
         "fit_is_empty": False,
-        "python_dependencies": ["pyod>=2.0.1"],
+        "python_dependencies": ["pyod"],
     }
 
     def __init__(

--- a/aeon/anomaly_detection/_pyodadapter.py
+++ b/aeon/anomaly_detection/_pyodadapter.py
@@ -81,10 +81,7 @@ class PyODAdapter(BaseAnomalyDetector):
         "capability:univariate": True,
         "capability:missing_values": False,
         "fit_is_empty": False,
-        # Omit the version specification until PyOD has __version__
-        # (https://github.com/yzhao062/pyod/pull/584 in dev but not released yet)
-        # "python_dependencies": ["pyod>=1.1.3"]
-        "python_dependencies": ["pyod"],
+        "python_dependencies": ["pyod>=2.0.1"],
     }
 
     def __init__(
@@ -176,7 +173,7 @@ class PyODAdapter(BaseAnomalyDetector):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        _check_soft_dependencies("pyod")
+        _check_soft_dependencies(*cls._tags["python_dependencies"])
 
         from pyod.models.lof import LOF
 

--- a/aeon/anomaly_detection/_stomp.py
+++ b/aeon/anomaly_detection/_stomp.py
@@ -8,7 +8,6 @@ __all__ = ["STOMP"]
 import numpy as np
 
 from aeon.anomaly_detection.base import BaseAnomalyDetector
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 from aeon.utils.windowing import reverse_windowing
 
 
@@ -92,7 +91,6 @@ class STOMP(BaseAnomalyDetector):
         super().__init__(axis=0)
 
     def _predict(self, X: np.ndarray) -> np.ndarray:
-        _check_soft_dependencies("stumpy", severity="error")
         import stumpy
 
         self._check_params(X)
@@ -138,8 +136,6 @@ class STOMP(BaseAnomalyDetector):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`.
         """
-        _check_soft_dependencies(*cls._tags["python_dependencies"])
-
         return {
             "window_size": 10,
             "ignore_trivial": True,

--- a/aeon/clustering/_k_shape.py
+++ b/aeon/clustering/_k_shape.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.random import RandomState
 
 from aeon.clustering.base import BaseClusterer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class TimeSeriesKShape(BaseClusterer):
@@ -115,7 +114,6 @@ class TimeSeriesKShape(BaseClusterer):
         self:
             Fitted estimator.
         """
-        _check_soft_dependencies("tslearn", severity="error")
         from tslearn.clustering import KShape
 
         self._tslearn_k_shapes = KShape(

--- a/aeon/clustering/_k_shapes.py
+++ b/aeon/clustering/_k_shapes.py
@@ -7,7 +7,6 @@ from deprecated.sphinx import deprecated
 from numpy.random import RandomState
 
 from aeon.clustering.base import BaseClusterer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 # TODO: remove in v1.0.0
@@ -116,7 +115,6 @@ class TimeSeriesKShapes(BaseClusterer):
         self:
             Fitted estimator.
         """
-        _check_soft_dependencies("tslearn", severity="error")
         from tslearn.clustering import KShape
 
         self._tslearn_k_shapes = KShape(

--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.random import RandomState
 
 from aeon.clustering.base import BaseClusterer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class TimeSeriesKernelKMeans(BaseClusterer):
@@ -134,7 +133,6 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         self:
             Fitted estimator.
         """
-        _check_soft_dependencies("tslearn", severity="error")
         from tslearn.clustering import KernelKMeans as TsLearnKernelKMeans
 
         verbose = 0

--- a/aeon/segmentation/_binseg.py
+++ b/aeon/segmentation/_binseg.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 
 from aeon.segmentation.base import BaseSegmenter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class BinSegSegmenter(BaseSegmenter):
@@ -93,7 +92,6 @@ class BinSegSegmenter(BaseSegmenter):
         return {}
 
     def _run_binseg(self, X):
-        _check_soft_dependencies("ruptures", severity="error")
         import ruptures as rpt
 
         binseg = rpt.Binseg(

--- a/aeon/segmentation/_fluss.py
+++ b/aeon/segmentation/_fluss.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 
 from aeon.segmentation.base import BaseSegmenter
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class FLUSSSegmenter(BaseSegmenter):
@@ -103,7 +102,6 @@ class FLUSSSegmenter(BaseSegmenter):
         return {"profile": self.profile}
 
     def _run_fluss(self, X):
-        _check_soft_dependencies("stumpy", severity="error")
         import stumpy
 
         mp = stumpy.stump(X, m=self.period_length)

--- a/aeon/transformations/series/_acf.py
+++ b/aeon/transformations/series/_acf.py
@@ -10,7 +10,6 @@ import numpy as np
 from numba import njit
 
 from aeon.transformations.series.base import BaseSeriesTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class AutoCorrelationSeriesTransformer(BaseSeriesTransformer):
@@ -222,7 +221,6 @@ class StatsModelsACF(BaseSeriesTransformer):
         -------
         transformed version of X
         """
-        _check_soft_dependencies("statsmodels", severity="error")
         X = X.squeeze()
         from statsmodels.tsa.stattools import acf
 
@@ -345,7 +343,6 @@ class StatsModelsPACF(BaseSeriesTransformer):
         -------
         transformed version of X
         """
-        _check_soft_dependencies("statsmodels", severity="error")
         X = X.squeeze()
 
         from statsmodels.tsa.stattools import pacf

--- a/aeon/transformations/series/_matrix_profile.py
+++ b/aeon/transformations/series/_matrix_profile.py
@@ -4,7 +4,6 @@ __maintainer__ = []
 __all__ = ["MatrixProfileSeriesTransformer"]
 
 from aeon.transformations.series.base import BaseSeriesTransformer
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class MatrixProfileSeriesTransformer(BaseSeriesTransformer):
@@ -64,26 +63,9 @@ class MatrixProfileSeriesTransformer(BaseSeriesTransformer):
             Matrix Profile of time series as output with length as
             (n_timepoints-window_length+1)
         """
-        _check_soft_dependencies("stumpy", severity="error")
         import stumpy
 
         X = X.squeeze()
 
         self.matrix_profile_ = stumpy.stump(X, self.window_length)
         return self.matrix_profile_[:, 0].astype("float")
-
-    @classmethod
-    def get_test_params(cls, parameter_set="default"):
-        """
-        Return testing parameter settings for the estimator.
-
-        Parameters
-        ----------
-        parameter_set : str, default="default"
-
-        Returns
-        -------
-        params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class.
-        """
-        return {}


### PR DESCRIPTION
#### Reference Issues/PRs

none, but inspired by [this PR comment](https://github.com/aeon-toolkit/aeon/pull/2091#discussion_r1775678022)

#### What does this implement/fix? Explain your changes.

- removes redundant calls to `_check_soft_dependencies` in estimators (this is already done by the `__init__`-function of the base classes
- adds the correct version bound for `pyod` in `PyODAdapter` since a new version with the `pyod.__version__`-attribute was published

#### Does your contribution introduce a new dependency? If yes, which one?

no


### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
