### PR TITLE
[ENH] Test coverage for AEAttentionBiGRUNetwork Improved

### DIFF
--- a/aeon/networks/_ae_abgru.py
+++ b/aeon/networks/_ae_abgru.py
@@ -162,7 +162,6 @@ class AEAttentionBiGRUNetwork(BaseDeepLearningNetwork):
             x = tf.keras.layers.Dense(self.latent_space_dim)(x)
         elif self.temporal_latent_space:
             x = tf.keras.layers.Conv1D(filters=self.latent_space_dim, kernel_size=1)(x)
-            shape_before_flatten = x.shape[1:]
 
         encoder = tf.keras.models.Model(inputs=input_layer, outputs=x, name="encoder")
 

--- a/aeon/networks/_ae_abgru.py
+++ b/aeon/networks/_ae_abgru.py
@@ -162,6 +162,7 @@ class AEAttentionBiGRUNetwork(BaseDeepLearningNetwork):
             x = tf.keras.layers.Dense(self.latent_space_dim)(x)
         elif self.temporal_latent_space:
             x = tf.keras.layers.Conv1D(filters=self.latent_space_dim, kernel_size=1)(x)
+            shape_before_flatten = x.shape[1:]
 
         encoder = tf.keras.models.Model(inputs=input_layer, outputs=x, name="encoder")
 

--- a/aeon/networks/tests/test_ae_abgru.py
+++ b/aeon/networks/tests/test_ae_abgru.py
@@ -15,10 +15,32 @@ def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
     """Test AEAttentionBiGRUNetwork with different latent space dimensions."""
     import tensorflow as tf
 
+    input_shape = (1000, 5)
     aeattentionbigru = AEAttentionBiGRUNetwork(latent_space_dim=latent_space_dim)
-    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    encoder, decoder = aeattentionbigru.build_network(input_shape)
+
+    # Check instance types
     assert isinstance(encoder, tf.keras.models.Model)
     assert isinstance(decoder, tf.keras.models.Model)
