### PR TITLE
[BUG] Fix TSAD dataset tests

### DIFF
--- a/aeon/datasets/tests/test_tsad_data_loader.py
+++ b/aeon/datasets/tests/test_tsad_data_loader.py
@@ -13,8 +13,13 @@ from aeon.datasets._tsad_data_loaders import (
     load_from_timeeval_csv_file,
     load_kdd_tsad_135,
 )
+from aeon.testing.testing_config import PR_TESTING
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 def test_load_anomaly_detection_wrong_name(mocker):
     """Test load non-existent anomaly detection datasets."""
     with pytest.raises(
@@ -32,6 +37,10 @@ def test_load_anomaly_detection_wrong_name(mocker):
             load_anomaly_detection(("FOO", "BAR"))
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 def test_load_anomaly_detection_no_train_split(mocker):
     """Test load train split of anomaly detection dataset without training split."""
     name = ("Dodgers", "101-freeway-traffic")
@@ -44,6 +53,10 @@ def test_load_anomaly_detection_no_train_split(mocker):
             load_anomaly_detection(name, extract_path=tmp, split="train")
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 def test_load_anomaly_detection_from_archive(mocker):
     """Test load anomaly detection dataset from archive."""
     name = ("Genesis", "genesis-anomalies")
@@ -63,6 +76,10 @@ def test_load_anomaly_detection_from_archive(mocker):
         np.testing.assert_almost_equal(meta["contamination"], 0.0031, decimal=4)
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 def test_load_anomaly_detection_unavailable(mocker):
     """Test load anomaly detection dataset that is not available."""
     name = ("IOPS", "05f10d3a-239c-3bef-9bdc-a2feeb0037aa")
@@ -74,6 +91,10 @@ def test_load_anomaly_detection_unavailable(mocker):
             load_anomaly_detection(name)
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 def test_load_anomaly_detection_custom_file(mocker):
     """Test load anomaly detection dataset from custom file."""
     name = ("correlation-anomalies", "rmj-2-short-2-diff-channel")

--- a/aeon/datasets/tests/test_tsad_datasets.py
+++ b/aeon/datasets/tests/test_tsad_datasets.py
@@ -1,5 +1,8 @@
 """Test functions in tsad_datasets.py."""
 
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from aeon.datasets.tsad_datasets import (
@@ -17,17 +20,20 @@ from aeon.testing.testing_config import PR_TESTING
     PR_TESTING,
     reason="Only run on overnights because of read from internet.",
 )
-def test_helper_functions():
+def test_helper_functions(mocker):
     """Test helper functions."""
-    d = tsad_collections()
-    assert isinstance(d, dict)
-    d = tsad_datasets()
-    assert isinstance(d, list)
-    d = univariate()
-    assert isinstance(d, list)
-    d = multivariate()
-    assert isinstance(d, list)
-    d = unsupervised()
-    assert isinstance(d, list)
-    d = supervised()
-    assert isinstance(d, list)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        mocker.patch("aeon.datasets.tsad_datasets._DATA_FOLDER", tmp)
+        d = tsad_collections()
+        assert isinstance(d, dict)
+        d = tsad_datasets()
+        assert isinstance(d, list)
+        d = univariate()
+        assert isinstance(d, list)
+        d = multivariate()
+        assert isinstance(d, list)
+        d = unsupervised()
+        assert isinstance(d, list)
+        d = supervised()
+        assert isinstance(d, list)


### PR DESCRIPTION
#### Reference Issues/PRs

fixes #2225

#### What does this implement/fix? Explain your changes.

Fixes the tests for TSAD datasets:

- only downloads stuff from the internet in overnight tests
- hopefully prevents sporadic test failures by using a tmp folder for `local_data`

#### Does your contribution introduce a new dependency? If yes, which one?

no

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.