### PR TITLE
[DOC]Fixed docstring ticks in documentation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,7 @@
 {
   "login": "iaadarsh23",
   "name": "Adarsh Triapthi",
-  
+
   "profile": "https://github.com/iaadarsh23",
   "contributions": [
     "code",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,4 +1,14 @@
 {
+  "login": "iaadarsh23",
+  "name": "Adarsh Triapthi",
+  
+  "profile": "https://github.com/iaadarsh23",
+  "contributions": [
+    "code",
+    "doc"
+  ]
+}
+{
   "projectName": "aeon",
   "projectOwner": "aeon-toolkit",
   "repoType": "github",


### PR DESCRIPTION
This pull request addresses the issue of incorrect docstring ticks in the documentation. The changes include:

Corrected single backticks to triple backticks for code blocks to ensure proper formatting.
Updated the formatting for the following parameters to improve readability:
random_state: int or RandomState, default=None
Random seed or RandomState object.
n_jobs: int, default=1
The number of jobs to run in parallel. -1 means using all processors.
n_cases_: int
Number of train instances in data passed to fit.
Reference Issues/PRs:
Fixes #2434

What does this implement/fix? Explain your changes.
This PR corrects the docstring formatting to ensure that code blocks are displayed correctly in the documentation. The changes improve the overall readability and consistency of the docstrings.

Does your contribution introduce a new dependency? If yes, which one?
No

Any other comments?

Ensure that the formatting aligns with the project's documentation guidelines.
Reviewers, please verify the updated docstrings for accuracy.
PR checklist
The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation, or governance.

[View the pull request](https://github.com/aeon-toolkit/aeon/compare/main...iaadarsh23:aeon-doc-update:fix-docstring-ticks?expand=1)

@contri