+
+    # Check encoder output shape matches the specified latent_space_dim
+    dummy_input = tf.keras.layers.Input(shape=input_shape)
+    encoder_output = encoder(dummy_input)
+    assert encoder_output.shape[-1] == latent_space_dim
+
+    # Check decoder input shape matches the specified latent_space_dim
+    decoder_input_shape = decoder.input_shape
+    assert decoder_input_shape[-1] == latent_space_dim
+
+    # Test the full autoencoder pipeline
+    autoencoder = tf.keras.models.Model(
+        inputs=encoder.inputs, outputs=decoder(encoder.outputs[0])
+    )
+    assert isinstance(autoencoder, tf.keras.models.Model)
+
+    # Check output shape matches input shape
+    output = autoencoder(dummy_input)
+    assert output.shape[1:] == input_shape
 
 
 @pytest.mark.skipif(
@@ -42,6 +64,23 @@ def test_aeattentionbigrunetwork_n_layers_decoder(n_layers_decoder):
         assert isinstance(encoder, tf.keras.models.Model)
         assert isinstance(decoder, tf.keras.models.Model)
 
+        # Count the number of Bidirectional layers in the decoder
+        bidirectional_layers = [
+            layer
+            for layer in decoder.layers
+            if isinstance(layer, tf.keras.layers.Bidirectional)
+        ]
+        assert len(bidirectional_layers) == n_layers_decoder, (
+            f"Expected {n_layers_decoder} Bidirectional layers in decoder, "
+            f"but found {len(bidirectional_layers)}"
+        )
+
+        # Check if all Bidirectional layers contain GRU as expected
+        for i, layer in enumerate(bidirectional_layers):
+            assert isinstance(
+                layer.forward_layer, tf.keras.layers.GRU
+            ), f"Layer {i} is not using GRU as expected"
+
 
 @pytest.mark.skipif(
     not _check_soft_dependencies(["tensorflow"], severity="none"),
@@ -64,6 +103,28 @@ def test_aeattentionbigrunetwork_n_layers_encoder(n_layers_encoder):
         assert isinstance(encoder, tf.keras.models.Model)
         assert isinstance(decoder, tf.keras.models.Model)
 
+        # Count the number of GRU layers in the encoder
+        gru_layers = [
+            layer for layer in encoder.layers if isinstance(layer, tf.keras.layers.GRU)
+        ]
+
+        # Each encoder layer has 2 GRUs (forward and backward)
+        assert len(gru_layers) == 2 * n_layers_encoder, (
+            f"Expected {2 * n_layers_encoder} GRU layers in encoder, "
+            f"but found {len(gru_layers)}"
+        )
+
+        # Count attention layers
+        attention_layers = [
+            layer
+            for layer in encoder.layers
+            if isinstance(layer, tf.keras.layers.Attention)
+        ]
+        assert len(attention_layers) == n_layers_encoder, (
+            f"Expected {n_layers_encoder} Attention layers, "
+            f"but found {len(attention_layers)}"
+        )
+
 
 @pytest.mark.skipif(
     not _check_soft_dependencies(["tensorflow"], severity="none"),
@@ -77,23 +138,46 @@ def test_aeattentionbigrunetwork_activation_decoder(activation_decoder):
     """Test AEAttentionBiGRUNetwork with different decoder activations."""
     import tensorflow as tf
 
-    if isinstance(activation_decoder, list) and len(activation_decoder) != 3:
+    n_layers = 3 if isinstance(activation_decoder, list) else 1
+    if isinstance(activation_decoder, list) and len(activation_decoder) != n_layers:
         with pytest.raises(ValueError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
                 activation_encoder="relu",
                 activation_decoder=activation_decoder,
-                n_layers_decoder=3,
+                n_layers_decoder=n_layers,
             )
             encoder, decoder = aeattentionbigru.build_network((1000, 5))
     else:
         aeattentionbigru = AEAttentionBiGRUNetwork(
             activation_encoder="relu",
             activation_decoder=activation_decoder,
-            n_layers_decoder=3 if isinstance(activation_decoder, list) else 1,
+            n_layers_decoder=n_layers,
         )
         encoder, decoder = aeattentionbigru.build_network((1000, 5))
         assert isinstance(encoder, tf.keras.models.Model)
         assert isinstance(decoder, tf.keras.models.Model)
+
+        # Check that the activations are correctly set in the Bidirectional GRU layers
+        bidirectional_layers = [
+            layer
+            for layer in decoder.layers
+            if isinstance(layer, tf.keras.layers.Bidirectional)
+        ]
+
+        expected_activations = (
+            activation_decoder
+            if isinstance(activation_decoder, list)
+            else [activation_decoder] * n_layers
+        )
+
+        for i, layer in enumerate(bidirectional_layers):
+            assert (
+                layer.forward_layer.activation.__name__
+                == expected_activations[n_layers - i - 1]
+            ), (
+                f"Layer {i} has activation {layer.forward_layer.activation.__name__}, "
+                f"expected {expected_activations[n_layers-i-1]}"
+            )
 
 
 @pytest.mark.skipif(
@@ -108,39 +192,90 @@ def test_aeattentionbigrunetwork_activation_encoder(activation_encoder):
     """Test AEAttentionBiGRUNetwork with different encoder activations."""
     import tensorflow as tf
 
-    if isinstance(activation_encoder, list) and len(activation_encoder) != 3:
+    n_layers = 3 if isinstance(activation_encoder, list) else 1
+    if isinstance(activation_encoder, list) and len(activation_encoder) != n_layers:
         with pytest.raises(ValueError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
                 activation_encoder=activation_encoder,
                 activation_decoder="relu",
-                n_layers_encoder=3,
+                n_layers_encoder=n_layers,
             )
             encoder, decoder = aeattentionbigru.build_network((1000, 5))
     else:
         aeattentionbigru = AEAttentionBiGRUNetwork(
             activation_encoder=activation_encoder,
             activation_decoder="relu",
-            n_layers_encoder=3 if isinstance(activation_encoder, list) else 1,
+            n_layers_encoder=n_layers,
         )
         encoder, decoder = aeattentionbigru.build_network((1000, 5))
         assert isinstance(encoder, tf.keras.models.Model)
         assert isinstance(decoder, tf.keras.models.Model)
+
+        # Extract GRU layers from the encoder
+        gru_layers = [
+            layer for layer in encoder.layers if isinstance(layer, tf.keras.layers.GRU)
+        ]
+
+        expected_activations = (
+            activation_encoder
+            if isinstance(activation_encoder, list)
+            else [activation_encoder] * n_layers
+        )
+
+        # Check activations for forward GRU layers (first half of GRU layers)
+        for i in range(n_layers):
+            assert gru_layers[i * 2].activation.__name__ == expected_activations[i], (
+                f"Forward GRU layer {i} has activation "
+                f"{gru_layers[i*2].activation.__name__}, expected "
+                f"{expected_activations[i]}"
+            )
 
 
 @pytest.mark.skipif(
     not _check_soft_dependencies(["tensorflow"], severity="none"),
     reason="Tensorflow soft dependency unavailable.",
 )
-@pytest.mark.parametrize(
-    "temporal_latent_space", [False]
-)  # fails if set to True  -> issue raised
+@pytest.mark.parametrize("temporal_latent_space", [False, True])
 def test_aeattentionbigrunetwork_temporal_latent_space(temporal_latent_space):
     """Test AEAttentionBiGRUNetwork with temporal latent space enabled/disabled."""
     import tensorflow as tf
 
+    input_shape = (1000, 5)
+    latent_space_dim = 64
     aeattentionbigru = AEAttentionBiGRUNetwork(
-        temporal_latent_space=temporal_latent_space
+        temporal_latent_space=temporal_latent_space, latent_space_dim=latent_space_dim
     )
-    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    encoder, decoder = aeattentionbigru.build_network(input_shape)
     assert isinstance(encoder, tf.keras.models.Model)
     assert isinstance(decoder, tf.keras.models.Model)
+
+    # Check the encoder output shape based on temporal_latent_space setting
+    dummy_input = tf.keras.layers.Input(shape=input_shape)
+    encoder_output = encoder(dummy_input)
+
+    if temporal_latent_space:
+        assert len(encoder_output.shape) == 3
+        assert encoder_output.shape[-1] == latent_space_dim
+        assert encoder_output.shape[1] == input_shape[0]  # Time dimension preserved
+    else:
+        assert len(encoder_output.shape) == 2
+        assert encoder_output.shape[-1] == latent_space_dim
+
+    # Check decoder input shape
+    if temporal_latent_space:
+        assert len(decoder.input_shape) == 3
+        assert decoder.input_shape[-1] == latent_space_dim
+    else:
+        assert len(decoder.input_shape) == 2
+        assert decoder.input_shape[-1] == latent_space_dim
+
+    # Check for specific layers based on temporal_latent_space setting
+    if not temporal_latent_space:
+        # Should have a RepeatVector layer in decoder
+        repeat_vector_layers = [
+            layer
+            for layer in decoder.layers
+            if isinstance(layer, tf.keras.layers.RepeatVector)
+        ]
+        assert len(repeat_vector_layers) == 1
+        assert repeat_vector_layers[0].n == input_shape[0]

--- a/aeon/networks/tests/test_ae_abgru.py
+++ b/aeon/networks/tests/test_ae_abgru.py
@@ -1,7 +1,6 @@
 """Tests for the Attention Bidirectional Network."""
 
 import pytest
-import tensorflow as tf
 
 from aeon.networks import AEAttentionBiGRUNetwork
 from aeon.utils.validation._dependencies import _check_soft_dependencies
@@ -14,6 +13,8 @@ from aeon.utils.validation._dependencies import _check_soft_dependencies
 @pytest.mark.parametrize("latent_space_dim", [64, 128, 256])
 def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
     """Test AEAttentionBiGRUNetwork with different latent space dimensions."""
+    import tensorflow as tf
+
     aeattentionbigru = AEAttentionBiGRUNetwork(latent_space_dim=latent_space_dim)
     encoder, decoder = aeattentionbigru.build_network((1000, 5))
     assert isinstance(encoder, tf.keras.models.Model)
@@ -27,6 +28,8 @@ def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
 @pytest.mark.parametrize("n_layers_decoder", [1, 2, 3, 2.5, "1"])
 def test_aeattentionbigrunetwork_n_layers_decoder(n_layers_decoder):
     """Test AEAttentionBiGRUNetwork with different number of decoder layers."""
+    import tensorflow as tf
+
     if not isinstance(n_layers_decoder, int):
         with pytest.raises(TypeError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
@@ -47,6 +50,8 @@ def test_aeattentionbigrunetwork_n_layers_decoder(n_layers_decoder):
 @pytest.mark.parametrize("n_layers_encoder", [1, 2, 3, 3.5, "2"])
 def test_aeattentionbigrunetwork_n_layers_encoder(n_layers_encoder):
     """Test AEAttentionBiGRUNetwork with different number of encoder layers."""
+    import tensorflow as tf
+
     if not isinstance(n_layers_encoder, int):
         with pytest.raises(TypeError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
@@ -70,6 +75,8 @@ def test_aeattentionbigrunetwork_n_layers_encoder(n_layers_encoder):
 )
 def test_aeattentionbigrunetwork_activation_decoder(activation_decoder):
     """Test AEAttentionBiGRUNetwork with different decoder activations."""
+    import tensorflow as tf
+
     if isinstance(activation_decoder, list) and len(activation_decoder) != 3:
         with pytest.raises(ValueError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
@@ -99,6 +106,8 @@ def test_aeattentionbigrunetwork_activation_decoder(activation_decoder):
 )
 def test_aeattentionbigrunetwork_activation_encoder(activation_encoder):
     """Test AEAttentionBiGRUNetwork with different encoder activations."""
+    import tensorflow as tf
+
     if isinstance(activation_encoder, list) and len(activation_encoder) != 3:
         with pytest.raises(ValueError):
             aeattentionbigru = AEAttentionBiGRUNetwork(
@@ -127,6 +136,8 @@ def test_aeattentionbigrunetwork_activation_encoder(activation_encoder):
 )  # fails if set to True  -> issue raised
 def test_aeattentionbigrunetwork_temporal_latent_space(temporal_latent_space):
     """Test AEAttentionBiGRUNetwork with temporal latent space enabled/disabled."""
+    import tensorflow as tf
+
     aeattentionbigru = AEAttentionBiGRUNetwork(
         temporal_latent_space=temporal_latent_space
     )

--- a/aeon/networks/tests/test_ae_abgru.py
+++ b/aeon/networks/tests/test_ae_abgru.py
@@ -1,0 +1,135 @@
+"""Tests for the Attention Bidirectional Network."""
+
+import pytest
+import tensorflow as tf
+
+from aeon.networks import AEAttentionBiGRUNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("latent_space_dim", [64, 128, 256])
+def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
+    """Test AEAttentionBiGRUNetwork with different latent space dimensions."""
+    aeattentionbigru = AEAttentionBiGRUNetwork(latent_space_dim=latent_space_dim)
+    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    assert isinstance(encoder, tf.keras.models.Model)
+    assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("n_layers_decoder", [1, 2, 3, 2.5, "1"])
+def test_aeattentionbigrunetwork_n_layers_decoder(n_layers_decoder):
+    """Test AEAttentionBiGRUNetwork with different number of decoder layers."""
+    if not isinstance(n_layers_decoder, int):
+        with pytest.raises(TypeError):
+            aeattentionbigru = AEAttentionBiGRUNetwork(
+                n_layers_decoder=n_layers_decoder
+            )
+            encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    else:
+        aeattentionbigru = AEAttentionBiGRUNetwork(n_layers_decoder=n_layers_decoder)
+        encoder, decoder = aeattentionbigru.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("n_layers_encoder", [1, 2, 3, 3.5, "2"])
+def test_aeattentionbigrunetwork_n_layers_encoder(n_layers_encoder):
+    """Test AEAttentionBiGRUNetwork with different number of encoder layers."""
+    if not isinstance(n_layers_encoder, int):
+        with pytest.raises(TypeError):
+            aeattentionbigru = AEAttentionBiGRUNetwork(
+                n_layers_encoder=n_layers_encoder
+            )
+            encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    else:
+        aeattentionbigru = AEAttentionBiGRUNetwork(n_layers_encoder=n_layers_encoder)
+        encoder, decoder = aeattentionbigru.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "activation_decoder",
+    ["relu", "tanh", "sigmoid", ["relu", "tanh"], ["sigmoid", "relu", "tanh"]],
+)
+def test_aeattentionbigrunetwork_activation_decoder(activation_decoder):
+    """Test AEAttentionBiGRUNetwork with different decoder activations."""
+    if isinstance(activation_decoder, list) and len(activation_decoder) != 3:
+        with pytest.raises(ValueError):
+            aeattentionbigru = AEAttentionBiGRUNetwork(
+                activation_encoder="relu",
+                activation_decoder=activation_decoder,
+                n_layers_decoder=3,
+            )
+            encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    else:
+        aeattentionbigru = AEAttentionBiGRUNetwork(
+            activation_encoder="relu",
+            activation_decoder=activation_decoder,
+            n_layers_decoder=3 if isinstance(activation_decoder, list) else 1,
+        )
+        encoder, decoder = aeattentionbigru.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "activation_encoder",
+    ["relu", "tanh", "sigmoid", ["relu", "tanh"], ["sigmoid", "relu", "tanh"]],
+)
+def test_aeattentionbigrunetwork_activation_encoder(activation_encoder):
+    """Test AEAttentionBiGRUNetwork with different encoder activations."""
+    if isinstance(activation_encoder, list) and len(activation_encoder) != 3:
+        with pytest.raises(ValueError):
+            aeattentionbigru = AEAttentionBiGRUNetwork(
+                activation_encoder=activation_encoder,
+                activation_decoder="relu",
+                n_layers_encoder=3,
+            )
+            encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    else:
+        aeattentionbigru = AEAttentionBiGRUNetwork(
+            activation_encoder=activation_encoder,
+            activation_decoder="relu",
+            n_layers_encoder=3 if isinstance(activation_encoder, list) else 1,
+        )
+        encoder, decoder = aeattentionbigru.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "temporal_latent_space", [False]
+)  # fails if set to True  -> issue raised
+def test_aeattentionbigrunetwork_temporal_latent_space(temporal_latent_space):
+    """Test AEAttentionBiGRUNetwork with temporal latent space enabled/disabled."""
+    aeattentionbigru = AEAttentionBiGRUNetwork(
+        temporal_latent_space=temporal_latent_space
+    )
+    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    assert isinstance(encoder, tf.keras.models.Model)
+    assert isinstance(decoder, tf.keras.models.Model)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Contributes to #2497. Reference PRs #2518 and #2534.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

The given issue improvises the test coverage of AEAttentionBiGRUNetwork class.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

No.
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

No.
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
