### PR TITLE
[BUG] Fix bug_report.yml template show_versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,7 +80,7 @@ body:
       Please run the following code snippet and paste the output here.
 
       ```python
-      from aeon.utils import show_versions; show_versions()
+      from aeon import show_versions; show_versions()
       ```
     placeholder: |
       <details>


### PR DESCRIPTION
The `show_versions()`-utility is in the package `aeon` or `aeon.utils._maint` and cannot be imported from `aeon.utils`. This fixes the template to import from `aeon`.