### PR TITLE
[ENH] More `BaseEstimator` method and attribute changes

### DIFF
--- a/aeon/anomaly_detection/base.py
+++ b/aeon/anomaly_detection/base.py
@@ -82,8 +82,6 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
     }
 
     def __init__(self, axis):
-        self._is_fitted = False
-
         super().__init__(axis=axis)
 
     @final
@@ -118,7 +116,7 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
             The fitted estimator, reference to self.
         """
         if self.get_class_tag("fit_is_empty"):
-            self._is_fitted = True
+            self.is_fitted = True
             return self
 
         if self.get_class_tag("requires_y"):
@@ -135,7 +133,7 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
         self._fit(X=X, y=y)
 
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final
@@ -206,7 +204,7 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
         X = self._preprocess_series(X, axis, True)
 
         if self.get_class_tag("fit_is_empty"):
-            self._is_fitted = True
+            self.is_fitted = True
             return self._predict(X)
 
         if y is not None:
@@ -215,7 +213,7 @@ class BaseAnomalyDetector(BaseSeriesEstimator, ABC):
         pred = self._fit_predict(X, y)
 
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return pred
 
     def _fit(self, X, y):

--- a/aeon/anomaly_detection/tests/test_base.py
+++ b/aeon/anomaly_detection/tests/test_base.py
@@ -33,18 +33,18 @@ def test_fit(series):
 
     # test fit is empty
     ad.fit(series)
-    assert ad._is_fitted
+    assert ad.is_fitted
 
     ad.fit(series, test_y)
-    assert ad._is_fitted
+    assert ad.is_fitted
 
     # test requires fit
     ad_fit.fit(series)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X.squeeze(), series)
 
     ad_fit.fit(series, test_y)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X.squeeze(), series)
 
     # test requires y
@@ -52,7 +52,7 @@ def test_fit(series):
         ad_y.fit(series)
 
     ad_y.fit(series, test_y)
-    assert ad_y._is_fitted
+    assert ad_y.is_fitted
     assert_almost_equal(ad_y._X.squeeze(), series)
     assert_almost_equal(ad_y._y, test_y)
 
@@ -65,11 +65,11 @@ def test_fit_axis(series):
     invert_series = series.T
 
     ad_fit.fit(series)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X, series)
 
     ad_fit.fit(invert_series, axis=0)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X, series)
 
 
@@ -129,27 +129,27 @@ def test_fit_predict(series):
 
     # test fit is empty
     pred = ad.fit_predict(series)
-    assert ad._is_fitted
+    assert ad.is_fitted
     assert isinstance(pred, np.ndarray)
     assert pred.shape == (10,)
     assert issubclass(pred.dtype.type, (np.integer, np.floating, np.bool_))
 
     pred = ad.fit_predict(series, test_y)
-    assert ad._is_fitted
+    assert ad.is_fitted
     assert isinstance(pred, np.ndarray)
     assert pred.shape == (10,)
     assert issubclass(pred.dtype.type, (np.integer, np.floating, np.bool_))
 
     # test requires fit
     pred = ad_fit.fit_predict(series)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X.squeeze(), series)
     assert isinstance(pred, np.ndarray)
     assert pred.shape == (10,)
     assert issubclass(pred.dtype.type, (np.integer, np.floating, np.bool_))
 
     pred = ad_fit.fit_predict(series, test_y)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X.squeeze(), series)
     assert isinstance(pred, np.ndarray)
     assert pred.shape == (10,)
@@ -160,7 +160,7 @@ def test_fit_predict(series):
         ad_y.fit_predict(series)
 
     pred = ad_y.fit_predict(series, test_y)
-    assert ad_y._is_fitted
+    assert ad_y.is_fitted
     assert_almost_equal(ad_y._X.squeeze(), series)
     assert_almost_equal(ad_y._y, test_y)
     assert isinstance(pred, np.ndarray)
@@ -176,12 +176,12 @@ def test_fit_predict_axis(series):
     invert_series = series.T
 
     pred = ad_fit.fit_predict(series)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X, series)
     assert len(pred) == series.shape[1]
 
     pred = ad_fit.fit_predict(invert_series, axis=0)
-    assert ad_fit._is_fitted
+    assert ad_fit.is_fitted
     assert_almost_equal(ad_fit._X, series)
     assert len(pred) == series.shape[1]
 

--- a/aeon/base/_base.py
+++ b/aeon/base/_base.py
@@ -1,37 +1,4 @@
-"""
-Base class template for estimators.
-
-Interface specifications below.
-
----
-
-Parameter inspection and setter methods
-    inspect parameter values      - get_params()
-    setting parameter values      - set_params(**params)
-    fitted parameter inspection - get_fitted_params()
-
-Tag inspection and setter methods
-    inspect tags (all)            - get_tags()
-    inspect tags (one tag)        - get_tag(tag_name: str, tag_value_default=None)
-    inspect tags (class method)   - get_class_tags()
-    inspect tags (one tag, class) - get_class_tag(tag_name:str, tag_value_default=None)
-    setting dynamic tags          - set_tags(**tag_dict: dict)
-    set/clone dynamic tags        - clone_tags(estimator, tag_names=None)
-
-Blueprinting: resetting and cloning, post-init state with same hyper-parameters
-    reset estimator to post-init  - reset()
-    cloneestimator (copy&reset)   - clone()
-
-Testing with default parameters methods
-    getting default parameters (all sets)         - get_test_params()
-    get one test instance with default parameters - create_test_instance()
-    get list of all test instances plus name list - create_test_instances_and_names()
-
-State:
-    fitted model/strategy   - by convention, any attributes ending in "_"
-    fitted state flag       - is_fitted (property)
-    fitted state check      - check_is_fitted (raises error if not is_fitted)
-"""
+"""Base class template for aeon estimators."""
 
 __maintainer__ = ["MatthewMiddlehurst", "TonyBagnall"]
 __all__ = ["BaseEstimator"]
@@ -46,7 +13,24 @@ from sklearn.exceptions import NotFittedError
 
 
 class BaseEstimator(_BaseEstimator):
-    """Base class for defining estimators in aeon."""
+    """
+    Base class for defining estimators in aeon.
+
+    Contains the following methods:
+
+    reset estimator to post-init  - reset(keep)
+    clonee stimator (copy)        - clone(random_state)
+    inspect tags (class method)   - get_class_tags()
+    inspect tags (one tag, class) - get_class_tag(tag_name, tag_value_default,
+                                                                    raise_error)
+    inspect tags (all)            - get_tags()
+    inspect tags (one tag)        - get_tag(tag_name, tag_value_default, raise_error)
+    setting dynamic tags          - set_tags(**tag_dict)
+
+    All estimators have the attribute:
+
+    fitted state flag             - is_fitted
+    """
 
     _tags = {
         "python_version": None,
@@ -59,27 +43,42 @@ class BaseEstimator(_BaseEstimator):
     }
 
     def __init__(self):
-        self._is_fitted = False  # flag to indicate if fit has been called
+        self.is_fitted = False  # flag to indicate if fit has been called
         self._tags_dynamic = dict()  # storage for dynamic tags
 
         super().__init__()
 
     def reset(self, keep=None):
-        """Reset the object to a clean post-init state.
+        """
+        Reset the object to a clean post-init state.
 
-        Equivalent to sklearn.clone but overwrites self.
-        After ``self.reset()`` call, self is equal in value to
-        ``type(self)(**self.get_params(deep=False))``
+        After a ``self.reset()`` call, self is equal or similar in value to
+        ``type(self)(**self.get_params(deep=False))``, assuming no other attributes
+        were kept using ``keep``.
 
-        Detail behaviour:
-        removes any object attributes, except:
-            hyper-parameters = arguments of ``__init__``
-            object attributes containing double-underscores, i.e., the string "__"
-        runs ``__init__`` with current values of hyper-parameters (result of get_params)
+        Detailed behaviour:
+            removes any object attributes, except:
+                hyper-parameters (arguments of ``__init__``)
+                object attributes containing double-underscores, i.e., the string "__"
+            runs ``__init__`` with current values of hyperparameters (result of
+            get_params)
 
         Not affected by the reset are:
-        object attributes containing double-underscores
-        class and object methods, class attributes
+            object attributes containing double-underscores
+            class and object methods, class attributes
+            any attributes specified in the ``keep`` argument
+
+        Parameters
+        ----------
+        keep : None, str, or list of str, default=None
+            If None, all attributes are removed except hyper-parameters.
+            If str, only the attribute with this name is kept.
+            If list of str, only the attributes with these names are kept.
+
+        Returns
+        -------
+        self
+            Reference to self.
         """
         # retrieve parameters to copy them later
         params = self.get_params(deep=False)
