### PR TITLE
[DOC] Contributing guide and template changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,7 +80,7 @@ body:
       Please run the following code snippet and paste the output here.
 
       ```python
-      from aeon import show_versions; show_versions()
+      from aeon.utils import show_versions; show_versions()
       ```
     placeholder: |
       <details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
 <!--
 Thanks for contributing a pull request! Please ensure you have taken a look at our
-contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html
+contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html.
 
 Feel free to delete sections of this template if they do not apply to your PR,
 avoid submitting a blank template or empty sections.
+If you are a new contributor, do not delete this template without a suitable
+replacement or reason. If in doubt, ask for help. We're here to help!
 -->
 
 #### Reference Issues/PRs
@@ -32,18 +34,17 @@ to a minimum.
 #### Any other comments?
 
 <!--
-Please be aware that we are a loose team of volunteers so patience is
-necessary; assistance handling other issues is very welcome. We value all
-user contributions, no matter how minor they are. If we are slow to
-review, either the pull request needs some benchmarking, tinkering,
-convincing, etc. or more likely the reviewers are simply busy. In either
-case, we ask for your understanding during the review process.
+Please be aware that we are a team of volunteers so patience is
+necessary when waiting for a review or reply. While we value all contributions big or
+small, pull requests which do not follow our guidelines may be closed.
 -->
 
 ### PR checklist
 
 <!--
-Please go through the checklist below. Please feel free to remove points if they are not applicable.
+Please go through the checklist below. Please feel free to remove points if they are
+not applicable. To check a box, replace the space inside the square brackets with an
+'x' i.e. [x].
 -->
 
 ##### For all contributions
@@ -51,7 +52,7 @@ Please go through the checklist below. Please feel free to remove points if they
 - [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
 
 ##### For new estimators and functions
-- [ ] I've added the estimator to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
+- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
 - [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.
 
 ##### For developers with write access

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,9 +11,14 @@ some experience with Python and be able to run tests. If the issue tackles the
 specifics of a machine learning algorithm, some relevant knowledge of machine learning
 will be required. While we want to encourage new contributors, a base level
 of knowledge is required to make a meaningful contribution to certain issues.
+ChatGPT is not a replacement for this knowledge.
+
+Pull requests from unknown contributors which do not attempt to resolve the issue being
+addressed, completely disregard the pull request template, or consist of low quality AI
+generated output may be closed without review.
 
 In the following we will give a brief overview of how to contribute to `aeon`. Making
-contributions to open source projects takes a bit of proactivity and can be daunting at
+contributions to open-source projects takes a bit of proactivity and can be daunting at
 first, but members of the community are here to help and answer questions. If you get
 stuck, please don’t hesitate to talk with us or raise an issue.
 
@@ -37,13 +42,16 @@ including '@aeon-actions-bot', the username of people to assign and the word `as
     ```python
     @aeon-actions-bot assign @MatthewMiddlehurst
     ```
-    If it is a larger issue with multiple components, indicate which part you are
-working on. A Core Developer may suggest a different issue if the one you chose is
-complex or somebody is already working on it.
+    Please ensure you understand and have a plan for resolving the issue before
+assigning yourself. Feel free to ask for clarification if you are unsure. If it is a
+larger issue with multiple components, indicate which part you are working on. A Core
+Developer may suggest a different issue if the one you chose is complex or somebody is
+already working on it.
 5. Create a [pull request (PR)](https://github.com/aeon-toolkit/aeon/compare)
 with your changes from your fork. For help, see the [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
-or ask in Slack. Follow the PR template and checklist. Please make sure to include
-an appropriate [title tag](contributing/issues.md).
+or ask in Slack. Follow the PR template, template comments and checklist. Please make
+sure to include an appropriate [title tag](contributing/issues.md). **Do not just delete the PR template
+text.**
 6. A Core Developer will review your PR and may provide feedback, which you can then
 address. If you are unsure about any feedback, please ask for clarification. Please
 be patient, as Core Developers are volunteers and may be busy with other tasks.


### PR DESCRIPTION
Fixes #2334

Updates GitHub templates and adds more details to the contributing guide, informing contributors that raw AI output and disregarding the template may led to PR closures.