### PR TITLE
[DOC] Tidy up `index`, `governance` and `code_of_conduct` pages.

### DIFF
--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -13,7 +13,7 @@ It is expected that community members will abide by the principles of the [Pytho
 Software Foundation Code of Conduct](https://www.python.org/psf/codeofconduct/) to
 help maintain an open, considerate and respectful environment.
 
-Unacceptable behavior and code of conduct violations are determined and dealt with
+Unacceptable behaviour and code of conduct violations are determined and dealt with
 at the discretion of the `aeon` [Code of Conduct Workgroup (COCW)](./governance.md#code-of-conduct-workgroup).
 Possible actions taken include warnings, mediated meeting and/or apologies, and
 expulsion from the project depending on the severity of the breach. The COCW can edit

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,6 +1,6 @@
 # Governance
 
-The purpose of this document is to formalize the governance process used by the `aeon`
+The purpose of this document is to formalise the governance process used by the `aeon`
 project, to clarify how decisions are made and how the various elements of our community
 interact. Our goal is to ensure a transparent, democratic, and inclusive decision-making
 process that empowers all community members to contribute to the project.
@@ -109,15 +109,15 @@ necessary.
 Decisions about the future of the project are announced publicly to allow discussion
 with all members of the community. The whole process from proposal to implementation
 is fully visible, apart from topics considered sensitive. All non-sensitive project
-management discussion takes place on the contributors channel on the project
-Slack and/or the issue tracker. Occasionally, sensitive discussion and votes such as
-appointments will occur in private Slack channels.
+management discussion takes place on the project Slack and/or the issue tracker.
+Occasionally, sensitive discussion and votes such as appointments will occur in private
+Slack channels or meetings.
 
-For most decisions a consensus seeking process of all interested contributors is used.
+For most decisions, a consensus seeking process of all interested contributors is used.
 Contributors try to find a resolution that has no open objections among core developers.
 If a reasonable amount of time (at least 7-days for non-trivial changes) has passed
 since the last change to a proposed contribution, the proposal has at least one approval
-(+1) and no rejections (-1) from core developers, it can be approved by lazy consensus.
+(+1), and no rejections (-1) from core developers, it can be approved by lazy consensus.
 If a change is rejected, it is expected that an explanation and description of
 conditions (if any) to withdraw the rejection is provided.
 
@@ -137,15 +137,15 @@ emergencies where harm will come to the project unless timely action is taken.
 ### Enhancement Proposals
 
 For contentious decision-making votes (not including appointment votes), a proposal
-must have been made public for discussion before the vote. It is recommended that this
+should be made public for discussion before the vote. It is recommended that this
 proposal is made as a consolidated document, in the form of an “aeon Enhancement
 Proposal” (AEP). The AEP template is available
 [here](https://github.com/aeon-toolkit/aeon-admin/blob/main/aep/aep_template.md), but
 the use of said template is not a requirement. A detailed issue or pull request can
-substitute an AEP if all parties believe it is sufficient, but a more formal proposal
+substitute an AEP if all parties believe it is enough, but a more formal proposal
 can be requested by any core developer.
 
-Having a rejection on a pull request does not necessitate the creation of an AEP and
+Having a rejection on a pull request does not require the creation of an AEP and
 further discussion to find consensus can be held, but one must be created prior to any
 vote to bypass a rejection.
 
@@ -155,7 +155,7 @@ submitted to the community for discussion and comment.
 
 ## Acknowledgements
 
-Substantial portions of this document were adapted from or inspired by the following
+Significant portions of this document were adapted from or inspired by the following
 projects governance documents:
 
 - [Scikit-learn](https://scikit-learn.org/stable/governance.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ hide-toc: true
 
 # Welcome to __aeon__
 
-`aeon` is a scikit-learn compatible toolkit for time series machine learning tasks
-such as anomaly detection, classification, clustering, forecasting, regression,
-segmentation and similarity search.</p>
+`aeon` is a `scikit-learn` compatible toolkit for time series machine learning tasks
+such as classification, regression, clustering, anomaly detection,
+segmentation and similarity search.
 
 - We provide a broad library of time series algorithms, including the latest
   advances and state-of-the-art for many tasks.
@@ -17,22 +17,6 @@ segmentation and similarity search.</p>
 - We provide a range of tools for reproducing benchmarking results and evaluating time
   series algorithms implemented in `aeon` and other `scikit-learn` compatible packages.
 
-```{admonition} Large scale changes for aeon v1.0.0
-We are currently working on v1.0.0 of aeon, which includes a number of large changes
-to better support the maintainability of the library and the direction the developer
-community wish to take the package.
-
-This includes the removal of current modules such as forecasting (to be reintroduced
-under a different interface), datatypes and the legacy BaseTransformer interface. We
-will also be making large changes to the base class API, removing `BaseObject` various
-functions associated with the base module currently.
-
-We hope these changes and the removal of long-untouched legacy code will allow aeon to
-grow and develop in a more sustainable way without the need for such large breaking
-changes in the future. Some of these changes will not come with a deprecation warning,
-so be wary of this when updating to v1.0.0 when it is released.
-```
-
 ## Community Channels
 
 **GitHub**: [github.com/aeon-toolkit/aeon](https://github.com/aeon-toolkit/aeon)
@@ -42,6 +26,8 @@ so be wary of this when updating to v1.0.0 when it is released.
 **Twitter**: [twitter/aeon-toolkit](https://twitter.com/aeon_toolkit)
 
 **LinkedIn**: [linkedin/aeon-toolkit](https://www.linkedin.com/company/aeon-toolkit)
+
+**Email**: [contact@aeon-toolkit.org](mailto:contact@aeon-toolkit.org)
 
 ## Modules
 
@@ -129,7 +115,7 @@ Anomaly Detection
 :class-img-top: aeon-card-image
 :text-align: center
 
-Segmentation
+Get started with segmentation
 
 +++
 
@@ -186,7 +172,7 @@ Distances
 :class-img-top: aeon-card-image
 :text-align: center
 
-Similarity Search
+Get started with time series similarity search
 
 +++
 
@@ -259,6 +245,17 @@ Networks
 
 ::::
 
+## Experimental Modules
+
+Some modules of `aeon` are still experimental and may have changing interfaces.
+To support development on these modules, the [deprecation policy](developer_guide/deprecation.md)
+is relaxed, so it is suggested that you integrate these modules with care. The current
+experimental modules are:
+
+- `anomaly_detection`
+- `segmentation`
+- `similarity_search`
+- `visualisation`
 
 ```{toctree}
 :caption: Using aeon


### PR DESCRIPTION
For the most part both the code of conduct and governance remain the same, it is just minor language changes. The exception to this is an alteration to 

> All non-sensitive project management discussion takes place on the contributors channel on the project Slack and/or the issue tracker. Occasionally, sensitive discussion and votes such as appointments will occur in private Slack channels.

as this has turned out to not really match how we develop since the time the document was created. The changes here could be seen as an alteration of expected practice. 

The index page removes the big v1.0.0 warning, mention of forecasting (for now), and adds experimental modules.