@@ -111,15 +110,23 @@ class BaseEstimator(_BaseEstimator):
 
     def clone(self, random_state=None):
         """
-        Obtain a clone of the object with same hyper-parameters.
+        Obtain a clone of the object with the same hyperparameters.
 
         A clone is a different object without shared references, in post-init state.
-        This function is equivalent to returning sklearn.clone of self.
+        This function is equivalent to returning ``sklearn.clone`` of self.
         Equal in value to ``type(self)(**self.get_params(deep=False))``.
+
+        Parameters
+        ----------
+        random_state : int, RandomState instance, or None, default=None
+            Sets the random state of the clone. If None, the random state is not set.
+            If int, random_state is the seed used by the random number generator.
+            If RandomState instance, random_state is the random number generator.
 
         Returns
         -------
-        instance of ``type(self)``, clone of self (see above)
+        estimator : object
+            Instance of ``type(self)``, clone of self (see above)
         """
         estimator = clone(self)
 
@@ -136,19 +143,18 @@ class BaseEstimator(_BaseEstimator):
         Returns
         -------
         collected_tags : dict
-            Dictionary of tag name : tag value pairs. Collected from _tags
-            class attribute via nested inheritance. NOT overridden by dynamic
-            tags set by set_tags or mirror_tags.
+            Dictionary of tag name and tag value pairs.
+            Collected from ``_tags`` class attribute via nested inheritance.
+            These are not overridden by dynamic tags set by ``set_tags`` or class
+            ``__init__`` calls.
         """
         collected_tags = dict()
 
         # We exclude the last two parent classes: sklearn.base.BaseEstimator and
         # the basic Python object.
         for parent_class in reversed(inspect.getmro(cls)[:-2]):
+            # Need the if here because classes might not have non-default tags
             if hasattr(parent_class, "_tags"):
-                # Need the if here because mixins might not have _more_tags
-                # but might do redundant work in estimators
-                # (i.e. calling more tags on BaseEstimator multiple times)
                 more_tags = parent_class._tags
                 collected_tags.update(more_tags)
 
@@ -170,20 +176,16 @@ class BaseEstimator(_BaseEstimator):
 
         Returns
         -------
-        tag_value :
-            Value of the `tag_name` tag in self. If not found, returns an error if
-            raise_error is True, otherwise it returns `tag_value_default`.
+        tag_value
+            Value of the ``tag_name`` tag in self.
+            If not found, returns an error if raise_error is True, otherwise it
+            returns `tag_value_default`.
 
         Raises
         ------
-        ValueError if raise_error is True i.e. if tag_name is not in self.get_tags(
-        ).keys()
-
-        See Also
-        --------
-        get_tag : Get a single tag from an object.
-        get_tags : Get all tags from an object.
-        get_class_tag : Get a single tag from a class.
+        ValueError
+            if raise_error is ``True`` and ``tag_name`` is not in
+            ``self.get_tags().keys()``
 
         Examples
         --------
@@ -202,41 +204,26 @@ class BaseEstimator(_BaseEstimator):
 
     def get_tags(self):
         """
