### PR TITLE
[ENH] Test coverage for AEResNetNetwork Improved

### DIFF
--- a/aeon/networks/tests/test_ae_resnet.py
+++ b/aeon/networks/tests/test_ae_resnet.py
@@ -1,0 +1,187 @@
+"""Tests for the AEResNetNetwork Model."""
+
+import pytest
+
+from aeon.networks import AEResNetNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "latent_space_dim, n_residual_blocks, activation, n_filters",
+    [
+        (128, 3, "relu", 32),  # Test with relu activation
+        (256, 5, "sigmoid", 64),  # Test with sigmoid activation
+        (64, 2, "tanh", 16),  # Test with tanh activation
+    ],
+)
+def test_ae_res_unit_activation(
+    latent_space_dim, n_residual_blocks, activation, n_filters
+):
+    """Test whether AEResNetNetwork initializes correctly with different activations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=latent_space_dim,
+        n_residual_blocks=n_residual_blocks,
+        activation=activation,
+        n_filters=n_filters,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "use_bias, n_conv_per_residual_block",
+    [
+        ([True, False, True], 3),  # list case
+        (True, 3),  # scalar broadcast case
+        pytest.param(
+            [True, False], 4, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_use_bias(use_bias, n_conv_per_residual_block):
+    """Test AEResNetNetwork use_bias configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        use_bias=use_bias,
+        n_conv_per_residual_block=n_conv_per_residual_block,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "n_filters, n_residual_blocks",
+    [
+        (64, 3),  # scalar case
+        ([64, 128, 256], 3),  # list case matching residual blocks
+        pytest.param(
+            [64, 128], 3, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_n_filters(n_filters, n_residual_blocks):
+    """Test AEResNetNetwork n_filters configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        n_filters=n_filters,
+        n_residual_blocks=n_residual_blocks,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "kernel_size, n_conv_per_residual_block",
+    [
+        (8, 3),  # scalar case
+        ([8, 5, 3], 3),  # list case matching conv layers
+        pytest.param(
+            [8, 5], 3, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_kernel_size(kernel_size, n_conv_per_residual_block):
+    """Test AEResNetNetwork kernel_size configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        kernel_size=kernel_size,
+        n_conv_per_residual_block=n_conv_per_residual_block,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "strides, n_conv_per_residual_block",
+    [
+        (1, 3),  # scalar case
+        pytest.param(
+            [1, 2], 3, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_strides(strides, n_conv_per_residual_block):
+    """Test AEResNetNetwork strides configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        strides=strides,
+        n_conv_per_residual_block=n_conv_per_residual_block,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "dilation_rate, n_conv_per_residual_block",
+    [
+        (1, 3),  # scalar case
+        pytest.param(
+            [1, 2], 3, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_dilation_rate(dilation_rate, n_conv_per_residual_block):
+    """Test AEResNetNetwork dilation_rate configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        dilation_rate=dilation_rate,
+        n_conv_per_residual_block=n_conv_per_residual_block,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "padding, n_conv_per_residual_block",
+    [
+        ("same", 3),  # scalar case
+        #    (['same', 'valid', 'same'], 3),  # list case matching conv layers
+        pytest.param(
+            ["same", "valid"], 3, marks=pytest.mark.xfail(raises=ValueError)
+        ),  # error case
+    ],
+)
+def test_padding(padding, n_conv_per_residual_block):
+    """Test AEResNetNetwork padding configurations."""
+    aer = AEResNetNetwork(
+        latent_space_dim=128,
+        padding=padding,
+        n_conv_per_residual_block=n_conv_per_residual_block,
+    )
+    encoder, decoder = aer.build_network((1000, 5))
+    assert encoder is not None
+    assert decoder is not None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Contributes to a part of #2497.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

The following implementation adds test cases for every parameter of AEResNetNetwork in networks module. 
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

This update ensures better maintainability of the AEResNetNetwork class by testing edge cases for various configurations
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
