### PR TITLE
[BUG] Bug fix in SimpleImputer

### DIFF
--- a/aeon/transformations/collection/_impute.py
+++ b/aeon/transformations/collection/_impute.py
@@ -118,7 +118,10 @@ class SimpleImputer(BaseCollectionTransformer):
                         x,
                     )
                 else:  # if strategy is a callable function
-                    x = np.where(np.isnan(x), self.strategy(x), x)
+                    n_channels = x.shape[0]
+                    for i in range(n_channels):
+                        nan_mask = np.isnan(x[i])
+                        x[i] = np.where(nan_mask, self.strategy(x[i][nan_mask]), x[i])
                 Xt.append(x)
 
             return Xt

--- a/aeon/transformations/collection/tests/test_simple_imputer.py
+++ b/aeon/transformations/collection/tests/test_simple_imputer.py
@@ -116,3 +116,23 @@ def test_valid_parameters():
 
     with pytest.raises(ValueError):
         imputer.fit_transform(X)
+
+
+def test_callable():
+    """Test SimpleImputer with callable strategy."""
+    X, _ = make_example_3d_numpy(
+        n_cases=10, n_channels=2, n_timepoints=50, random_state=42
+    )
+    X[2, 1, 10] = np.nan
+    X[5, 0, 20] = np.nan
+
+    def dummy_strategy(x):
+        return 0
+
+    imputer = SimpleImputer(strategy=dummy_strategy)
+    Xt = imputer.fit_transform(X)
+
+    assert not np.isnan(Xt).any()
+    assert Xt.shape == X.shape
+    assert np.allclose(Xt[2, 1, 10], 0)
+    assert np.allclose(Xt[5, 0, 20], 0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs

Fixes a small bug in SimpleImputer #2347 . 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

In my previous PR #2347 , I accidentally did not notice a bug. When `strategy` is a callable, it was fitting on 2d array instead of 1d array of independent case. I was about to correct it but the PR got merged. This PR fixes that bug and includes a test case for it. 

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