-        Get tags from estimator class.
+        Get tags from estimator.
 
-        Includes the dynamic tag overrides.
+        Includes dynamic and overridden tags.
 
         Returns
         -------
-        dict
-            Dictionary of tag name : tag value pairs. Collected from _tags
-            class attribute via nested inheritance and then any overrides
-            and new tags from _tags_dynamic object attribute.
-
-        See Also
-        --------
-        get_tag : Get a single tag from an object.
-        get_class_tags : Get all tags from a class.
-        get_class_tag : Get a single tag from a class.
-
-        Examples
-        --------
-        >>> from aeon.classification import DummyClassifier
-        >>> d = DummyClassifier()
-        >>> tags = d.get_tags()
+        collected_tags : dict
+            Dictionary of tag name and tag value pairs.
+            Collected from ``_tags`` class attribute via nested inheritance and
+            then any overridden and new tags from ``__init__`` or ``set_tags``.
         """
         collected_tags = self.get_class_tags()
-
-        if hasattr(self, "_tags_dynamic"):
-            collected_tags.update(self._tags_dynamic)
-
+        collected_tags.update(self._tags_dynamic)
         return deepcopy(collected_tags)
 
     def get_tag(self, tag_name, tag_value_default=None, raise_error=True):
         """
         Get tag value from estimator class.
 
