### PR TITLE
[ENH] Test coverage for MLP Network improved

### DIFF
--- a/aeon/networks/tests/test_mlp.py
+++ b/aeon/networks/tests/test_mlp.py
@@ -1,0 +1,179 @@
+"""Tests for the MLPNetwork Model."""
+
+import pytest
+
+from aeon.networks import MLPNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "n_layers, n_units, activation",
+    [
+        (3, 500, "relu"),
+        (5, [256, 128, 128, 64, 32], "sigmoid"),
+        (2, 128, ["tanh", "relu"]),
+    ],
+)
+def test_mlp_initialization(n_layers, n_units, activation):
+    """Test whether MLPNetwork initializes correctly with different configurations."""
+    from tensorflow.keras.layers import Dense, Dropout, Flatten, InputLayer
+    from tensorflow.keras.models import Model
+
+    mlp = MLPNetwork(n_layers=n_layers, n_units=n_units, activation=activation)
+    input_layer, output_layer = mlp.build_network((1000, 5))
+
+    # Wrap in a Model to access internal layers
+    model = Model(inputs=input_layer, outputs=output_layer)
+    layers = model.layers
+
+    assert isinstance(layers[0], InputLayer), "Expected first layer to be InputLayer"
+
+    assert isinstance(layers[1], Flatten), "Expected second layer to be Flatten"
+
+    # Check dropout and dense layers ordering
+    for i in range(n_layers):
+        dropout_layer = layers[2 + 2 * i]  # Dropout before Dense
+        dense_layer = layers[3 + 2 * i]  # Dense comes after Dropout
+
+        assert isinstance(
+            dropout_layer, Dropout
+        ), f"Expected Dropout at index {2 + 2 * i}"
+        assert isinstance(dense_layer, Dense), f"Expected Dense at index {3 + 2 * i}"
+
+        # Assert activation function
+        expected_activation = (
+            activation[i] if isinstance(activation, list) else activation
+        )
+        assert dense_layer.activation.__name__ == expected_activation, (
+            f"Expected activation {expected_activation}, "
+            f"got {dense_layer.activation.__name__}"
+        )
+
+        # Assert number of units
+        expected_units = n_units[i] if isinstance(n_units, list) else n_units
+        assert (
+            dense_layer.units == expected_units
+        ), f"Expected {expected_units} units, got {dense_layer.units}"
+
+    # Check last layer is Dropout
+    assert isinstance(layers[-1], Dropout), "Expected final layer to be Dropout"
+
+    # Assert model parameters (Just for show)
+    assert mlp.n_layers == n_layers
+    assert mlp.n_units == n_units
+    assert mlp.activation == activation
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "dropout_rate, n_layers",
+    [
+        (0.2, 3),
+        ([0.1, 0.2, 0.3], 3),
+        pytest.param([0.1, 0.2], 3, marks=pytest.mark.xfail(raises=AssertionError)),
+    ],
+)
+def test_mlp_dropout_rate(dropout_rate, n_layers):
+    """Test MLPNetwork dropout_rate configurations."""
+    from tensorflow.keras.layers import Dense, Dropout, Flatten, InputLayer
+    from tensorflow.keras.models import Model
+
+    mlp = MLPNetwork(n_layers=n_layers, dropout_rate=dropout_rate)
+    input_layer, output_layer = mlp.build_network((1000, 5))
+
+    # Wrap in a Model to access internal layers
+    model = Model(inputs=input_layer, outputs=output_layer)
+    layers = model.layers
+
+    # Check first two layers
+    assert isinstance(layers[0], InputLayer), "Expected first layer to be InputLayer"
+    assert isinstance(layers[1], Flatten), "Expected second layer to be Flatten"
+
+    # Check dropout and dense layers ordering
+    for i in range(n_layers):
+        dropout_layer = layers[2 + 2 * i]
+        dense_layer = layers[3 + 2 * i]
+
+        assert isinstance(
+            dropout_layer, Dropout
+        ), f"Expected Dropout at index {2 + 2 * i}"
+        assert isinstance(dense_layer, Dense), f"Expected Dense at index {3 + 2 * i}"
+
+        # Assert dropout rates match expected values
+        expected_dropout = (
+            dropout_rate[i] if isinstance(dropout_rate, list) else dropout_rate
+        )
+        assert (
+            dropout_layer.rate == expected_dropout
+        ), f"Expected {expected_dropout},got {dropout_layer.rate}"
+    assert isinstance(layers[-1], Dropout), "Expected final layer to be Dropout"
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "dropout_last",
+    [0.3, 0.5, pytest.param(1.2, marks=pytest.mark.xfail(raises=AssertionError))],
+)
+def test_mlp_dropout_last(dropout_last):
+    """Test MLPNetwork dropout_last configurations."""
+    from tensorflow.keras.layers import Dropout, Flatten, InputLayer
+    from tensorflow.keras.models import Model
+
+    mlp = MLPNetwork(dropout_last=dropout_last)
+    input_layer, output_layer = mlp.build_network((1000, 5))
+
+    # Wrap in a Model to access internal layers
+    model = Model(inputs=input_layer, outputs=output_layer)
+    layers = model.layers
+
+    assert isinstance(layers[0], InputLayer), "Expected first layer to be InputLayer"
+    assert isinstance(layers[1], Flatten), "Expected second layer to be Flatten"
+    assert isinstance(layers[-1], Dropout), "Expected final layer to be Dropout"
+
+    assert (
+        layers[-1].rate == dropout_last
+    ), f"Expected {dropout_last}, got {layers[-1].rate}"
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_mlp_use_bias(use_bias):
+    """Test MLPNetwork use_bias configurations."""
+    from tensorflow.keras.layers import Dense, Dropout, Flatten, InputLayer
+    from tensorflow.keras.models import Model
+
+    mlp = MLPNetwork(use_bias=use_bias)
+    input_layer, output_layer = mlp.build_network((1000, 5))
+
+    # Wrap in a Model to access internal layers
+    model = Model(inputs=input_layer, outputs=output_layer)
+    layers = model.layers
+
+    assert isinstance(layers[0], InputLayer), "Expected first layer to be InputLayer"
+    assert isinstance(layers[1], Flatten), "Expected second layer to be Flatten"
+    assert isinstance(layers[-1], Dropout), "Expected final layer to be Dropout"
+
+    # Find the last Dense layer before the final Dropout layer
+    last_dense_layer = next(
+        (layer for layer in reversed(layers) if isinstance(layer, Dense)), None
+    )
+
+    assert last_dense_layer is not None, "No Dense layer found before final Dropout"
+    assert isinstance(last_dense_layer, Dense), "Expected last layer to be Dense"
+
+    assert (
+        last_dense_layer.use_bias == use_bias
+    ), f"Expected use_bias {use_bias}, got {last_dense_layer.use_bias}"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Contributes to #2497 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Adds test coverage for _mlp.py
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
Achieves 96% coverage on _mlp.py, checked using 
```pytest --cov=aeon.networks aeon/networks/ ```
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
