### PR TITLE
[ENH] Added possibility for pooling strides in TimeCNN

### DIFF
--- a/aeon/classification/deep_learning/_cnn.py
+++ b/aeon/classification/deep_learning/_cnn.py
@@ -42,6 +42,9 @@ class TimeCNNClassifier(BaseDeepClassifier):
     strides : int or list of int, default = 1
         The strides of kernels in the convolution and max pooling layers, if not a
         list, the same strides are used for all layers.
+    strides_pooling : int or list of int, default = None
+        Strides for the pooling layers. If None, defaults to pool_size.
+        If not a list, the same strides are used for all pooling layers.
     dilation_rate : int or list of int, default = 1
         The dilation rate of the convolution layers, if not a list, the same dilation
         rate is used all over the network.

--- a/aeon/classification/deep_learning/_cnn.py
+++ b/aeon/classification/deep_learning/_cnn.py
@@ -125,6 +125,7 @@ class TimeCNNClassifier(BaseDeepClassifier):
         activation="sigmoid",
         padding="valid",
         strides=1,
+        strides_pooling=None,
         dilation_rate=1,
         n_epochs=2000,
         batch_size=16,
@@ -148,6 +149,7 @@ class TimeCNNClassifier(BaseDeepClassifier):
         self.n_filters = n_filters
         self.padding = padding
         self.strides = strides
+        self.strides_pooling = strides_pooling
         self.dilation_rate = dilation_rate
         self.avg_pool_size = avg_pool_size
         self.activation = activation
@@ -182,6 +184,7 @@ class TimeCNNClassifier(BaseDeepClassifier):
             activation=self.activation,
             padding=self.padding,
             strides=self.strides,
+            strides_pooling=self.strides_pooling,
             dilation_rate=self.dilation_rate,
             use_bias=self.use_bias,
         )

--- a/aeon/networks/_cnn.py
+++ b/aeon/networks/_cnn.py
@@ -141,8 +141,8 @@ class TimeCNNNetwork(BaseDeepLearningNetwork):
         elif isinstance(self.strides_pooling, list):
             if len(self.strides_pooling) != self.n_layers:
                 raise ValueError(
-                    f"Number of strides for pooling {len(self.strides_pooling)} should be"
-                    f" the same as number of layers but is"
+                    f"Number of strides for pooling {len(self.strides_pooling)}"
+                    f" should be the same as number of layers but is"
                     f" not: {self.n_layers}"
                 )
             self._strides_pooling = self.strides_pooling

--- a/aeon/networks/_cnn.py
+++ b/aeon/networks/_cnn.py
@@ -225,7 +225,7 @@ class TimeCNNNetwork(BaseDeepLearningNetwork):
             conv = tf.keras.layers.AveragePooling1D(
                 pool_size=self._avg_pool_size[i],
                 strides=self._strides_pooling[i],
-                )(conv)
+            )(conv)
 
             x = conv
 

--- a/aeon/networks/_cnn.py
+++ b/aeon/networks/_cnn.py
@@ -32,6 +32,9 @@ class TimeCNNNetwork(BaseDeepLearningNetwork):
     strides : int or list of int, default = 1
         The strides of kernels in the convolution and max pooling layers, if not a list,
         the same strides are used for all layers.
+    strides_pooling : int or list of int, default = None
+        Strides for the pooling layers. If None, defaults to pool_size.
+        If not a list, the same strides are used for all pooling layers.
     dilation_rate : int or list of int, default = 1
         The dilation rate of the convolution layers, if not a list, the same dilation
         rate is used all over the network.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Fixes #2307 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Added strides_pooling to the TimeCNNNetwork class as well as TimeCNNClassifier class to allow independent configuration of strides for pooling layers while ensuring backward compatibility by defaulting to avg_pool_size if not specified, and also added checks to ensure the size if a list is provided.
![image](https://github.com/user-attachments/assets/7a3d74e3-7dfc-4c56-af37-bd6e7358a09b)

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
@all-contributors please add @kavya-r30 for code
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