-        Uses dynamic tag overrides.
+        Includes dynamic and overridden tags.
 
         Parameters
         ----------
@@ -249,20 +236,16 @@ class BaseEstimator(_BaseEstimator):
 
         Returns
         -------
-        tag_value :
-            Value of the `tag_name` tag in self. If not found, returns an error if
-            raise_error is True, otherwise it returns `tag_value_default`.
+        tag_value
+            Value of the ``tag_name`` tag in self.
+            If not found, returns an error if raise_error is True, otherwise it
+            returns `tag_value_default`.
 
         Raises
         ------
-        ValueError if raise_error is True i.e. if tag_name is not in self.get_tags(
-        ).keys()
-
-        See Also
-        --------
-        get_tags : Get all tags from an object.
-        get_clas_tags : Get all tags from a class.
-        get_class_tag : Get a single tag from a class.
+        ValueError
+            if raise_error is ``True`` and ``tag_name`` is not in
+            ``self.get_tags().keys()``
 
         Examples
         --------
@@ -287,24 +270,15 @@ class BaseEstimator(_BaseEstimator):
         Parameters
         ----------
         **tag_dict : dict
-            Dictionary of tag name : tag value pairs.
+            Dictionary of tag name and tag value pairs.
 
         Returns
         -------
-        Self :
+        self
             Reference to self.
-
-        Notes
-        -----
-        Changes object state by setting tag values in tag_dict as dynamic tags
-        in self.
         """
         tag_update = deepcopy(tag_dict)
-        if hasattr(self, "_tags_dynamic"):
-            self._tags_dynamic.update(tag_update)
-        else:
-            self._tags_dynamic = tag_update
-
+        self._tags_dynamic.update(tag_update)
         return self
 
     @classmethod
@@ -352,11 +326,7 @@ class BaseEstimator(_BaseEstimator):
             Instance of the class with default parameters. If return_first
             is False, returns list of instances.
         """
-        # todo, update all methods to use parameter_set and remove when done
-        if "parameter_set" in inspect.getfullargspec(cls.get_test_params).args:
-            params = cls.get_test_params(parameter_set=parameter_set)
-        else:
-            params = cls.get_test_params()
+        params = cls.get_test_params(parameter_set=parameter_set)
 
         if isinstance(params, list):
             if return_first:
@@ -368,113 +338,6 @@ class BaseEstimator(_BaseEstimator):
                 return cls(**params)
             else:
                 return [cls(**params)]
