### PR TITLE
[MNT] CI fixes and pytest options

### DIFF
--- a/aeon/anomaly_detection/_copod.py
+++ b/aeon/anomaly_detection/_copod.py
@@ -67,7 +67,7 @@ class COPOD(PyODAdapter):
         return super()._fit_predict(X, y)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default") -> dict:
+    def _get_test_params(cls, parameter_set="default") -> dict:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/transformations/collection/dictionary_based/_borf.py
+++ b/aeon/transformations/collection/dictionary_based/_borf.py
@@ -548,10 +548,7 @@ def _ndindex_2d_array(idx, dim2_shape):
 
 @nb.njit(cache=True)
 def _get_norm_bins(alphabet_size: int, mu=0, std=1):
-    b = np.linspace(0, 1, alphabet_size + 1)[1:-1]
-    for i, v in enumerate(b):
-        b[i] = _ppf(v, mu, std)
-    return b
+    return _ppf(np.linspace(0, 1, alphabet_size + 1)[1:-1], mu, std)
 
 
 @nb.njit(fastmath=True, cache=True)
@@ -582,7 +579,7 @@ def _erfinv(x: float) -> float:
     return p * x
 
 
-@nb.njit(cache=True)
+@nb.vectorize(cache=True)
 def _ppf(x, mu=0, std=1):
     return mu + math.sqrt(2) * _erfinv(2 * x - 1) * std
 

--- a/aeon/transformations/collection/dictionary_based/_borf.py
+++ b/aeon/transformations/collection/dictionary_based/_borf.py
@@ -182,7 +182,7 @@ class BORF(BaseCollectionTransformer):
         return self.pipe_.transform(X)
 
     @classmethod
-    def get_test_params(cls, parameter_set="default"):
+    def _get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
 
         Parameters
@@ -200,40 +200,7 @@ class BORF(BaseCollectionTransformer):
             instance. `create_test_instance` uses the first (or only) dictionary in
             `params`.
         """
-        params = [
-            {
-                "window_size_min_window_size": 4,
-                "window_size_max_window_size": None,
-                "word_lengths_n_word_lengths": 4,
-                "alphabets_min_symbols": 3,
-                "alphabets_max_symbols": 4,
-                "alphabets_step": 1,
-                "dilations_min_dilation": 1,
-                "dilations_max_dilation": None,
-                "min_window_to_signal_std_ratio": 0.0,
-                "n_jobs": 1,
-                "n_jobs_numba": 1,
-                "transformer_weights": None,
-                "complexity": "quadratic",
-                "densify": False,
-            },
-            {
-                "window_size_min_window_size": 4,
-                "window_size_max_window_size": None,
-                "word_lengths_n_word_lengths": 4,
-                "alphabets_min_symbols": 3,
-                "alphabets_max_symbols": 4,
-                "alphabets_step": 1,
-                "dilations_min_dilation": 1,
-                "dilations_max_dilation": None,
-                "min_window_to_signal_std_ratio": 0.0,
-                "n_jobs": 1,
-                "n_jobs_numba": 1,
-                "transformer_weights": None,
-                "complexity": "quadratic",
-                "densify": True,
-            },
-        ]
+        params = [{"densify": False}, {"densify": True}]
         return params
 
 
@@ -581,7 +548,10 @@ def _ndindex_2d_array(idx, dim2_shape):
 
 @nb.njit(cache=True)
 def _get_norm_bins(alphabet_size: int, mu=0, std=1):
-    return _ppf(np.linspace(0, 1, alphabet_size + 1)[1:-1], mu, std)
+    b = np.linspace(0, 1, alphabet_size + 1)[1:-1]
+    for i, v in enumerate(b):
+        b[i] = _ppf(v, mu, std)
+    return b
 
 
 @nb.njit(fastmath=True, cache=True)
@@ -612,7 +582,7 @@ def _erfinv(x: float) -> float:
     return p * x
 
 
-@nb.vectorize(cache=True)
+@nb.njit(cache=True)
 def _ppf(x, mu=0, std=1):
     return mu + math.sqrt(2) * _erfinv(2 * x - 1) * std
 

--- a/conftest.py
+++ b/conftest.py
@@ -52,7 +52,6 @@ def pytest_configure(config):
         os.environ["OPENBLAS_NUM_THREADS"] = "1"
         os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 
-        os.environ["NUMBA_NUM_THREADS"] = "1"
         import numba
 
         numba.set_num_threads(1)

--- a/conftest.py
+++ b/conftest.py
@@ -8,11 +8,24 @@ tests are run on each operating system at least once, and on each python version
 least once, but not necessarily on each operating system / python version combination.
 """
 
