### PR TITLE
[MNT] Change the "metric" parameter to "measure in the distance module

### DIFF
--- a/aeon/classification/distance_based/_proximity_tree.py
+++ b/aeon/classification/distance_based/_proximity_tree.py
@@ -234,7 +234,7 @@ class ProximityTree(BaseClassifier):
                     dist = distance(
                         X[j],
                         splitter[0][labels[k]],
-                        metric=measure,
+                        measure=measure,
                         **splitter[1][measure],
                     )
                     if dist < min_dist:
@@ -320,7 +320,7 @@ class ProximityTree(BaseClassifier):
                 dist = distance(
                     X[i],
                     splitter[0][labels[j]],
-                    metric=measure,
+                    measure=measure,
                     **splitter[1][measure],
                 )
                 if dist < min_dist:
@@ -404,7 +404,7 @@ class ProximityTree(BaseClassifier):
                 dist = distance(
                     x,
                     treenode.splitter[0][branches[i]],
-                    metric=measure,
+                    measure=measure,
                     **treenode.splitter[1][measure],
                 )
                 if dist < min_dist:

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -111,7 +111,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         y : array-like, shape = (n_cases)
             The class labels.
         """
-        self.metric_ = get_distance_function(metric=self.distance)
+        self.metric_ = get_distance_function(measure=self.distance)
         self.X_ = X
         self.classes_, self.y_ = np.unique(y, return_inverse=True)
         return self

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -189,7 +189,7 @@ class TimeSeriesCLARA(BaseClusterer):
             curr_centers = pam.cluster_centers_
             if isinstance(pam.distance, str):
                 pairwise_matrix = pairwise_distance(
-                    X, curr_centers, metric=self.distance, **pam._distance_params
+                    X, curr_centers, measure=self.distance, **pam._distance_params
                 )
             else:
                 pairwise_matrix = pairwise_distance(

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -42,7 +42,7 @@ class TimeSeriesCLARA(BaseClusterer):
         If a np.ndarray provided it must be of shape (n_clusters,) and contain
         the indexes of the time series to use as centroids.
     distance : str or Callable, default='msm'
-        Distance metric to compute similarity between time series. A list of valid
+        Distance measure to compute similarity between time series. A list of valid
         strings for metrics can be found in the documentation for
         :func:`aeon.distances.get_distance_function`. If a callable is passed it must be
         a function that takes two 2d numpy arrays as input and returns a float.
@@ -73,7 +73,7 @@ class TimeSeriesCLARA(BaseClusterer):
         If `None`, the random number generator is the `RandomState` instance used
         by `np.random`.
     distance_params : dict, default=None
-        Dictionary containing kwargs for the distance metric being used.
+        Dictionary containing kwargs for the distance measure being used.
 
     Attributes
     ----------

--- a/aeon/clustering/_clarans.py
+++ b/aeon/clustering/_clarans.py
@@ -43,8 +43,8 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
         If a np.ndarray provided it must be of shape (n_clusters,) and contain
         the indexes of the time series to use as centroids.
     distance : str or Callable, default='msm'
-        Distance metric to compute similarity between time series. A list of valid
-        strings for metrics can be found in the documentation for
+        Distance measure to compute similarity between time series. A list of valid
+        strings for measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function`. If a callable is passed it must be
         a function that takes two 2d numpy arrays as input and returns a float.
     max_neighbours : int, default=None,
@@ -62,7 +62,7 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
     random_state : int or np.random.RandomState instance or None, default=None
         Determines random number generation for centroid initialization.
     distance_params : dict, default=None
-        Dictionary containing kwargs for the distance metric being used.
+        Dictionary containing kwargs for the distance measure being used.
 
     Attributes
     ----------

--- a/aeon/clustering/_elastic_som.py
+++ b/aeon/clustering/_elastic_som.py
@@ -224,7 +224,7 @@ class ElasticSOM(BaseClusterer):
         pairwise_matrix = pairwise_distance(
             x,
             weights,
-            metric=self.distance,
+            measure=self.distance,
             **self._distance_params,
         )
         return pairwise_matrix.argmin(axis=1)
@@ -366,7 +366,7 @@ class ElasticSOM(BaseClusterer):
 
         for _ in range(1, self.n_clusters):
             pw_dist = pairwise_distance(
-                X, X[indexes], metric=self.distance, **self._distance_params
+                X, X[indexes], measure=self.distance, **self._distance_params
             )
             min_distances = pw_dist.min(axis=1)
             probabilities = min_distances / min_distances.sum()

--- a/aeon/clustering/_elastic_som.py
+++ b/aeon/clustering/_elastic_som.py
@@ -44,8 +44,8 @@ class ElasticSOM(BaseClusterer):
     n_clusters : int, default=8
         The number of clusters to form as well as the number of centroids to generate.
     distance : str or Callable, default='dtw'
-        Distance metric to compute similarity between time series. A list of valid
-        strings for metrics can be found in the documentation for
+        Distance measure to compute similarity between time series. A list of valid
+        strings for measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function`. If a callable is passed it must be
         a function that takes two 2d numpy arrays as input and returns a float.
     init : str or np.ndarray, default='random'

--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -236,7 +236,7 @@ class TimeSeriesKMeans(BaseClusterer):
         prev_labels = None
         for i in range(self.max_iter):
             curr_pw = pairwise_distance(
-                X, cluster_centres, metric=self.distance, **self._distance_params
+                X, cluster_centres, measure=self.distance, **self._distance_params
             )
             curr_labels = curr_pw.argmin(axis=1)
             curr_inertia = curr_pw.min(axis=1).sum()
@@ -273,13 +273,13 @@ class TimeSeriesKMeans(BaseClusterer):
     def _predict(self, X: np.ndarray, y=None) -> np.ndarray:
         if isinstance(self.distance, str):
             pairwise_matrix = pairwise_distance(
-                X, self.cluster_centers_, metric=self.distance, **self._distance_params
+                X, self.cluster_centers_, measure=self.distance, **self._distance_params
             )
         else:
             pairwise_matrix = pairwise_distance(
                 X,
                 self.cluster_centers_,
-                metric=self.distance,
+                measure=self.distance,
                 **self._distance_params,
             )
         return pairwise_matrix.argmin(axis=1)
@@ -346,7 +346,7 @@ class TimeSeriesKMeans(BaseClusterer):
 
         for _ in range(1, self.n_clusters):
             pw_dist = pairwise_distance(
-                X, X[indexes], metric=self.distance, **self._distance_params
+                X, X[indexes], measure=self.distance, **self._distance_params
             )
             min_distances = pw_dist.min(axis=1)
             probabilities = min_distances / min_distances.sum()
@@ -381,7 +381,7 @@ class TimeSeriesKMeans(BaseClusterer):
             index_furthest_from_centre = curr_pw.min(axis=1).argmax()
             cluster_centres[current_empty_cluster_index] = X[index_furthest_from_centre]
             curr_pw = pairwise_distance(
-                X, cluster_centres, metric=self.distance, **self._distance_params
+                X, cluster_centres, measure=self.distance, **self._distance_params
             )
             curr_labels = curr_pw.argmin(axis=1)
             curr_inertia = curr_pw.min(axis=1).sum()

--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -54,8 +54,8 @@ class TimeSeriesKMeans(BaseClusterer):
         n_timepoints)
         and contains the time series to use as centroids.
     distance : str or Callable, default='msm'
-        Distance metric to compute similarity between time series. A list of valid
-        strings for metrics can be found in the documentation for
+        Distance measure to compute similarity between time series. A list of valid
+        strings for measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function`. If a callable is passed it must be
         a function that takes two 2d numpy arrays as input and returns a float.
     n_init : int, default=10

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -211,7 +211,7 @@ class TimeSeriesKMedoids(BaseClusterer):
     def _predict(self, X: np.ndarray, y=None) -> np.ndarray:
         if isinstance(self.distance, str):
             pairwise_matrix = pairwise_distance(
-                X, self.cluster_centers_, metric=self.distance, **self._distance_params
+                X, self.cluster_centers_, measure=self.distance, **self._distance_params
             )
         else:
             pairwise_matrix = pairwise_distance(
@@ -456,7 +456,7 @@ class TimeSeriesKMedoids(BaseClusterer):
                 f"n_clusters ({self.n_clusters}) cannot be larger than "
                 f"n_cases ({X.shape[0]})"
             )
-        self._distance_callable = get_distance_function(metric=self.distance)
+        self._distance_callable = get_distance_function(measure=self.distance)
         self._distance_cache = np.full((X.shape[0], X.shape[0]), np.inf)
 
         if self.method == "alternate":
@@ -486,7 +486,7 @@ class TimeSeriesKMedoids(BaseClusterer):
 
         for _ in range(1, self.n_clusters):
             pw_dist = pairwise_distance(
-                X, X[indexes], metric=self.distance, **self._distance_params
+                X, X[indexes], measure=self.distance, **self._distance_params
             )
             min_distances = pw_dist.min(axis=1)
             probabilities = min_distances / min_distances.sum()

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -56,8 +56,8 @@ class TimeSeriesKMedoids(BaseClusterer):
         If a np.ndarray provided it must be of shape (n_clusters,) and contain
         the indexes of the time series to use as centroids.
     distance : str or Callable, default='msm'
-        Distance metric to compute similarity between time series. A list of valid
-        strings for metrics can be found in the documentation for
+        Distance measure to compute similarity between time series. A list of valid
+        strings for measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function`. If a callable is passed it must be
         a function that takes two 2d numpy arrays as input and returns a float.
     method : str, default='pam'
@@ -88,7 +88,7 @@ class TimeSeriesKMedoids(BaseClusterer):
         If `None`, the random number generator is the `RandomState` instance used
         by `np.random`.
     distance_params: dict, default=None
-        Dictionary containing kwargs for the distance metric being used.
+        Dictionary containing kwargs for the distance measure being used.
 
     Attributes
     ----------

--- a/aeon/clustering/averaging/_ba_petitjean.py
+++ b/aeon/clustering/averaging/_ba_petitjean.py
@@ -55,7 +55,7 @@ def petitjean_barycenter_average(
     random_state: int or None, default=None
         Random state to use for the barycenter averaging.
     **kwargs
-        Keyword arguments to pass to the distance metric.
+        Keyword arguments to pass to the distance measure.
 
     Returns
     -------

--- a/aeon/clustering/averaging/_ba_subgradient.py
+++ b/aeon/clustering/averaging/_ba_subgradient.py
@@ -70,7 +70,7 @@ def subgradient_barycenter_average(
     random_state: int or None, default=None
         Random state to use for the barycenter averaging.
     **kwargs
-        Keyword arguments to pass to the distance metric.
+        Keyword arguments to pass to the distance measure.
 
     Returns
     -------

--- a/aeon/clustering/averaging/_ba_utils.py
+++ b/aeon/clustering/averaging/_ba_utils.py
@@ -31,7 +31,7 @@ def _medoids(
         return X
 
     if precomputed_pairwise_distance is None:
-        precomputed_pairwise_distance = pairwise_distance(X, metric=distance, **kwargs)
+        precomputed_pairwise_distance = pairwise_distance(X, measure=distance, **kwargs)
 
     x_size = X.shape[0]
     distance_matrix = np.zeros((x_size, x_size))

--- a/aeon/clustering/averaging/_ba_utils.py
+++ b/aeon/clustering/averaging/_ba_utils.py
@@ -155,6 +155,6 @@ def _get_alignment_path(
     elif distance == "adtw":
         return adtw_alignment_path(ts, center, window=window, warp_penalty=warp_penalty)
     else:
-        # When numba version > 0.57 add more informative error with what metric
+        # When numba version > 0.57 add more informative error with what measure
         # was passed.
         raise ValueError("Distance parameter invalid")

--- a/aeon/clustering/averaging/_barycenter_averaging.py
+++ b/aeon/clustering/averaging/_barycenter_averaging.py
@@ -84,7 +84,7 @@ def elastic_barycenter_average(
     random_state: int or None, default=None
         Random state to use for the barycenter averaging.
     **kwargs
-        Keyword arguments to pass to the distance metric.
+        Keyword arguments to pass to the distance measure.
 
     Returns
     -------

--- a/aeon/distances/_distance.py
+++ b/aeon/distances/_distance.py
@@ -118,7 +118,7 @@ PairwiseFunction = Callable[[np.ndarray, np.ndarray, Any], np.ndarray]
 def distance(
     x: np.ndarray,
     y: np.ndarray,
-    metric: Union[str, DistanceFunction],
+    measure: Union[str, DistanceFunction],
     **kwargs: Unpack[DistanceKwargs],
 ) -> float:
     """Compute the distance between two time series.