-
-    @classmethod
-    def create_test_instances_and_names(cls, parameter_set="default"):
-        """
-        Create list of all test instances and a list of names for them.
-
-        Parameters
-        ----------
-        parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
-
-        Returns
-        -------
-        objs : list of instances of cls
-            i-th instance is cls(**cls.get_test_params()[i]).
-        names : list of str, same length as objs
-            i-th element is name of i-th instance of obj in tests
-            convention is {cls.__name__}-{i} if more than one instance
-            otherwise {cls.__name__}.
-        parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
-        """
-        if "parameter_set" in inspect.getfullargspec(cls.get_test_params).args:
-            param_list = cls.get_test_params(parameter_set=parameter_set)
-        else:
-            param_list = cls.get_test_params()
-
-        objs = []
-        if not isinstance(param_list, (dict, list)):
-            raise RuntimeError(
-                f"Error in {cls.__name__}.get_test_params, "
-                "return must be param dict for class, or list thereof"
-            )
-        if isinstance(param_list, dict):
-            param_list = [param_list]
-        for params in param_list:
-            if not isinstance(params, dict):
-                raise RuntimeError(
-                    f"Error in {cls.__name__}.get_test_params, "
-                    "return must be param dict for class, or list thereof"
-                )
-            objs += [cls(**params)]
-
-        n_cases = len(param_list)
-        if n_cases > 1:
-            names = [cls.__name__ + "-" + str(i) for i in range(n_cases)]
-        else:
-            names = [cls.__name__]
-
-        return objs, names
-
-    @classmethod
-    def _has_implementation_of(cls, method):
-        """
-        Check if method has a concrete implementation in this class.
-
-        This assumes that having an implementation is equivalent to
-            one or more overrides of `method` in the method resolution order.
-
-        Parameters
-        ----------
-        method : str
-            name of method to check implementation of.
-
-        Returns
-        -------
-        bool, whether method has implementation in cls
-            True if cls.method has been overridden at least once in
-                the inheritance tree (according to method resolution order).
-        """
-        # walk through method resolution order and inspect methods
-        #   of classes and direct parents, "adjacent" classes in mro
-        mro = inspect.getmro(cls)
-        # collect all methods that are not none
-        methods = [getattr(c, method, None) for c in mro]
-        methods = [m for m in methods if m is not None]
-
-        for i in range(len(methods) - 1):
-            # the method has been overridden once iff
-            #  at least two of the methods collected are not equal
-            #  equivalently: some two adjacent methods are not equal
-            overridden = methods[i] != methods[i + 1]
-            if overridden:
-                return True
-
-        return False
-
-    def is_composite(self):
-        """
-        Check if the object is composite.
-
-        A composite object is an object which contains objects, as parameters.
-        Called on an instance, since this may differ by instance.
-
-        Returns
-        -------
-        composite: bool
-            Whether self contains a parameter which is BaseEstimator.
-        """
-        # walk through method resolution order and inspect methods
-        #   of classes and direct parents, "adjacent" classes in mro
-        params = self.get_params(deep=False)
-        composite = any(isinstance(x, BaseEstimator) for x in params.values())
-
-        return composite
 
     def _components(self, base_class=None):
         """
@@ -605,11 +468,6 @@ class BaseEstimator(_BaseEstimator):
         with ZipFile(serial, "r") as file:
             return pickle.loads(file.open("_obj").read())
 
-    @property
-    def is_fitted(self):
-        """Whether ``fit`` has been called."""
-        return self._is_fitted
-
     def check_is_fitted(self):
         """
         Check if the estimator has been fitted.
@@ -679,7 +537,7 @@ class BaseEstimator(_BaseEstimator):
         # add all nested parameters from components that are aeon BaseEstimator
         c_dict = self._components()
         for c, comp in c_dict.items():
-            if isinstance(comp, BaseEstimator) and comp._is_fitted:
+            if isinstance(comp, BaseEstimator) and comp.is_fitted:
                 c_f_params = comp.get_fitted_params()
                 c_f_params = {f"{sh(c)}__{k}": v for k, v in c_f_params.items()}
                 fitted_params.update(c_f_params)
