### PR TITLE
[ENH, BUG] Fixes issue with lower bounding in SAX for TS length not divisible by the number of segments 

### DIFF
--- a/aeon/distances/_paa_sax_mindist.py
+++ b/aeon/distances/_paa_sax_mindist.py
@@ -61,6 +61,13 @@ def _univariate_PAA_SAX_distance(
     x_paa: np.ndarray, y_sax: np.ndarray, breakpoints: np.ndarray, n: int
 ) -> float:
     dist = 0.0
+
+    # The number of segments
+    m = x_paa.shape[0]
+
+    # Compute the actual length of each segment in analogy to the PAA transform
+    n_split = np.array_split(np.arange(n), m)
+
     for i in range(x_paa.shape[0]):
         if y_sax[i] >= breakpoints.shape[0]:
             br_upper = np.inf
@@ -73,12 +80,11 @@ def _univariate_PAA_SAX_distance(
             br_lower = breakpoints[y_sax[i] - 1]
 
         if br_lower > x_paa[i]:
-            dist += (br_lower - x_paa[i]) ** 2
+            dist += n_split[i].shape[0] * (br_lower - x_paa[i]) ** 2
         elif br_upper < x_paa[i]:
-            dist += (x_paa[i] - br_upper) ** 2
+            dist += n_split[i].shape[0] * (x_paa[i] - br_upper) ** 2
 
-    m = x_paa.shape[0]
-    return np.sqrt(n / m) * np.sqrt(dist)
+    return np.sqrt(dist)
 
 
 @njit(cache=True, fastmath=True)

--- a/aeon/distances/_sax_mindist.py
+++ b/aeon/distances/_sax_mindist.py
@@ -58,16 +58,23 @@ def _univariate_SAX_distance(
     x: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n: int
 ) -> float:
     dist = 0.0
+
+    # The number of segments
+    m = x.shape[0]
+
+    # Compute the actual length of each segment in analogy to the PAA transform
+    n_split = np.array_split(np.arange(n), m)
+
     for i in range(x.shape[0]):
         if np.abs(x[i] - y[i]) <= 1:
             continue
         else:
             dist += (
-                breakpoints[max(x[i], y[i]) - 1] - breakpoints[min(x[i], y[i])]
-            ) ** 2
+                n_split[i].shape[0]
+                * (breakpoints[max(x[i], y[i]) - 1] - breakpoints[min(x[i], y[i])]) ** 2
+            )
 
-    m = x.shape[0]
-    return np.sqrt(n / m) * np.sqrt(dist)
+    return np.sqrt(dist)
 
 
 @njit(cache=True, fastmath=True)


### PR DESCRIPTION
This fixes an issue with lower bounding in iSAX. 

If the time series length is not divisible by the number of segments, PAA is padding some segments with 0. The concrete segments to pad are determined using `np.array_split()`.

To hold lower bounding, each segment's mean must thus be multiplied by the exact number of values it represents, again using `np.array_split()`.