@@ -131,13 +131,13 @@ def distance(
     y : np.ndarray
         Second time series, either univariate, shape ``(n_timepoints,)``, or
         multivariate, shape ``(n_channels, n_timepoints)``.
-    metric : str or Callable
-        The distance metric to use.
-        A list of valid distance metrics can be found in the documentation for
+    measure : str or Callable
+        The distance measure to use.
+        A list of valid distance measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function` or by calling  the function
         :func:`aeon.distances.get_distance_function_names`.
     kwargs : Any
-        Arguments for metric. Refer to each metrics documentation for a list of
+        Arguments for measure. Refer to each measure documentation for a list of
         possible arguments.
 
     Returns
@@ -149,7 +149,7 @@ def distance(
     ------
     ValueError
         If x and y are not 1D, or 2D arrays.
-        If metric is not a valid string or callable.
+        If measure is not a valid string or callable.
 
     Examples
     --------
@@ -157,21 +157,21 @@ def distance(
     >>> from aeon.distances import distance
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
-    >>> distance(x, y, metric="dtw")
+    >>> distance(x, y, measure="dtw")
     768.0
     """
-    if metric in DISTANCES_DICT:
-        return DISTANCES_DICT[metric]["distance"](x, y, **kwargs)
-    elif isinstance(metric, Callable):
-        return metric(x, y, **kwargs)
+    if measure in DISTANCES_DICT:
+        return DISTANCES_DICT[measure]["distance"](x, y, **kwargs)
+    elif isinstance(measure, Callable):
+        return measure(x, y, **kwargs)
     else:
-        raise ValueError("Metric must be one of the supported strings or a callable")
+        raise ValueError("Measure must be one of the supported strings or a callable")
 
 
 def pairwise_distance(
     x: np.ndarray,
     y: Optional[np.ndarray] = None,
-    metric: Union[str, DistanceFunction, None] = None,
+    measure: Union[str, DistanceFunction, None] = None,
     symmetric: bool = True,
     **kwargs: Unpack[DistanceKwargs],
 ) -> np.ndarray:
@@ -185,20 +185,20 @@ def pairwise_distance(
     y : np.ndarray or None, default=None
        A single series or a collection of time series of shape ``(m_timepoints,)`` or
        ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``
-    metric : str or Callable
-        The distance metric to use.
-        A list of valid distance metrics can be found in the documentation for
+    measure : str or Callable
+        The distance measure to use.
+        A list of valid distance measure can be found in the documentation for
         :func:`aeon.distances.get_distance_function` or by calling  the function
         :func:`aeon.distances.get_distance_function_names`.
     symmetric : bool, default=True
-        If True and a function is provided as the "metric" paramter, then it will
+        If True and a function is provided as the "measure" paramter, then it will
         compute a symmetric distance matrix where d(x, y) = d(y, x). Only the lower
         triangle is calculated, and the upper triangle is ignored. If False and a
-        function is provided as the "metric" parameter, then it will compute an
+        function is provided as the "measure" parameter, then it will compute an
         asymmetric distance matrix, and the entire matrix (including both upper and
         lower triangles) is returned.
     kwargs : Any
-        Extra arguments for metric. Refer to each metric documentation for a list of
+        Extra arguments for measure. Refer to each measure documentation for a list of
         possible arguments.
 
     Returns
@@ -211,7 +211,7 @@ def pairwise_distance(
     ValueError
         If X is not 2D or 3D array when only passing X.
         If X and y are not 1D, 2D or 3D arrays when passing both X and y.
-        If metric is not a valid string or callable.
+        If measure is not a valid string or callable.
 
     Examples
     --------
@@ -219,7 +219,7 @@ def pairwise_distance(
     >>> from aeon.distances import pairwise_distance
     >>> # Distance between each time series in a collection of time series
     >>> X = np.array([[[1, 2, 3]],[[4, 5, 6]], [[7, 8, 9]]])
-    >>> pairwise_distance(X, metric='dtw')
+    >>> pairwise_distance(X, measure='dtw')
     array([[  0.,  26., 108.],
            [ 26.,   0.,  26.],
            [108.,  26.,   0.]])
@@ -227,26 +227,26 @@ def pairwise_distance(
     >>> # Distance between two collections of time series
     >>> X = np.array([[[1, 2, 3]],[[4, 5, 6]], [[7, 8, 9]]])
     >>> y = np.array([[[11, 12, 13]],[[14, 15, 16]], [[17, 18, 19]]])
-    >>> pairwise_distance(X, y, metric='dtw')
+    >>> pairwise_distance(X, y, measure='dtw')
     array([[300., 507., 768.],
            [147., 300., 507.],
            [ 48., 147., 300.]])
 
     >>> X = np.array([[[1, 2, 3]],[[4, 5, 6]], [[7, 8, 9]]])
     >>> y_univariate = np.array([11, 12, 13])
-    >>> pairwise_distance(X, y_univariate, metric='dtw')
+    >>> pairwise_distance(X, y_univariate, measure='dtw')
     array([[300.],
            [147.],
            [ 48.]])
     """
-    if metric in PAIRWISE_DISTANCE:
-        return DISTANCES_DICT[metric]["pairwise_distance"](x, y, **kwargs)
-    elif isinstance(metric, Callable):
+    if measure in PAIRWISE_DISTANCE:
+        return DISTANCES_DICT[measure]["pairwise_distance"](x, y, **kwargs)
+    elif isinstance(measure, Callable):
         if y is None and not symmetric:
-            return _custom_func_pairwise(x, x, metric, **kwargs)
-        return _custom_func_pairwise(x, y, metric, **kwargs)
+            return _custom_func_pairwise(x, x, measure, **kwargs)
+        return _custom_func_pairwise(x, y, measure, **kwargs)
     else:
-        raise ValueError("Metric must be one of the supported strings or a callable")
+        raise ValueError("Measure must be one of the supported strings or a callable")
 
 
 def _custom_func_pairwise(
@@ -302,7 +302,7 @@ def _custom_from_multiple_to_multiple_distance(
 def alignment_path(
     x: np.ndarray,
     y: np.ndarray,
-    metric: Union[str, DistanceFunction, None] = None,
+    measure: Union[str, DistanceFunction, None] = None,
     **kwargs: Unpack[DistanceKwargs],
 ) -> tuple[list[tuple[int, int]], float]:
     """Compute the alignment path and distance between two time series.
@@ -313,13 +313,13 @@ def alignment_path(
         First time series.
     y : np.ndarray, of shape (m_channels, m_timepoints) or (m_timepoints,)
         Second time series.
-    metric : str or Callable
-        The distance metric to use.
-        A list of valid distance metrics can be found in the documentation for
+    measure : str or Callable
+        The distance measure to use.
+        A list of valid distance measure can be found in the documentation for
         :func:`aeon.distances.get_distance_function` or by calling  the function
         :func:`aeon.distances.get_distance_function_names`.
     kwargs : any
-        Arguments for metric. Refer to each metrics documentation for a list of
+        Arguments for measure. Refer to each measure documentation for a list of
         possible arguments.
 
     Returns
@@ -335,7 +335,7 @@ def alignment_path(
     ------
     ValueError
         If x and y are not 1D, or 2D arrays.
-        If metric is not one of the supported strings or a callable.
+        If measure is not one of the supported strings or a callable.
 
     Examples
     --------
@@ -343,21 +343,21 @@ def alignment_path(
     >>> from aeon.distances import alignment_path
     >>> x = np.array([[1, 2, 3, 6]])
     >>> y = np.array([[1, 2, 3, 4]])
-    >>> alignment_path(x, y, metric='dtw')
+    >>> alignment_path(x, y, measure='dtw')
     ([(0, 0), (1, 1), (2, 2), (3, 3)], 4.0)
     """
-    if metric in ALIGNMENT_PATH:
-        return DISTANCES_DICT[metric]["alignment_path"](x, y, **kwargs)
-    elif isinstance(metric, Callable):
-        return metric(x, y, **kwargs)
+    if measure in ALIGNMENT_PATH:
+        return DISTANCES_DICT[measure]["alignment_path"](x, y, **kwargs)
+    elif isinstance(measure, Callable):
+        return measure(x, y, **kwargs)
     else:
-        raise ValueError("Metric must be one of the supported strings")
+        raise ValueError("Measure must be one of the supported strings")
 
 
 def cost_matrix(
     x: np.ndarray,
     y: np.ndarray,
-    metric: Union[str, DistanceFunction, None] = None,
+    measure: Union[str, DistanceFunction, None] = None,
     **kwargs: Unpack[DistanceKwargs],
 ) -> np.ndarray:
     """Compute the alignment path and distance between two time series.
@@ -368,13 +368,13 @@ def cost_matrix(
         First time series.
     y : np.ndarray, of shape (m_channels, m_timepoints) or (m_timepoints,)
         Second time series.
-    metric : str or Callable
-        The distance metric to use.
-        A list of valid distance metrics can be found in the documentation for
+    measure : str or Callable
+        The distance measure to use.
+        A list of valid distance measures can be found in the documentation for
         :func:`aeon.distances.get_distance_function` or by calling  the function
         :func:`aeon.distances.get_distance_function_names`.
     kwargs : Any
-        Arguments for metric. Refer to each metrics documentation for a list of
+        Arguments for measure. Refer to each measures documentation for a list of
         possible arguments.
 
     Returns
@@ -386,7 +386,7 @@ def cost_matrix(
     ------
     ValueError
         If x and y are not 1D, or 2D arrays.
-        If metric is not one of the supported strings or a callable.
+        If measure is not one of the supported strings or a callable.
 
     Examples
     --------
@@ -394,7 +394,7 @@ def cost_matrix(
     >>> from aeon.distances import cost_matrix
     >>> x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     >>> y = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
-    >>> cost_matrix(x, y, metric="dtw")
+    >>> cost_matrix(x, y, measure="dtw")
     array([[  0.,   1.,   5.,  14.,  30.,  55.,  91., 140., 204., 285.],
            [  1.,   0.,   1.,   5.,  14.,  30.,  55.,  91., 140., 204.],
            [  5.,   1.,   0.,   1.,   5.,  14.,  30.,  55.,  91., 140.],
@@ -406,12 +406,12 @@ def cost_matrix(
            [204., 140.,  91.,  55.,  30.,  14.,   5.,   1.,   0.,   1.],
            [285., 204., 140.,  91.,  55.,  30.,  14.,   5.,   1.,   0.]])
     """
-    if metric in COST_MATRIX:
-        return DISTANCES_DICT[metric]["cost_matrix"](x, y, **kwargs)
-    elif isinstance(metric, Callable):
-        return metric(x, y, **kwargs)
+    if measure in COST_MATRIX:
+        return DISTANCES_DICT[measure]["cost_matrix"](x, y, **kwargs)
+    elif isinstance(measure, Callable):
+        return measure(x, y, **kwargs)
     else:
-        raise ValueError("Metric must be one of the supported strings")
+        raise ValueError("Measure must be one of the supported strings")
 
 
 def get_distance_function_names() -> list[str]:
@@ -440,11 +440,11 @@ def get_distance_function_names() -> list[str]:
     return sorted(DISTANCES_DICT.keys())
 
 
-def get_distance_function(metric: Union[str, DistanceFunction]) -> DistanceFunction:
-    """Get the distance function for a given metric string or callable.
+def get_distance_function(measure: Union[str, DistanceFunction]) -> DistanceFunction:
+    """Get the distance function for a given measure string or callable.
 
     =============== ========================================
-    metric          Distance Function
+    measure         Distance Function
     =============== ========================================
     'dtw'           distances.dtw_distance
     'shape_dtw'     distances.shape_dtw_distance
@@ -468,8 +468,8 @@ def get_distance_function(metric: Union[str, DistanceFunction]) -> DistanceFunct
 
     Parameters
     ----------
-    metric : str or Callable
-        The distance metric to use.
+    measure : str or Callable
+        The distance measure to use.
         If string given then it will be resolved to a alignment path function.
         If a callable is given, the value must be a function that accepts two
         numpy arrays and **kwargs returns a float.
@@ -477,12 +477,12 @@ def get_distance_function(metric: Union[str, DistanceFunction]) -> DistanceFunct
     Returns
     -------
     Callable[[np.ndarray, np.ndarray, Any], float]
-        The distance function for the given metric.
+        The distance function for the given measure.
 
     Raises
     ------
     ValueError
-        If metric is not one of the supported strings or a callable.
+        If measure is not one of the supported strings or a callable.
 
     Examples
     --------
@@ -494,16 +494,16 @@ def get_distance_function(metric: Union[str, DistanceFunction]) -> DistanceFunct
     >>> dtw_dist_func(x, y, window=0.2)
     874.0
     """
-    return _resolve_key_from_distance(metric, "distance")
+    return _resolve_key_from_distance(measure, "distance")
 
 
 def get_pairwise_distance_function(
-    metric: Union[str, PairwiseFunction]
+    measure: Union[str, PairwiseFunction]
 ) -> PairwiseFunction:
-    """Get the pairwise distance function for a given metric string or callable.
+    """Get the pairwise distance function for a given measure string or callable.
 
     =============== ========================================
-    metric          Distance Function
+    measure         Distance Function
     =============== ========================================
     'dtw'           distances.dtw_pairwise_distance
     'shape_dtw'     distances.shape_dtw_pairwise_distance
@@ -527,8 +527,8 @@ def get_pairwise_distance_function(
 
     Parameters
     ----------
-    metric : str or Callable
-        The metric string to resolve to a alignment path function.
+    measure : str or Callable
+        The measure string to resolve to a alignment path function.
         If string given then it will be resolved to a alignment path function.
         If a callable is given, the value must be a function that accepts two
         numpy arrays and **kwargs returns a np.ndarray that is the pairwise distance
@@ -537,12 +537,12 @@ def get_pairwise_distance_function(
     Returns
     -------
     Callable[[np.ndarray, np.ndarray, Any], np.ndarray]
-        The pairwise distance function for the given metric.
+        The pairwise distance function for the given measure.
 
     Raises
     ------
     ValueError
-        If metric is not one of the supported strings or a callable.
+        If measure is not one of the supported strings or a callable.
 
     Examples
     --------
@@ -556,14 +556,14 @@ def get_pairwise_distance_function(
            [147., 300., 507.],
            [ 48., 147., 300.]])
     """
-    return _resolve_key_from_distance(metric, "pairwise_distance")
+    return _resolve_key_from_distance(measure, "pairwise_distance")
 
 
-def get_alignment_path_function(metric: str) -> AlignmentPathFunction:
-    """Get the alignment path function for a given metric string or callable.
+def get_alignment_path_function(measure: str) -> AlignmentPathFunction:
+    """Get the alignment path function for a given measure string or callable.
 
     =============== ========================================
-    metric          Distance Function
+    measure         Distance Function
     =============== ========================================
     'dtw'           distances.dtw_alignment_path
     'shape_dtw'     distances.shape_dtw_alignment_path
@@ -581,19 +581,19 @@ def get_alignment_path_function(metric: str) -> AlignmentPathFunction:
 
     Parameters
     ----------
-    metric : str or Callable
-        The metric string to resolve to an alignment path function.
+    measure : str or Callable
+        The measure string to resolve to an alignment path function.
 
     Returns
     -------
     Callable[[np.ndarray, np.ndarray, Any], Tuple[List[Tuple[int, int]], float]]
-        The alignment path function for the given metric.
+        The alignment path function for the given measure.
 
     Raises
     ------
     ValueError
-        If metric is not one of the supported strings or a callable.
-        If the metric doesn't have an alignment path function.
+        If measure is not one of the supported strings or a callable.
+        If the measure doesn't have an alignment path function.
 
     Examples
     --------
@@ -605,14 +605,14 @@ def get_alignment_path_function(metric: str) -> AlignmentPathFunction:
     >>> dtw_alignment_path_func(x, y, window=0.2)
     ([(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)], 500.0)
     """
-    return _resolve_key_from_distance(metric, "alignment_path")
+    return _resolve_key_from_distance(measure, "alignment_path")
 
 
-def get_cost_matrix_function(metric: str) -> CostMatrixFunction:
-    """Get the cost matrix function for a given metric string or callable.
+def get_cost_matrix_function(measure: str) -> CostMatrixFunction:
+    """Get the cost matrix function for a given measure string or callable.
 
     =============== ========================================
-    metric          Distance Function
+    measure         Distance Function
     =============== ========================================
     'dtw'           distances.dtw_cost_matrix
     'shape_dtw'     distances.shape_dtw_cost_matrix
@@ -630,19 +630,19 @@ def get_cost_matrix_function(metric: str) -> CostMatrixFunction:
 
     Parameters
     ----------
-    metric : str or Callable
-        The metric string to resolve to a cost matrix function.
+    measure : str or Callable
+        The measure string to resolve to a cost matrix function.
 
     Returns
     -------
     Callable[[np.ndarray, np.ndarray, Any], np.ndarray]
-        The cost matrix function for the given metric.
+        The cost matrix function for the given measure.
 
     Raises
     ------
     ValueError
-        If metric is not one of the supported strings or a callable.
-        If the metric doesn't have a cost matrix function.
+        If measure is not one of the supported strings or a callable.
+        If the measure doesn't have a cost matrix function.
 
     Examples
     --------
@@ -658,20 +658,20 @@ def get_cost_matrix_function(metric: str) -> CostMatrixFunction:
            [ inf,  inf, 343., 400., 521.],
            [ inf,  inf,  inf, 424., 500.]])
     """
-    return _resolve_key_from_distance(metric, "cost_matrix")
+    return _resolve_key_from_distance(measure, "cost_matrix")
 
 
-def _resolve_key_from_distance(metric: Union[str, Callable], key: str) -> Any:
-    if isinstance(metric, Callable):
-        return metric
-    if metric == "mpdist":
+def _resolve_key_from_distance(measure: Union[str, Callable], key: str) -> Any:
+    if isinstance(measure, Callable):
+        return measure
+    if measure == "mpdist":
         return mp_distance
-    dist = DISTANCES_DICT.get(metric)
+    dist = DISTANCES_DICT.get(measure)
     if dist is None:
-        raise ValueError(f"Unknown metric {metric}")
+        raise ValueError(f"Unknown measure {measure}")
     dist_callable = dist.get(key)
     if dist_callable is None:
-        raise ValueError(f"Metric {metric} does not have a {key} function")
+        raise ValueError(f"Measure {measure} does not have a {key} function")
     return dist_callable
 
 

--- a/aeon/distances/elastic/tests/test_alignment_path.py
+++ b/aeon/distances/elastic/tests/test_alignment_path.py
@@ -32,7 +32,7 @@ def _validate_alignment_path_result(
     assert isinstance(alignment_path_result, tuple)
     assert isinstance(alignment_path_result[0], list)
     assert isinstance(alignment_path_result[1], float)
-    assert compute_alignment_path(x, y, metric=name) == alignment_path_result
+    assert compute_alignment_path(x, y, measure=name) == alignment_path_result
     # Test a callable being passed
     assert callable_alignment_path == alignment_path_result
 

--- a/aeon/distances/elastic/tests/test_cost_matrix.py
+++ b/aeon/distances/elastic/tests/test_cost_matrix.py
@@ -30,8 +30,8 @@ def _validate_cost_matrix_result(
     ----------
     x (np.ndarray): The first input array.
     y (np.ndarray): The second input array.
-    name: The name of the distance metric.
-    distance: The distance metric function.
+    name: The name of the distance measure.
+    distance: The distance measure function.
     cost_matrix: The cost matrix function.
     """
     original_x = x.copy()
@@ -40,7 +40,7 @@ def _validate_cost_matrix_result(
     cost_matrix_callable_result = DISTANCES_DICT[name]["cost_matrix"](x, y)
 
     assert isinstance(cost_matrix_result, np.ndarray)
-    assert_almost_equal(cost_matrix_result, compute_cost_matrix(x, y, metric=name))
+    assert_almost_equal(cost_matrix_result, compute_cost_matrix(x, y, measure=name))
     assert_almost_equal(cost_matrix_callable_result, cost_matrix_result)
     if name == "ddtw" or name == "wddtw":
         assert cost_matrix_result.shape == (x.shape[-1] - 2, y.shape[-1] - 2)

--- a/aeon/distances/tests/test_distances.py
+++ b/aeon/distances/tests/test_distances.py
@@ -37,7 +37,7 @@ def _validate_distance_result(
     ----------
     x (np.ndarray): First array.
     y (np.ndarray): Second array.
-    name (str): Name of the distance metric.
+    name (str): Name of the distance measure.
     distance (callable): Distance function.
     expected_result (float): Expected distance result.
     check_xy_permuted: (bool): recursively call with swapped series
@@ -50,8 +50,8 @@ def _validate_distance_result(
     dist_result = distance(x, y)
     assert isinstance(dist_result, float)
     assert_almost_equal(dist_result, expected_result)
-    assert_almost_equal(dist_result, compute_distance(x, y, metric=name))
-    assert_almost_equal(dist_result, compute_distance(x, y, metric=distance))
+    assert_almost_equal(dist_result, compute_distance(x, y, measure=name))
+    assert_almost_equal(dist_result, compute_distance(x, y, measure=distance))
 
     dist_result_to_self = distance(x, x)
     assert isinstance(dist_result_to_self, float)
@@ -160,10 +160,10 @@ def test_get_distance_function_names():
 
 def test_resolve_key_from_distance():
     """Test _resolve_key_from_distance."""
-    with pytest.raises(ValueError, match="Unknown metric"):
-        _resolve_key_from_distance(metric="FOO", key="cost_matrix")
+    with pytest.raises(ValueError, match="Unknown measure"):
+        _resolve_key_from_distance(measure="FOO", key="cost_matrix")
     with pytest.raises(ValueError):
-        _resolve_key_from_distance(metric="dtw", key="FOO")
+        _resolve_key_from_distance(measure="dtw", key="FOO")
 
     def foo(x, y):
         return 0
@@ -176,17 +176,23 @@ def test_incorrect_inputs():
     x = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     y = np.array([[11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
     with pytest.raises(
-        ValueError, match="Metric must be one of the supported strings or a " "callable"
+        ValueError,
+        match="Measure must be one of the supported strings or a " "callable",
     ):
-        compute_distance(x, y, metric="FOO")
+        compute_distance(x, y, measure="FOO")
     with pytest.raises(
-        ValueError, match="Metric must be one of the supported strings or a " "callable"
+        ValueError,
+        match="Measure must be one of the supported strings or a " "callable",
     ):
-        pairwise_distance(x, y, metric="FOO")
-    with pytest.raises(ValueError, match="Metric must be one of the supported strings"):
-        alignment_path(x, y, metric="FOO")
-    with pytest.raises(ValueError, match="Metric must be one of the supported strings"):
-        cost_matrix(x, y, metric="FOO")
+        pairwise_distance(x, y, measure="FOO")
+    with pytest.raises(
+        ValueError, match="Measure must be one of the supported strings"
+    ):
+        alignment_path(x, y, measure="FOO")
+    with pytest.raises(
+        ValueError, match="Measure must be one of the supported strings"
+    ):
+        cost_matrix(x, y, measure="FOO")
 
     x = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     with pytest.raises(ValueError, match="dist_func must be a callable"):

--- a/aeon/distances/tests/test_numba_distance_parameters.py
+++ b/aeon/distances/tests/test_numba_distance_parameters.py
@@ -93,7 +93,7 @@ def _test_distance_params(
                     del param_dict["g"]
             results = [
                 distance_func(x, y, **param_dict.copy()),
-                distance(x, y, metric=distance_str, **param_dict.copy()),
+                distance(x, y, measure=distance_str, **param_dict.copy()),
             ]
 
             if distance_str in _expected_distance_results_params:

--- a/aeon/distances/tests/test_pairwise.py
+++ b/aeon/distances/tests/test_pairwise.py
@@ -52,7 +52,7 @@ def _validate_pairwise_result(
     Parameters
     ----------
     x: Input np.ndarray.
-    name: Name of the distance metric.
+    name: Name of the distance measure.
     distance: Distance function.
     pairwise_distance: Pairwise distance function.
     """
@@ -64,11 +64,11 @@ def _validate_pairwise_result(
     assert isinstance(pairwise_result, np.ndarray)
     assert pairwise_result.shape == expected_size
     assert_almost_equal(
-        pairwise_result, compute_pairwise_distance(x, metric=name, symmetric=symmetric)
+        pairwise_result, compute_pairwise_distance(x, measure=name, symmetric=symmetric)
     )
     assert_almost_equal(
         pairwise_result,
-        compute_pairwise_distance(x, metric=distance, symmetric=symmetric),
+        compute_pairwise_distance(x, measure=distance, symmetric=symmetric),
     )
 
     if isinstance(x, np.ndarray):
@@ -100,7 +100,7 @@ def _validate_multiple_to_multiple_result(
     ----------
     x: Input array.
     y: Input array.
-    name: Name of the distance metric.
+    name: Name of the distance measure.
     distance: Distance function.
     multiple_to_multiple_distance: Mul-to-Mul distance function.
     check_xy_permuted: recursively call with swapped series
@@ -123,11 +123,11 @@ def _validate_multiple_to_multiple_result(
     assert multiple_to_multiple_result.shape == expected_size
 
     assert_almost_equal(
-        multiple_to_multiple_result, compute_pairwise_distance(x, y, metric=name)
+        multiple_to_multiple_result, compute_pairwise_distance(x, y, measure=name)
     )
     assert_almost_equal(
         multiple_to_multiple_result,
-        compute_pairwise_distance(x, y, metric=distance),
+        compute_pairwise_distance(x, y, measure=distance),
     )
 
     if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
@@ -168,7 +168,7 @@ def _validate_single_to_multiple_result(
     ----------
     x: Input array.
     y: Input array.
-    name: Name of the distance metric.
+    name: Name of the distance measure.
     distance: Distance function.
     single_to_multiple_distance: Single to multiple distance function.
     run_inverse: Boolean that reruns the test with x and y swapped in position
@@ -198,11 +198,11 @@ def _validate_single_to_multiple_result(
         assert single_to_multiple_result.shape[1] == expected_size
     assert_almost_equal(
         single_to_multiple_result,
-        compute_pairwise_distance(x, y, metric=name, symmetric=symmetric),
+        compute_pairwise_distance(x, y, measure=name, symmetric=symmetric),
     )
     assert_almost_equal(
         single_to_multiple_result,
-        compute_pairwise_distance(x, y, metric=distance, symmetric=symmetric),
+        compute_pairwise_distance(x, y, measure=distance, symmetric=symmetric),
     )
 
     if len(x_shape) < len(y_shape):

--- a/aeon/regression/distance_based/_time_series_neighbors.py
+++ b/aeon/regression/distance_based/_time_series_neighbors.py
@@ -111,7 +111,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         y : array-like, shape = (n_cases)
             The output value.
         """
-        self.metric_ = get_distance_function(metric=self.distance)
+        self.metric_ = get_distance_function(measure=self.distance)
         self.X_ = X
         self.y_ = y
         return self

--- a/aeon/transformations/collection/channel_selection/_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/_elbow_class.py
@@ -90,7 +90,7 @@ def _create_distance_matrix(
                     lambda row: aeon_distance(
                         row[: row.shape[0] // 2],
                         row[row.shape[0] // 2 :],
-                        metric="dtw",
+                        measure="dtw",
                     ),
                     axis=1,
                     arr=np.concatenate((cls1_ch, cls2_ch), axis=1),

--- a/aeon/transformations/series/tests/test_warping.py
+++ b/aeon/transformations/series/tests/test_warping.py
@@ -16,7 +16,7 @@ def test_warping_path_transformer(distance):
     x = make_example_2d_numpy_series(n_timepoints=20, n_channels=2)
     y = make_example_2d_numpy_series(n_timepoints=20, n_channels=2)
 
-    alignment_path_function = get_alignment_path_function(metric=distance)
+    alignment_path_function = get_alignment_path_function(measure=distance)
 
     warping_path = alignment_path_function(x, y)[0]
 

--- a/examples/distances/distances.ipynb
+++ b/examples/distances/distances.ipynb
@@ -192,7 +192,7 @@
     "\n",
     "d1 = euclidean_distance(first, second)\n",
     "d2 = euclidean_distance(first, third)\n",
-    "d3 = distance(second, third, metric=\"euclidean\")\n",
+    "d3 = distance(second, third, measure=\"euclidean\")\n",
     "print(d1, \",\", d2, \",\", d3)"
    ]
   },
@@ -568,7 +568,7 @@
     "y = np.array([[2, 3, 4, 5, 6, 7]])\n",
     "p, d = dtw_alignment_path(x, y)\n",
     "print(\"path =\", p, \" distance = \", d)\n",
-    "p, d = alignment_path(x, y, metric=\"dtw\")\n",
+    "p, d = alignment_path(x, y, measure=\"dtw\")\n",
     "print(\"path =\", p, \" distance = \", d)"
    ]
   },

--- a/examples/pydata/Amsterdam-2023/Lets_do_the_time_warp_again.ipynb
+++ b/examples/pydata/Amsterdam-2023/Lets_do_the_time_warp_again.ipynb
@@ -60,7 +60,7 @@
     "from aeon.distances import distance\n",
     "\n",
     "# Any value in the table above is a valid metric string\n",
-    "distance(x, y, metric=\"dtw\")"
+    "distance(x, y, measure=\"dtw\")"
    ]
   },
   {
@@ -109,7 +109,7 @@
     "msm_distance(x, y, window=0.2)\n",
     "\n",
     "# Calling a distance using utility function\n",
-    "distance(x, y, metric=\"msm\", window=0.2)"
+    "distance(x, y, measure=\"msm\", window=0.2)"
    ]
   },
   {
@@ -160,7 +160,7 @@
     "# Using utility function\n",
     "from aeon.distances import pairwise_distance\n",
     "\n",
-    "pairwise_distance(X, metric=\"twe\")"
+    "pairwise_distance(X, measure=\"twe\")"
    ]
   },
   {
@@ -205,7 +205,7 @@
     "erp_pairwise_distance(X, y)\n",
     "\n",
     "# Using utility function\n",
-    "pairwise_distance(X, y, metric=\"erp\")"
+    "pairwise_distance(X, y, measure=\"erp\")"
    ]
   },
   {
@@ -260,7 +260,7 @@
     "wdtw_pairwise_distance(X, y, window=0.2)\n",
     "\n",
     "# Using utility function\n",
-    "pairwise_distance(X, y, metric=\"wdtw\", window=0.2)"
+    "pairwise_distance(X, y, measure=\"wdtw\", window=0.2)"
    ]
   },
   {
@@ -314,7 +314,7 @@
     "# Using utility function\n",
     "from aeon.distances import alignment_path\n",
     "\n",
-    "alignment_path(x, y, metric=\"msm\", window=0.2)"
+    "alignment_path(x, y, measure=\"msm\", window=0.2)"
    ]
   },
   {
@@ -391,7 +391,7 @@
     "X_test, y_test = load_data(split=\"TEST\", return_type=\"numpy2D\")\n",
     "x = X_train[0]\n",
     "y = X_train[22]\n",
-    "msm_alignment_path = alignment_path(x, y, metric=\"msm\")\n",
+    "msm_alignment_path = alignment_path(x, y, measure=\"msm\")\n",
     "curr_plot = plot_alignment(x, y, msm_alignment_path[0])\n",
     "curr_plot.show()"
    ]
@@ -467,7 +467,7 @@
     ")\n",
     "\n",
     "# Precompute pairwise twe distances\n",
-    "train_pw_distance = pairwise_distance(X_train, metric=\"twe\")\n",
+    "train_pw_distance = pairwise_distance(X_train, measure=\"twe\")\n",
     "\n",
     "# Fit model using precomputed\n",
     "model_precomputed.fit(train_pw_distance)\n",
@@ -517,8 +517,8 @@
     "model_distance = SVC(kernel=msm_pairwise_distance)\n",
     "\n",
     "# Precompute pairwise twe distances\n",
-    "train_pw_distance = pairwise_distance(X_train, metric=\"msm\")\n",
-    "test_pw_distance = pairwise_distance(X_test, X_train, metric=\"msm\")\n",
+    "train_pw_distance = pairwise_distance(X_train, measure=\"msm\")\n",
+    "test_pw_distance = pairwise_distance(X_test, X_train, measure=\"msm\")\n",
     "\n",
     "# Fit model using precomputed\n",
     "model_precomputed.fit(train_pw_distance, y_train)\n",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
#2379

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR changes the "metric" parameter to "measure" for the distance module. The reason for this is not all distance functions are metrics and therefore this parameter doesn't make sense for all distances.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