@@ -745,8 +603,21 @@ class BaseEstimator(_BaseEstimator):
         """
         return self._get_fitted_params_default()
 
+    # override some sklearn private methods
+
+    def __sklearn_is_fitted__(self):
+        """Check fitted status and return a Boolean value."""
+        return self.is_fitted
+
+    def _validate_data(self, **kwargs):
+        """Sklearn data validation."""
+        raise NotImplementedError(
+            "aeon estimators do not have a _validate_data method."
+        )
+
 
 def _clone_estimator(base_estimator, random_state=None):
+    """Clone an estimator."""
     estimator = clone(base_estimator)
 
     if random_state is not None:

--- a/aeon/base/tests/test_base.py
+++ b/aeon/base/tests/test_base.py
@@ -218,20 +218,6 @@ class CompositionDummy(BaseEstimator):
         self.bar = bar
 
 
-def test_is_composite():
-    """Tests is_composite tag for correctness.
-
-    Raises
-    ------
-    AssertionError if logic behind is_composite is incorrect
-    """
-    non_composite = CompositionDummy(foo=42)
-    composite = CompositionDummy(foo=non_composite)
-
-    assert not non_composite.is_composite()
-    assert composite.is_composite()
-
-
 class ResetTester(BaseEstimator):
     clsvar = 210
 
@@ -325,7 +311,7 @@ class FittableCompositionDummy(BaseEstimator):
     def fit(self):
         if hasattr(self.foo_, "fit"):
             self.foo_.fit()
-        self._is_fitted = True
+        self.is_fitted = True
 
 
 def test_get_fitted_params():

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -119,7 +119,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
 
         self.fit_time_ = int(round(time.time() * 1000)) - start
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final
@@ -271,7 +271,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             y_pred = self._fit_predict(X, y, **kwargs)
 
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return y_pred
 
     @final
@@ -340,7 +340,7 @@ class BaseClassifier(BaseCollectionEstimator, ABC):
             y_proba = self._fit_predict_proba(X, y, **kwargs)
 
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return y_proba
 
     def score(

--- a/aeon/classification/deep_learning/base.py
+++ b/aeon/classification/deep_learning/base.py
@@ -184,7 +184,7 @@ class BaseDeepClassifier(BaseClassifier, ABC):
         import tensorflow as tf
 
         self.model_ = tf.keras.models.load_model(model_path)
-        self._is_fitted = True
+        self.is_fitted = True
 
         self.classes_ = classes
         self.n_classes_ = len(self.classes_)

--- a/aeon/classification/dictionary_based/_boss.py
+++ b/aeon/classification/dictionary_based/_boss.py
@@ -659,7 +659,7 @@ class IndividualBOSS(BaseClassifier):
         new_boss.classes_ = self.classes_
         new_boss._class_dictionary = self._class_dictionary
         new_boss.metadata_ = self.metadata_
-        new_boss._is_fitted = True
+        new_boss.is_fitted = True
 
         return new_boss
 

--- a/aeon/classification/early_classification/base.py
+++ b/aeon/classification/early_classification/base.py
@@ -120,7 +120,7 @@ class BaseEarlyClassifier(BaseCollectionEstimator, ABC):
         self._fit(X, y)
         self.fit_time_ = int(round(time.time() * 1000)) - start
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     def predict(self, X) -> tuple[np.ndarray, np.ndarray]:

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -142,7 +142,7 @@ class RISTClassifier(BaseRIST, BaseClassifier):
     }
 
     @classmethod
-    def get_test_params(cls, parameter_set=None):
+    def get_test_params(cls, parameter_set="default"):
         """Return unit test parameter settings for the estimator.
 
         Parameters

--- a/aeon/classification/shapelet_based/_ls.py
+++ b/aeon/classification/shapelet_based/_ls.py
@@ -173,7 +173,7 @@ class LearningShapeletClassifier(BaseClassifier):
         array of shape=(n_ts, n_shapelets)
             Shapelet-Transform of the provided time series.
         """
-        if not self._is_fitted:
+        if not self.is_fitted:
             raise ValueError(
                 "You must fit the classifier before recovering the transform"
             )
@@ -197,7 +197,7 @@ class LearningShapeletClassifier(BaseClassifier):
         array of shape=(n_ts, n_shapelets)
             Location of the shapelet matches for the provided time series.
         """
-        if not self._is_fitted:
+        if not self.is_fitted:
             raise ValueError(
                 "You must fit the classifier before recovering the transform"
             )

