### PR TITLE
[ENH] fix the zero_method of the wilcoxon sign rank test to "wilcox" in mcm

### DIFF
--- a/aeon/visualisation/results/_mcm.py
+++ b/aeon/visualisation/results/_mcm.py
@@ -300,7 +300,10 @@ def _get_analysis(
         if pvalue_test == "wilcoxon":
             _pvalue_test_params = {}
             if pvalue_test_params is None:
-                _pvalue_test_params = {"zero_method": "pratt", "alternative": "greater"}
+                _pvalue_test_params = {
+                    "zero_method": "wilcox",
+                    "alternative": "greater",
+                }
             else:
                 _pvalue_test_params = pvalue_test_params
             p_value = round(wilcoxon(x=x, y=y, **_pvalue_test_params)[1], precision)


### PR DESCRIPTION
fixes #2358 sets the zero_method in mcm to "wilcox" to match scatter and cd diagrams