### PR TITLE
[BUG] BORF failing without numba

### DIFF
--- a/aeon/transformations/collection/dictionary_based/_borf.py
+++ b/aeon/transformations/collection/dictionary_based/_borf.py
@@ -584,7 +584,7 @@ def _get_norm_bins(alphabet_size: int, mu=0, std=1):
     return _ppf(np.linspace(0, 1, alphabet_size + 1)[1:-1], mu, std)
 
 
-@nb.njit(fastmath=True, cache=True)
+@nb.vectorize(fastmath=True, cache=True)
 def _erfinv(x: float) -> float:
     w = -math.log((1 - x) * (1 + x))
     if w < 5:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixe proposition for #2245.

#### What does this implement/fix? Explain your changes.

Replace `_erfinv` decorator from `njit` into `vectorize`.
More details in https://github.com/aeon-toolkit/aeon/issues/2245#issuecomment-2438337161

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Only tested locally, need to be tested for real.

Run numba-disabled codecov tests

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
  * Send this when change is accepted `@all-contributors add @Cyril-Meyer for bug`
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
