### PR TITLE
[BUG] set dynamic tag after call to parent constructor

### DIFF
--- a/aeon/transformations/collection/_periodogram.py
+++ b/aeon/transformations/collection/_periodogram.py
@@ -71,10 +71,10 @@ class PeriodogramTransformer(BaseCollectionTransformer):
         self.use_pyfftw = use_pyfftw
         self.n_jobs = n_jobs
 
+        super().__init__()
         if use_pyfftw:
             self.set_tags(**{"python_dependencies": "pyfftw"})
 
-        super().__init__()
 
     def _transform(self, X, y=None):
         threads_to_use = check_n_jobs(self.n_jobs)

--- a/aeon/transformations/collection/_periodogram.py
+++ b/aeon/transformations/collection/_periodogram.py
@@ -75,7 +75,6 @@ class PeriodogramTransformer(BaseCollectionTransformer):
         if use_pyfftw:
             self.set_tags(**{"python_dependencies": "pyfftw"})
 
-
     def _transform(self, X, y=None):
         threads_to_use = check_n_jobs(self.n_jobs)
 


### PR DESCRIPTION
fixes #2168 

Sets the dynamic tag "python_dependencies": "pyfftw" after the call to the parent constructor, which initialises the dynamic tags. The current call is trying to set a value in a data structure that is yet to exist. 

