### PR TITLE
Added type hints in few modules

### DIFF
--- a/aeon/classification/convolution_based/_arsenal.py
+++ b/aeon/classification/convolution_based/_arsenal.py
@@ -130,15 +130,15 @@ class Arsenal(BaseClassifier):
 
     def __init__(
         self,
-        num_kernels=2000,
-        n_estimators=25,
-        rocket_transform="rocket",
-        max_dilations_per_kernel=32,
-        n_features_per_kernel=4,
-        time_limit_in_minutes=0.0,
-        contract_max_n_estimators=100,
+        num_kernels: int = 2000,
+        n_estimators: int = 25,
+        rocket_transform: str = "rocket",
+        max_dilations_per_kernel: int = 32,
+        n_features_per_kernel: int = 4,
+        time_limit_in_minutes: float = 0.0,
+        contract_max_n_estimators: int = 100,
         class_weight=None,
-        n_jobs=1,
+        n_jobs: int = 1,
         random_state=None,
     ):
         self.num_kernels = num_kernels

--- a/aeon/classification/convolution_based/_hydra.py
+++ b/aeon/classification/convolution_based/_hydra.py
@@ -96,7 +96,12 @@ class HydraClassifier(BaseClassifier):
     }
 
     def __init__(
-        self, n_kernels=8, n_groups=64, class_weight=None, n_jobs=1, random_state=None
+        self,
+        n_kernels: int = 8,
+        n_groups: int = 64,
+        class_weight=None,
+        n_jobs: int = 1,
+        random_state=None,
     ):
         self.n_kernels = n_kernels
         self.n_groups = n_groups

--- a/aeon/classification/convolution_based/_minirocket.py
+++ b/aeon/classification/convolution_based/_minirocket.py
@@ -89,11 +89,11 @@ class MiniRocketClassifier(BaseClassifier):
 
     def __init__(
         self,
-        num_kernels=10000,
-        max_dilations_per_kernel=32,
+        num_kernels: int = 10000,
+        max_dilations_per_kernel: int = 32,
         estimator=None,
         class_weight=None,
-        n_jobs=1,
+        n_jobs: int = 1,
         random_state=None,
     ):
         self.num_kernels = num_kernels

--- a/aeon/classification/convolution_based/_mr_hydra.py
+++ b/aeon/classification/convolution_based/_mr_hydra.py
@@ -88,7 +88,12 @@ class MultiRocketHydraClassifier(BaseClassifier):
     }
 
     def __init__(
-        self, n_kernels=8, n_groups=64, class_weight=None, n_jobs=1, random_state=None
+        self,
+        n_kernels: int = 8,
+        n_groups: int = 64,
+        class_weight=None,
+        n_jobs: int = 1,
+        random_state=None,
     ):
         self.n_kernels = n_kernels
         self.n_groups = n_groups

--- a/aeon/classification/convolution_based/_multirocket.py
+++ b/aeon/classification/convolution_based/_multirocket.py
@@ -90,12 +90,12 @@ class MultiRocketClassifier(BaseClassifier):
 
     def __init__(
         self,
-        num_kernels=10000,
-        max_dilations_per_kernel=32,
-        n_features_per_kernel=4,
+        num_kernels: int = 10000,
+        max_dilations_per_kernel: int = 32,
+        n_features_per_kernel: int = 4,
         estimator=None,
         class_weight=None,
-        n_jobs=1,
+        n_jobs: int = 1,
         random_state=None,
     ):
         self.num_kernels = num_kernels

--- a/aeon/classification/convolution_based/_rocket.py
+++ b/aeon/classification/convolution_based/_rocket.py
@@ -92,10 +92,10 @@ class RocketClassifier(BaseClassifier):
 
     def __init__(
         self,
-        num_kernels=10000,
+        num_kernels: int = 10000,
         estimator=None,
         class_weight=None,
-        n_jobs=1,
+        n_jobs: int = 1,
         random_state=None,
     ):
         self.num_kernels = num_kernels

--- a/aeon/classification/early_classification/_probability_threshold.py
+++ b/aeon/classification/early_classification/_probability_threshold.py
@@ -102,10 +102,10 @@ class ProbabilityThresholdEarlyClassifier(BaseEarlyClassifier):
     def __init__(
         self,
         estimator=None,
-        probability_threshold=0.85,
-        consecutive_predictions=1,
+        probability_threshold: float = 0.85,
+        consecutive_predictions: int = 1,
         classification_points=None,
-        n_jobs=1,
+        n_jobs: int = 1,
         random_state=None,
     ):
         self.estimator = estimator


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1454

#### What does this implement/fix? Explain your changes.

I have made changes to the following modules:
all the .py files under the following directories :
aeon/classification/convolution_based
aeon/classification/feature_based

this particular file
aeon/classification/early_classification/_probability_threshold.py

the init method of these .py files had missing type hints for primitive and string data types. I have added those.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Any other comments?
No

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.

