### PR TITLE
[MNT] Set upper bound on matplotlib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,9 @@ dependencies = [
 all_extras = [
     "esig>=0.9.7; platform_system != 'Darwin' and python_version < '3.11'",
     "imbalanced-learn",
-    "matplotlib>=3.3.2",
+    # Upper bound set as 3.10 dropped support for python 3.9. We will remove the
+    # upper bound once we also drop support for python 3.9 later in 2025.
+    "matplotlib>=3.3.2,<=3.9.4",  # Remove upper bound
     "pycatch22>=0.4.5",
     "pyod>=1.1.3",
     "prts>=1.0.0.0",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
The CI started breaking today on python version 3.9: https://github.com/aeon-toolkit/aeon/actions/runs/12390736933/job/34586409381.

@patrickzib did some investigating and found Matplotlib stopped supporting python 3.9 today as per their docs: https://github.com/matplotlib/matplotlib/blob/main/doc/devel/min_dep_policy.rst

As such the latest version fails to install on 3.9. As we still support 3.9 we have to set a upper bound on the version so that users still on 3.9 don't find their install breaking. This PR adds a upper bounding to matplotlib.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. While we value all contributions big or
small, pull requests which do not follow our guidelines may be closed.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