-__maintainer__ = []
+__maintainer__ = ["MatthewMiddlehurst"]
 
 
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
+    parser.addoption(
+        "--nonumba",
+        default=False,
+        help=("Disable numba via the NUMBA_DISABLE_JIT environment variable."),
+    )
+    parser.addoption(
+        "--enablethreading",
+        default=False,
+        help=(
+            "Allow threading and skip setting number of threads to 1 for various "
+            "libraries and environment variables."
+        ),
+    )
     parser.addoption(
         "--prtesting",
         default=False,
@@ -28,33 +41,39 @@ def pytest_configure(config):
     """Pytest configuration preamble."""
     import os
 
-    # Must be called before any numpy imports
-    os.environ["MKL_NUM_THREADS"] = "1"
-    os.environ["NUMEXPR_NUM_THREADS"] = "1"
-    os.environ["OMP_NUM_THREADS"] = "1"
-    os.environ["OPENBLAS_NUM_THREADS"] = "1"
-    os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+    if config.getoption("--nonumba") in [True, "True", "true"]:
+        os.environ["NUMBA_DISABLE_JIT"] = "1"
 
-    import numba
+    if config.getoption("--enablethreading") in [True, "True", "true"]:
+        # Must be called before any numpy imports
+        os.environ["MKL_NUM_THREADS"] = "1"
+        os.environ["NUMEXPR_NUM_THREADS"] = "1"
+        os.environ["OMP_NUM_THREADS"] = "1"
+        os.environ["OPENBLAS_NUM_THREADS"] = "1"
+        os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 
-    from aeon.testing import testing_config
-    from aeon.utils.validation._dependencies import _check_soft_dependencies
+        os.environ["NUMBA_NUM_THREADS"] = "1"
+        import numba
 
-    numba.set_num_threads(1)
+        numba.set_num_threads(1)
 
-    if _check_soft_dependencies("tensorflow", severity="none"):
-        from tensorflow.config.threading import (
-            set_inter_op_parallelism_threads,
-            set_intra_op_parallelism_threads,
-        )
+        from aeon.utils.validation._dependencies import _check_soft_dependencies
 
-        set_inter_op_parallelism_threads(1)
-        set_intra_op_parallelism_threads(1)
+        if _check_soft_dependencies("tensorflow", severity="none"):
+            from tensorflow.config.threading import (
+                set_inter_op_parallelism_threads,
+                set_intra_op_parallelism_threads,
+            )
 
-    if _check_soft_dependencies("torch", severity="none"):
-        import torch
+            set_inter_op_parallelism_threads(1)
+            set_intra_op_parallelism_threads(1)
 
-        torch.set_num_threads(1)
+        if _check_soft_dependencies("torch", severity="none"):
+            import torch
+
+            torch.set_num_threads(1)
 
     if config.getoption("--prtesting") in [True, "True", "true"]:
+        from aeon.testing import testing_config
+
         testing_config.PR_TESTING = True

--- a/conftest.py
+++ b/conftest.py
@@ -44,7 +44,7 @@ def pytest_configure(config):
     if config.getoption("--nonumba") in [True, "True", "true"]:
         os.environ["NUMBA_DISABLE_JIT"] = "1"
 
-    if config.getoption("--enablethreading") in [True, "True", "true"]:
+    if not config.getoption("--enablethreading") in [True, "True", "true"]:
         # Must be called before any numpy imports
         os.environ["MKL_NUM_THREADS"] = "1"
         os.environ["NUMEXPR_NUM_THREADS"] = "1"


### PR DESCRIPTION
~~Fixes #2245~~  See #2254

~~Fixes the current periodic and main CI failures. `numba` `vectorize` is apparently not disabled by the environmental variable, so disabling  `njit` for the function called in it breaks it since it needs to be a numba function.~~

Fixes main branch CI issue. Mainly leftover `get_test_params` from PRs before the refactor. Adds some `pytest` options for multithreading and disabling numba
