### PR TITLE
[ENH] Convert `BaseTransformer` into an abstract class

### DIFF
--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -1,22 +1,14 @@
 """Base class for transformers."""
 
-__maintainer__ = ["TonyBagnall"]
+__maintainer__ = ["MatthewMiddlehurst", "TonyBagnall"]
 __all__ = ["BaseTransformer"]
 
+from abc import ABC, abstractmethod
 
 from aeon.base import BaseEstimator
-from aeon.utils.validation._dependencies import _check_estimator_deps
 
 
-def _coerce_to_list(obj):
-    """Return [obj] if obj is not a list, otherwise obj."""
-    if not isinstance(obj, list):
-        return [obj]
-    else:
-        return obj
-
-
-class BaseTransformer(BaseEstimator):
+class BaseTransformer(BaseEstimator, ABC):
     """Transformer base class."""
 
     # default tag values - these typically make the "safest" assumption
@@ -42,29 +34,10 @@ class BaseTransformer(BaseEstimator):
         "remember_data": False,  # whether all data seen is remembered as self._X
     }
 
-    # allowed types for transformers - Series and Collections
-    ALLOWED_INPUT_TYPES = [
-        "pd.Series",
-        "pd.DataFrame",
-        "np.ndarray",
-        "nested_univ",
-        "numpy3D",
-        # "numpy2D",
-        "pd-multiindex",
-        # "pd-wide",
-        # "pd-long",
-        "df-list",
-        "np-list",
-        "pd_multiindex_hier",
-    ]
-
-    def __init__(self, _output_convert="auto"):
-        self._converter_store_X = dict()  # storage dictionary for in/output conversion
-        self._output_convert = _output_convert
-
+    def __init__(self):
         super().__init__()
-        _check_estimator_deps(self)
 
+    @abstractmethod
     def fit(self, X, y=None):
         """Fit transformer to X, optionally to y.
 
@@ -88,12 +61,9 @@ class BaseTransformer(BaseEstimator):
         -------
         self : a fitted instance of the estimator
         """
-        self._fit(X=X, y=y)
-        # this should happen last: fitted state is set to True
-        self._is_fitted = True
+        ...
 
-        return self
-
+    @abstractmethod
     def transform(self, X, y=None):
         """Transform X and return a transformed version.
 
@@ -113,12 +83,9 @@ class BaseTransformer(BaseEstimator):
         y : Series, default=None
             Additional data, e.g., labels for transformation.
         """
-        # check whether is fitted
-        self.check_is_fitted()
+        ...
 
-        Xt = self._transform(X=X, y=y)
-        return Xt
-
+    @abstractmethod
     def fit_transform(self, X, y=None):
         """Fit to data, then transform it.
 
@@ -134,209 +101,4 @@ class BaseTransformer(BaseEstimator):
         y : Series, default=None
             Additional data, e.g., labels for transformation.
         """
