### PR TITLE
[MNT] Deprecation in deep clustering module

### DIFF
--- a/aeon/clustering/deep_learning/_ae_abgru.py
+++ b/aeon/clustering/deep_learning/_ae_abgru.py
@@ -20,10 +20,6 @@ class AEAttentionBiGRUClusterer(BaseDeepClusterer):
 
     Parameters
     ----------
-    clustering_algorithm : str, default="deprecated"
-        Use 'estimator' parameter instead.
-    clustering_params : dict, default=None
-        Use 'estimator' parameter instead.
     estimator : aeon clusterer, default=None
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
@@ -105,8 +101,6 @@ class AEAttentionBiGRUClusterer(BaseDeepClusterer):
     def __init__(
         self,
         estimator=None,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         latent_space_dim=128,
         n_layers_encoder=2,
         n_layers_decoder=2,
@@ -150,8 +144,6 @@ class AEAttentionBiGRUClusterer(BaseDeepClusterer):
         self.random_state = random_state
 
         super().__init__(
-            clustering_algorithm=clustering_algorithm,
-            clustering_params=clustering_params,
             estimator=estimator,
             batch_size=batch_size,
             last_file_name=last_file_name,

--- a/aeon/clustering/deep_learning/_ae_bgru.py
+++ b/aeon/clustering/deep_learning/_ae_bgru.py
@@ -20,10 +20,6 @@ class AEBiGRUClusterer(BaseDeepClusterer):
 
     Parameters
     ----------
-    clustering_algorithm : str, default="deprecated"
-        Use 'estimator' parameter instead.
-    clustering_params : dict, default=None
-        Use 'estimator' parameter instead.
     estimator : aeon clusterer, default=None
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
@@ -103,9 +99,7 @@ class AEBiGRUClusterer(BaseDeepClusterer):
 
     def __init__(
         self,
-        clustering_algorithm="deprecated",
         estimator=None,
-        clustering_params=None,
         latent_space_dim=128,
         temporal_latent_space=False,
         n_layers=2,
@@ -149,8 +143,6 @@ class AEBiGRUClusterer(BaseDeepClusterer):
         self.random_state = random_state
 
         super().__init__(
-            clustering_algorithm=clustering_algorithm,
-            clustering_params=clustering_params,
             estimator=estimator,
             batch_size=batch_size,
             last_file_name=last_file_name,

--- a/aeon/clustering/deep_learning/_ae_dcnn.py
+++ b/aeon/clustering/deep_learning/_ae_dcnn.py
@@ -19,10 +19,6 @@ class AEDCNNClusterer(BaseDeepClusterer):
 
     Parameters
     ----------
-    clustering_algorithm : str, default="deprecated"
-        Use 'estimator' parameter instead.
-    clustering_params : dict, default=None
-        Use 'estimator' parameter instead.
     estimator : aeon clusterer, default=None
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
@@ -118,8 +114,6 @@ class AEDCNNClusterer(BaseDeepClusterer):
     def __init__(
         self,
         estimator=None,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         latent_space_dim=128,
         temporal_latent_space=False,
         n_layers=3,
@@ -171,8 +165,6 @@ class AEDCNNClusterer(BaseDeepClusterer):
         self.random_state = random_state
 
         super().__init__(
-            clustering_params=clustering_params,
-            clustering_algorithm=clustering_algorithm,
             estimator=estimator,
             batch_size=batch_size,
             last_file_name=last_file_name,

--- a/aeon/clustering/deep_learning/_ae_drnn.py
+++ b/aeon/clustering/deep_learning/_ae_drnn.py
@@ -24,14 +24,10 @@ class AEDRNNClusterer(BaseDeepClusterer):
 
     Parameters
     ----------
-    clustering_algorithm : str, default="deprecated"
-        Please use the 'estimator' parameter.
     estimator : aeon clusterer, default=None
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
         and mean averaging method and n_clusters set to 2.
-    clustering_params : dict, default=None
-        Please use 'estimator' parameter.
     latent_space_dim : int, default=128
         Dimension of the latent space of the auto-encoder.
     temporal_latent_space : bool, default = False
@@ -119,8 +115,6 @@ class AEDRNNClusterer(BaseDeepClusterer):
     def __init__(
         self,
         estimator=None,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         latent_space_dim=128,
         temporal_latent_space=False,
         n_layers_encoder=3,
@@ -175,8 +169,6 @@ class AEDRNNClusterer(BaseDeepClusterer):
 
         super().__init__(
             estimator=estimator,
-            clustering_algorithm=clustering_algorithm,
-            clustering_params=clustering_params,
             batch_size=batch_size,
             last_file_name=last_file_name,
         )

--- a/aeon/clustering/deep_learning/_ae_fcn.py
+++ b/aeon/clustering/deep_learning/_ae_fcn.py
@@ -25,10 +25,6 @@ class AEFCNClusterer(BaseDeepClusterer):
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
         and mean averaging method and n_clusters set to 2.
-    clustering_algorithm : str, default="deprecated"
-        Please use 'estimator' parameter.
-    clustering_params : dict, default=None
-        Please use 'estimator' parameter.
     latent_space_dim : int, default=128
         Dimension of the latent space of the auto-encoder.
     temporal_latent_space : bool, default = False
@@ -127,8 +123,6 @@ class AEFCNClusterer(BaseDeepClusterer):
     def __init__(
         self,
         estimator=None,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         latent_space_dim=128,
         temporal_latent_space=False,
         n_layers=3,
@@ -183,8 +177,6 @@ class AEFCNClusterer(BaseDeepClusterer):
 
         super().__init__(
             estimator=estimator,
-            clustering_algorithm=clustering_algorithm,
-            clustering_params=clustering_params,
             batch_size=batch_size,
             last_file_name=last_file_name,
         )

--- a/aeon/clustering/deep_learning/_ae_resnet.py
+++ b/aeon/clustering/deep_learning/_ae_resnet.py
@@ -28,10 +28,6 @@ class AEResNetClusterer(BaseDeepClusterer):
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
         and mean averaging method and n_clusters set to 2.
-    clustering_algorithm : str, default="deprecated"
-        Please use 'estimator' parameter.
-    clustering_params : dict, default=None
-        Please use 'estimator' parameter.
     latent_space_dim : int, default=128
         Dimension of the latent space of the auto-encoder.
     temporal_latent_space : bool, default = False
@@ -137,8 +133,6 @@ class AEResNetClusterer(BaseDeepClusterer):
         self,
         estimator=None,
         n_residual_blocks=3,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         n_conv_per_residual_block=3,
         n_filters=None,
         kernel_size=None,
@@ -193,8 +187,6 @@ class AEResNetClusterer(BaseDeepClusterer):
 
         super().__init__(
             estimator=estimator,
-            clustering_algorithm=clustering_algorithm,
-            clustering_params=clustering_params,
             batch_size=batch_size,
             last_file_name=last_file_name,
         )

--- a/aeon/clustering/deep_learning/base.py
+++ b/aeon/clustering/deep_learning/base.py
@@ -15,16 +15,10 @@ class BaseDeepClusterer(BaseClusterer):
 
     Parameters
     ----------
-    n_clusters : int, default=None
-        Please use 'estimator' parameter.
     estimator : aeon clusterer, default=None
         An aeon estimator to be built using the transformed data.
         Defaults to aeon TimeSeriesKMeans() with euclidean distance
         and mean averaging method and n_clusters set to 2.
-    clustering_algorithm : str, default="deprecated"
-        Please use 'estimator' parameter.
-    clustering_params : dict, default=None
-        Please use 'estimator' parameter.
     batch_size : int, default = 40
         training batch size for the model
     last_file_name : str, default = "last_model"
@@ -46,14 +40,10 @@ class BaseDeepClusterer(BaseClusterer):
     def __init__(
         self,
         estimator=None,
-        clustering_algorithm="deprecated",
-        clustering_params=None,
         batch_size=32,
         last_file_name="last_model",
     ):
         self.estimator = estimator
-        self.clustering_algorithm = clustering_algorithm
-        self.clustering_params = clustering_params
         self.batch_size = batch_size
         self.last_file_name = last_file_name
 
@@ -110,8 +100,6 @@ class BaseDeepClusterer(BaseClusterer):
         X : np.ndarray, shape=(n_cases, n_timepoints, n_channels)
             The input time series.
         """
-        import warnings
-
         self._estimator = (
             TimeSeriesKMeans(
                 n_clusters=2, distance="euclidean", averaging_method="mean"
@@ -119,22 +107,6 @@ class BaseDeepClusterer(BaseClusterer):
             if self.estimator is None
             else _clone_estimator(self.estimator)
         )
-
-        # to be removed in 1.0.0
-        if (
-            self.clustering_algorithm != "deprecated"
-            or self.clustering_params is not None
-        ):
-            warnings.warn(
-                "The 'n_clusters' 'clustering_algorithm' and "
-                "'clustering_params' parameters "
-                "will be removed in v1.0.0. "
-                "Their usage will not have an effect, "
-                "please use the new 'estimator' parameter to directly "
-                "give an aeon clusterer as input.",
-                FutureWarning,
-                stacklevel=2,
-            )
 
         latent_space = self.model_.layers[1].predict(X)
         self._estimator.fit(X=latent_space)


### PR DESCRIPTION
Part of #1518 
deprecating `clustering_algorithm` and `clustering_params` arguments as they were replaced by `estimator`