### PR TITLE
[DOC] Update custom CSS for dataframe styling in documentation

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -41,18 +41,42 @@ img.avatar {
   margin: 0;
 }
 
-/* For some reason, Sphinx alwawys considers the default property for odd */
-/* hence adding !important */
-.dataframe>tbody>tr:nth-child(odd) {
-  background-color: #1e1e1e !important;
-  color: white !important;
+/* DataFrame Color Variables */
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) {
+    --dataframe-header: #1f1f1f;
+    --dataframe-body-1: #2f2f2f;
+    --dataframe-body-2: #3f3f3f;
+    --dataframe-text: #f0f0f0;
+  }
 }
 
-.dataframe>tbody>tr:nth-child(even) {
-  background-color: #2e2e2e;
-  color: white;
+body[data-theme="dark"] {
+    --dataframe-header: #1f1f1f;
+    --dataframe-body-1: #2f2f2f;
+    --dataframe-body-2: #3f3f3f;
+    --dataframe-text: #f0f0f0;
 }
 
-.dataframe > thead {
-  color: white !important
+body {
+    --dataframe-header: #f0f0f0;
+    --dataframe-body-1: #f8f8f8;
+    --dataframe-body-2: #f0f0f0;
+    --dataframe-text: #000000;
 }
+
+  .dataframe > tbody > tr:nth-child(odd) {
+    background-color: var(--dataframe-body-1) !important;
+    color: var(--dataframe-text) !important;
+  }
+
+  .dataframe > tbody > tr:nth-child(even) {
+    background-color: var(--dataframe-body-2) !important;
+    color: var(--dataframe-text) !important;
+  }
+
+  .dataframe > thead {
+    background-color: var(--dataframe-header) !important;
+    color: var(--dataframe-text) !important;
+  }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -40,3 +40,19 @@ img.avatar {
 .autosummary table {
   margin: 0;
 }
+
+/* For some reason, Sphinx alwawys considers the default property for odd */
+/* hence adding !important */
+.dataframe>tbody>tr:nth-child(odd) {
+  background-color: #1e1e1e !important;
+  color: white !important;
+}
+
+.dataframe>tbody>tr:nth-child(even) {
+  background-color: #2e2e2e;
+  color: white;
+}
+
+.dataframe > thead {
+  color: white !important
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -42,6 +42,9 @@ img.avatar {
 }
 
 /* DataFrame Color Variables */
+/* The following variables are defined only here, */
+/* meaning they are new variables. */
+/* They are used for displaying pandas dataframes in the rendered notebooks. */
 
 @media (prefers-color-scheme: dark) {
   body:not([data-theme="light"]) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #1283 

#### What does this implement/fix? Explain your changes.

Updated styles to make the dataframe tables more accessible in the dark mode.

![image](https://github.com/user-attachments/assets/7edf2d6b-d241-4305-b949-e031e59e0f6f)


#### Does your contribution introduce a new dependency? If yes, which one?

No


### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