-        Xt = self._fit_transform(X=X, y=y)
-        return Xt
-
-    def inverse_transform(self, X, y=None):
-        """Inverse transform X and return an inverse transformed version.
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-        _is_fitted : must be True
-
-        Parameters
-        ----------
-        X : Series or Collection, any supported type
-            Data to fit transform to, of python type as follows:
-                Series: 2D np.ndarray shape (n_channels, n_timepoints)
-                Collection: 3D np.ndarray shape (n_cases, n_channels, n_timepoints)
-                or list of 2D np.ndarray, case i has shape (n_channels, n_timepoints_i)
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-        Returns
-        -------
-        inverse transformed version of X
-            of the same type as X,
-        """
-        if self.get_tag("skip-inverse-transform"):
-            return X
-
-        if not self.get_tag("capability:inverse_transform"):
-            raise NotImplementedError(
-                f"{type(self)} does not implement inverse_transform"
-            )
-
-        # check whether is fitted
-        self.check_is_fitted()
-        Xt = self._inverse_transform(X=X, y=y)
-        return Xt
-
-    def update(self, X, y=None, update_params=True):
-        """Update transformer with X, optionally y.
-
-        State required:
-            Requires state to be "fitted".
-
-        Accesses in self:
-        _is_fitted : must be True
-
-        Parameters
-        ----------
-        X : Series or Collection, any supported type
-            Data to fit transform to, of python type as follows:
-                Series: 2D np.ndarray shape (n_channels, n_timepoints)
-                Collection: 3D np.ndarray shape (n_cases, n_channels, n_timepoints)
-                or list of 2D np.ndarray, case i has shape (n_channels, n_timepoints_i)
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-        Returns
-        -------
-        self : a fitted instance of the estimator
-        """
-        # check whether is fitted
-        self.check_is_fitted()
-
-        # if requires_y is set, y is required in fit and update
-        if self.get_tag("requires_y") and y is None:
-            raise ValueError(f"{self.__class__.__name__} requires `y` in `update`.")
-
-        self._update(X=X, y=y)
-
-        return self
-
-    def get_fitted_params(self, deep=True):
-        """Get fitted parameters.
-
-        State required:
-            Requires state to be "fitted".
-
-        Parameters
-        ----------
-        deep : bool, default=True
-            Whether to return fitted parameters of components.
-
-            * If True, will return a dict of parameter name : value for this object,
-              including fitted parameters of fittable components
-              (= BaseEstimator-valued parameters).
-            * If False, will return a dict of parameter name : value for this object,
-              but not include fitted parameters of components.
-
-        Returns
-        -------
-        fitted_params : dict with str-valued keys
-            Dictionary of fitted parameters, paramname : paramvalue
-            keys-value pairs include:
-        """
-        return super().get_fitted_params(deep=deep)
-
-    def _fit(self, X, y=None):
-        """Fit transformer to X and y.
-
-        private _fit containing the core logic, called from fit
-
-        Parameters
-        ----------
-        X: data structure of type X_inner_type
-            if X_inner_type is list, _fit must support all types in it
-            Data to fit transform to
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        # default fit is "no fitting happens"
-        return self
-
-    def _transform(self, X, y=None):
-        """Transform X and return a transformed version.
-
-        private _transform containing the core logic, called from transform
-
-        Parameters
-        ----------
-        X: data structure of type X_inner_type
-            if X_inner_type is list, _fit must support all types in it
-            Data to fit transform to
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-        Returns
-        -------
-        transformed version of X
-        """
-        raise NotImplementedError("abstract method")
-
-    def _fit_transform(self, X, y=None):
-        """Fit to data, then transform it.
-
-        Fits the transformer to X and y and returns a transformed version of X.
-
-        private _fit_transform containing the core logic, called from fit_transform
-
-        Parameters
-        ----------
-        X: data structure of type X_inner_type
-            if X_inner_type is list, _fit_transform must support all types in it
-            Data to fit transform to
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-        """
-        # Non-optimized default implementation; override when a better
-        # method is possible for a given algorithm.
-        self._fit(X, y)
-        return self._transform(X, y)
-
-    def _inverse_transform(self, X, y=None):
-        """Inverse transform X and return an inverse transformed version.
-
-        private _inverse_transform containing core logic, called from inverse_transform
-
-        Parameters
-        ----------
-        X: data structure of type X_inner_type
-            if X_inner_type is list, _inverse_transform must support all types in it
-            Data to be transformed
-        y : Series, default=None
-            Additional data, e.g., labels for transformation.
-
-
-        Returns
-        -------
-        inverse transformed version of X
-            of the same type as X, and conforming to type format specifications
-
-        See extension_templates/transformer.py for implementation details.
-        """
-        raise NotImplementedError("abstract method")
-
-    def _update(self, X, y=None):
-        """Update transformer with X and y.
-
-        private _update containing the core logic, called from update
-
-        Parameters
-        ----------
-        X: data structure of type X_inner_type
-            if X_inner_type is list, _update must support all types in it
-            Data to update transformer with
-        y : Series, default=None
-            Additional data, e.g., labels for tarnsformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator
-
-        See extension_templates/transformer.py for implementation details.
-        """
-        # standard behaviour: no update takes place, new data is ignored
-        return self
+        ...


### PR DESCRIPTION
Only other base classes extend from `BaseTransformer` currently, and the goal is to have it remain this way in lieu of specific series and collection transformers. There is no need for it to have its own functionality, so this PR converts it into a simple abstract class for other base transformers for now.