### PR TITLE
[MNT] Fixed wrong type annotations for aeon classes

### DIFF
--- a/aeon/classification/sklearn/_continuous_interval_tree.py
+++ b/aeon/classification/sklearn/_continuous_interval_tree.py
@@ -483,7 +483,7 @@ class ContinuousIntervalTree(ClassifierMixin, BaseEstimator):
 
         return splits, gains
 
-    def _find_splits_gain(self, node: type[_TreeNode], splits: list, gains: list):
+    def _find_splits_gain(self, node: _TreeNode, splits: list, gains: list):
         """Recursively find the split and information gain for each tree node."""
         splits.append(node.best_split)
         gains.append(node.best_gain)

--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -453,7 +453,7 @@ class RotationForestClassifier(ClassifierMixin, BaseEstimator):
 
         return tree, pcas, groups, X_t if save_transformed_data else None
 
-    def _predict_proba_for_estimator(self, X, clf: int, pcas: type[PCA], groups):
+    def _predict_proba_for_estimator(self, X, clf: int, pcas: PCA, groups):
         X_t = np.concatenate(
             [pcas[i].transform(X[:, group]) for i, group in enumerate(groups)], axis=1
         )

--- a/aeon/regression/sklearn/_rotation_forest_regressor.py
+++ b/aeon/regression/sklearn/_rotation_forest_regressor.py
@@ -352,7 +352,7 @@ class RotationForestRegressor(RegressorMixin, BaseEstimator):
 
         return tree, pcas, groups, X_t if save_transformed_data else None
 
-    def _predict_for_estimator(self, X, clf: int, pcas: type[PCA], groups):
+    def _predict_for_estimator(self, X, clf: int, pcas: PCA, groups):
         X_t = np.concatenate(
             [pcas[i].transform(X[:, group]) for i, group in enumerate(groups)], axis=1
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Fixes #1928 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Fixed incorrect type hinting in private methods for _TreeNode and PCA

1. Changed type hint for the `_find_splits_gain` method in _continuous_interval_tree.py from `type[_TreeNode]` to `_TreeNode`.
2.  Updated the type hint for `pcas` in `_predict_for_estimator` and `_predict_proba_for_estimator` methods in _rotation_forest_classifier.py and _rotation_forest_regressor.py from `type[PCA]` to `PCA`.

The changes correct type hints by using class instances instead of class types for _TreeNode and PCA.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