--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -226,7 +226,6 @@ class TimeSeriesKMeans(BaseClusterer):
                     print("Resumed because of empty cluster")  # noqa: T001, T201
 
         if best_labels is None:
-            self._is_fitted = False
             raise ValueError(
                 "Unable to find a valid cluster configuration "
                 "with parameters specified (empty clusters kept "

--- a/aeon/clustering/base.py
+++ b/aeon/clustering/base.py
@@ -63,7 +63,7 @@ class BaseClusterer(BaseCollectionEstimator, ABC):
         X = self._preprocess_collection(X)
         self._fit(X)
         self.fit_time_ = int(round(time.time() * 1000)) - _start_time
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final

--- a/aeon/regression/base.py
+++ b/aeon/regression/base.py
@@ -120,7 +120,7 @@ class BaseRegressor(BaseCollectionEstimator, ABC):
 
         self.fit_time_ = int(round(time.time() * 1000)) - start
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final
@@ -209,7 +209,7 @@ class BaseRegressor(BaseCollectionEstimator, ABC):
         y_pred = self._fit_predict(X, y)
 
         # this should happen last
-        self._is_fitted = True
+        self.is_fitted = True
         return y_pred
 
     def score(self, X, y, metric="r2", metric_params=None) -> float:

--- a/aeon/regression/deep_learning/base.py
+++ b/aeon/regression/deep_learning/base.py
@@ -129,7 +129,7 @@ class BaseDeepRegressor(BaseRegressor, ABC):
         import tensorflow as tf
 
         self.model_ = tf.keras.models.load_model(model_path)
-        self._is_fitted = True
+        self.is_fitted = True
 
     def _get_model_checkpoint_callback(self, callbacks, file_path, file_name):
         import tensorflow as tf

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -134,7 +134,7 @@ class RISTRegressor(BaseRIST, BaseRegressor):
     }
 
     @classmethod
-    def get_test_params(cls, parameter_set=None):
+    def get_test_params(cls, parameter_set="default"):
         """Return unit test parameter settings for the estimator.
 
         Parameters

--- a/aeon/segmentation/_eagglo.py
+++ b/aeon/segmentation/_eagglo.py
@@ -350,7 +350,7 @@ class EAggloSegmenter(BaseSegmenter):
         )
 
     @classmethod
-    def get_test_params(cls) -> list[dict]:
+    def get_test_params(cls, parameter_set: str = "default") -> list[dict]:
         """Test parameters."""
         return [
             {"alpha": 1.0, "penalty": None},

--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -72,7 +72,6 @@ class BaseSegmenter(BaseSeriesEstimator, ABC):
 
     def __init__(self, axis, n_segments=2):
         self.n_segments = n_segments
-        self._is_fitted = False
 
         super().__init__(axis=axis)
 
@@ -107,7 +106,7 @@ class BaseSegmenter(BaseSeriesEstimator, ABC):
             Fitted estimator
         """
         if self.get_class_tag("fit_is_empty"):
-            self._is_fitted = True
+            self.is_fitted = True
             return self
         if self.get_class_tag("requires_y"):
             if y is None:
@@ -120,7 +119,7 @@ class BaseSegmenter(BaseSeriesEstimator, ABC):
         if y is not None:
             y = self._check_y(y)
         self._fit(X=X, y=y)
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final

--- a/aeon/transformations/collection/_resize.py
+++ b/aeon/transformations/collection/_resize.py
@@ -83,7 +83,7 @@ class Resizer(BaseCollectionTransformer):
         return np.array(Xt)
 
     @classmethod
