### PR TITLE
[ENH] convert list ogf 1D numpy to 2D

### DIFF
--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -1,5 +1,7 @@
 """Base class for estimators that fit collections of time series."""
 
+import numpy as np
+
 from aeon.base._base import BaseAeonEstimator
 from aeon.utils.conversion import (
     convert_collection,
@@ -79,6 +81,8 @@ class BaseCollectionEstimator(BaseAeonEstimator):
         >>> X2.shape
         (10, 1, 20)
         """
+        if isinstance(X, list) and isinstance(X[0], np.ndarray):
+            X = self._reshape_np_list(X)
         meta = self._check_X(X)
         if len(self.metadata_) == 0 and store_metadata:
             self.metadata_ = meta
@@ -267,3 +271,20 @@ class BaseCollectionEstimator(BaseAeonEstimator):
             None if metadata["unequal_length"] else get_n_timepoints(X)
         )
         return metadata
+
+    @staticmethod
+    def _reshape_np_list(X):
+        """Reshape 1D numpy to be 2D."""
+        reshape = False
+        for x in X:
+            if x.ndim == 1:
+                reshape = True
+                break
+        if reshape:
+            X2 = []
+            for x in X:
+                if x.ndim == 1:
+                    x = x.reshape(1, -1)
+                X2.append(x)
+            return X2
+        return X

--- a/aeon/base/tests/test_base_collection.py
+++ b/aeon/base/tests/test_base_collection.py
@@ -234,3 +234,16 @@ def test_preprocess_collection(data):
     meta = cls.metadata_
     cls._preprocess_collection(data2)
     assert meta == cls.metadata_
+
+
+def test_convert_np_list():
+    """Test np-list of 1D numpy converted to 2D."""
+    x1 = np.random.random(size=(1, 10))
+    x2 = np.random.rand(20)
+    x3 = np.random.rand(30)
+    np_list = [x1, x2, x3]
+    np2 = BaseCollectionEstimator._reshape_np_list(np_list)
+    assert len(np2) == len(np_list)
+    assert np2[0].shape == (1, 10)
+    assert np2[1].shape == (1, 20)
+    assert np2[2].shape == (1, 30)


### PR DESCRIPTION
allows the input of a list of 1D numpy for unequal length univariate collections. Simple test and conversion in _preprocess_collection in BaseCollection, bound to work first time