### PR TITLE
[DOC] Base collection class docstring formatting

### DIFF
--- a/aeon/regression/base.py
+++ b/aeon/regression/base.py
@@ -76,7 +76,7 @@ class BaseRegressor(BaseCollectionEstimator):
             allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series, so either ``n_channels == 1`` is
             true or X is 2D of shape ``(n_cases, n_timepoints)``. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal
@@ -122,7 +122,7 @@ class BaseRegressor(BaseCollectionEstimator):
             other types are allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series, so either ``n_channels == 1`` is
             true or X is 2D of shape ``(n_cases, n_timepoints)``. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -70,7 +70,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
@@ -125,7 +125,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
@@ -230,7 +230,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -62,12 +62,12 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         Parameters
         ----------
         X : np.ndarray or list
-            Input data, any number of channels, equal length series of shape ``(
-            n_cases, n_channels, n_timepoints)``
-            or list of numpy arrays (any number of channels, unequal length series)
-            of shape ``[n_cases]``, 2D np.array ``(n_channels, n_timepoints_i)``,
-            where ``n_timepoints_i`` is length of series ``i``. Other types are
-            allowed and converted into one of the above.
+            Data to fit transform to, of valid collection type. Input data,
+            any number of channels, equal length series of shape ``(
+            n_cases, n_channels, n_timepoints)`` or list of numpy arrays (any number
+            of channels, unequal length series) of shape ``[n_cases]``, 2D np.array
+            ``(n_channels, n_timepoints_i)``, where ``n_timepoints_i`` is length of
+            series ``i``. Other types are allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
             types of input. If ``self.get_tag("capability:multivariate")`` is False,
@@ -75,7 +75,6 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
             characteristic that the estimator does not have the capability to handle.
-              Data to fit transform to, of valid collection type.
         y : np.ndarray, default=None
             1D np.array of float or str, of shape ``(n_cases)`` - class labels
             (ground truth) for fitting indices corresponding to instance indices in X.
@@ -117,12 +116,12 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         Parameters
         ----------
         X : np.ndarray or list
-            Input data, any number of channels, equal length series of shape ``(
-            n_cases, n_channels, n_timepoints)``
-            or list of numpy arrays (any number of channels, unequal length series)
-            of shape ``[n_cases]``, 2D np.array ``(n_channels, n_timepoints_i)``,
-            where ``n_timepoints_i`` is length of series ``i``. Other types are
-            allowed and converted into one of the above.
+            Data to fit transform to, of valid collection type. Input data,
+            any number of channels, equal length series of shape ``(
+            n_cases, n_channels, n_timepoints)`` or list of numpy arrays (any number
+            of channels, unequal length series) of shape ``[n_cases]``, 2D np.array
+            ``(n_channels, n_timepoints_i)``, where ``n_timepoints_i`` is length of
+            series ``i``. Other types are allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
             types of input. If ``self.get_tag("capability:multivariate")`` is False,
@@ -130,7 +129,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
             characteristic that the estimator does not have the capability to handle.
-              Data to fit transform to, of valid collection type.
+
         y : np.ndarray, default=None
             1D np.array of float or str, of shape ``(n_cases)`` - class labels
             (ground truth) for fitting indices corresponding to instance indices in X.
@@ -171,20 +170,19 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         Parameters
         ----------
         X : np.ndarray or list
-            Input data, any number of channels, equal length series of shape ``(
-            n_cases, n_channels, n_timepoints)``
-            or list of numpy arrays (any number of channels, unequal length series)
-            of shape ``[n_cases]``, 2D np.array ``(n_channels, n_timepoints_i)``,
-            where ``n_timepoints_i`` is length of series ``i``. Other types are
-            allowed and converted into one of the above.
+            Data to fit transform to, of valid collection type. Input data,
+            any number of channels, equal length series of shape ``(n_cases,
+            n_channels, n_timepoints)`` or list of numpy arrays (any number of
+            channels, unequal length series) of shape ``[n_cases]``, 2D np.array ``(
+            n_channels, n_timepoints_i)``, where ``n_timepoints_i`` is length of
+            series ``i``. Other types are allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
-            types of input. If `self.get_tag("capability:multivariate")`` is False,
+            types of input. If ``self.get_tag("capability:multivariate")`` is False,
             they cannot handle multivariate series. If ``self.get_tag(
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
             characteristic that the estimator does not have the capability to handle.
-              Data to fit transform to, of valid collection type.
         y : np.ndarray, default=None
             1D np.array of float or str, of shape ``(n_cases)`` - class labels
             (ground truth) for fitting indices corresponding to instance indices in X.
@@ -222,12 +220,12 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         Parameters
         ----------
         X : np.ndarray or list
-            Input data, any number of channels, equal length series of shape ``(
-            n_cases, n_channels, n_timepoints)``
-            or list of numpy arrays (any number of channels, unequal length series)
-            of shape ``[n_cases]``, 2D np.array ``(n_channels, n_timepoints_i)``,
-            where ``n_timepoints_i`` is length of series ``i``. Other types are
-            allowed and converted into one of the above.
+            Data to fit transform to, of valid collection type. Input data,
+            any number of channels, equal length series of shape ``(
+            n_cases, n_channels, n_timepoints)`` or list of numpy arrays (any number
+            of channels, unequal length series)  of shape ``[n_cases]``, 2D np.array
+            ``(n_channels, n_timepoints_i)``, where ``n_timepoints_i`` is length of
+            series ``i``. Other types are allowed and converted into one of the above.
 
             Different estimators have different capabilities to handle different
             types of input. If ``self.get_tag("capability:multivariate")`` is False,
@@ -235,7 +233,6 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
             "capability:unequal_length")`` is False, they cannot handle unequal
             length input. In both situations, a ``ValueError`` is raised if X has a
             characteristic that the estimator does not have the capability to handle.
-              Data to fit transform to, of valid collection type.
         y : np.ndarray, default=None
             1D np.array of float or str, of shape ``(n_cases)`` - class labels
             (ground truth) for fitting indices corresponding to instance indices in X.


### PR DESCRIPTION
corrects a few formatting issues in BaseCollectionTransformer and BaseClassifier. missing ticks and incorrect indentation (see #2444)