-    def get_test_params(cls):
+    def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
 
         Returns

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -93,7 +93,7 @@ class BaseCollectionTransformer(
                 raise ValueError("Tag requires_y is true, but fit called with y=None")
         # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
-            self._is_fitted = True
+            self.is_fitted = True
             return self
         self.reset()
 
@@ -102,7 +102,7 @@ class BaseCollectionTransformer(
         y_inner = y
         self._fit(X=X_inner, y=y_inner)
 
-        self._is_fitted = True
+        self.is_fitted = True
 
         return self
 
@@ -203,7 +203,7 @@ class BaseCollectionTransformer(
         y_inner = y
         Xt = self._fit_transform(X=X_inner, y=y_inner)
 
-        self._is_fitted = True
+        self.is_fitted = True
 
         return Xt
 

--- a/aeon/transformations/collection/channel_selection/_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/_elbow_class.py
@@ -288,7 +288,6 @@ class ElbowClassSum(BaseChannelSelector):
         self.distance = distance
         self.mean_center = mean_center
         self.prototype_type = prototype_type
-        self._is_fitted = False
 
         super().__init__()
 
@@ -321,7 +320,6 @@ class ElbowClassSum(BaseChannelSelector):
 
         self.channels_selected_.extend(_detect_knee_point(distance, indices))
         self.rank = self.channels_selected_
-        self._is_fitted = True
 
         return self
 
@@ -400,7 +398,6 @@ class ElbowClassPairwise(BaseChannelSelector):
         self.distance = distance
         self.prototype_type = prototype_type
         self.mean_center = mean_center
-        self._is_fitted = False
 
         super().__init__()
 
@@ -438,7 +435,7 @@ class ElbowClassPairwise(BaseChannelSelector):
 
         self.rank = self._rank()
         self.channels_selected_ = list(set(self.channels_selected_))
-        self._is_fitted = True
+
         return self
 
     def _rank(self) -> list[int]:

--- a/aeon/transformations/collection/dictionary_based/_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa.py
@@ -261,7 +261,6 @@ class SFA(BaseCollectionTransformer):
         self.n_cases, self.n_timepoints = X.shape
         self.breakpoints = self._binning(X, y)
 
-        self._is_fitted = True
         return self
 
     def _transform(self, X, y=None):

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -270,7 +270,6 @@ class SFAFast(BaseCollectionTransformer):
 
         self.n_cases, self.n_timepoints = X2.shape
         self.breakpoints = self._binning(X2, y)
-        self._is_fitted = True
 
         words, dfts = _transform_case(
             X2,
@@ -737,10 +736,6 @@ class SFAFast(BaseCollectionTransformer):
             "alphabet_size": 2,
         }
         return params
-
-    def set_fitted(self):
-        """Whether `fit` has been called."""
-        self._is_fitted = True
 
     def __getstate__(self):
         """Return state as dictionary for pickling, required for typed Dict objects."""

--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -192,10 +192,10 @@ class Catch22(BaseCollectionTransformer):
         self.n_jobs = n_jobs
         self.parallel_backend = parallel_backend
 
+        super().__init__()
+
         if use_pycatch22:
             self.set_tags(**{"python_dependencies": "pycatch22"})
-
-        super().__init__()
 
     def _transform(self, X, y=None):
         """Transform X into the catch22 features.

--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -59,7 +59,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         """
         # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
-            self._is_fitted = True
+            self.is_fitted = True
             return self
         if self.get_tag("requires_y"):
             if y is None:
@@ -70,7 +70,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         if y is not None:
             self._check_y(y)
         self._fit(X=X, y=y)
-        self._is_fitted = True
+        self.is_fitted = True
         return self
 
     @final
@@ -140,7 +140,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer, metaclass=ABCM
         self.reset()
         X = self._preprocess_series(X, axis=axis, store_metadata=True)
         Xt = self._fit_transform(X=X, y=y)
-        self._is_fitted = True
+        self.is_fitted = True
         return self._postprocess_series(Xt, axis=axis)
 
     @final


### PR DESCRIPTION
- replaces `_is_fitted` and the `is_fitted` property with just an `is_fitted` attribute
- requires `_tags_dynamic` be present (I do not know why it would be gone, but there are checks for some reason)
- requires a `parameter_set` argument for `get_test_params` method
- removes `create_test_instances_and_names` method (no usages, cant see why it would be useful for users)
- removes `is_composite` method. I don't know why you would want this, but it should be a tag if it stays
- adds some overloads for `sklearn` private methods to make them more compatible with our framework (or raise a better error where there is no compatibility)