### PR TITLE
[ENH] Distance module n_jobs support

### DIFF
--- a/aeon/distances/_mpdist.py
+++ b/aeon/distances/_mpdist.py
@@ -1,5 +1,6 @@
 """Matrix Profile Distances."""
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
@@ -287,6 +288,7 @@ def mp_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
     m: int = 0,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the mpdist pairwise distance between a set of time series.
 
@@ -339,13 +341,19 @@ def mp_pairwise_distance(
            [2.82842712],
            [2.82842712]])
     """
+    if "n_jobs" in kwargs:
+        warnings.warn(
+            "n_jobs is not supported for the mpdist distance method and will be "
+            "ignored.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if m == 0:
+        m = int(X.shape[2] / 4)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
     )
-
-    if m == 0:
-        m = int(_X.shape[2] / 4)
 
     if y is None:
         return _mpdist_pairwise_distance_single(_X, m)

--- a/aeon/distances/_sbd.py
+++ b/aeon/distances/_sbd.py
@@ -2,14 +2,16 @@
 
 __maintainer__ = ["SebastianSchmidl"]
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit, objmode
+from numba import njit, objmode, prange, set_num_threads
 from numba.typed import List as NumbaList
 from scipy.signal import correlate
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -117,6 +119,8 @@ def sbd_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
     standardize: bool = True,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """
     Compute the shape-based distance (SBD) between all pairs of time series.
@@ -138,6 +142,10 @@ def sbd_pairwise_distance(
     standardize : bool, default=True
         Apply z-score to both input time series for standardization before
         computing the distance. This makes SBD scaling invariant. Default is True.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -188,6 +196,17 @@ def sbd_pairwise_distance(
            [0.36754447, 0.        , 0.29289322],
            [0.5527864 , 0.29289322, 0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
+    if n_jobs > 1:
+        warnings.warn(
+            "You have set n_jobs > 1. For this distance function "
+            "unless your data is very large (> 10000 time series), it is "
+            "recommended to use n_jobs=1. If this function is slower than "
+            "expected try setting n_jobs=1.",
+            UserWarning,
+            stacklevel=2,
+        )
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, _ = _convert_collection_to_numba_list(X, "", multivariate_conversion)
 
@@ -199,14 +218,14 @@ def sbd_pairwise_distance(
     return _sbd_pairwise_distance(_X, _y, standardize)
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _sbd_pairwise_distance_single(
     x: NumbaList[np.ndarray], standardize: bool
 ) -> np.ndarray:
     n_cases = len(x)
     distances = np.zeros((n_cases, n_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             distances[i, j] = sbd_distance(x[i], x[j], standardize)
             distances[j, i] = distances[i, j]
@@ -214,7 +233,7 @@ def _sbd_pairwise_distance_single(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _sbd_pairwise_distance(
     x: NumbaList[np.ndarray], y: NumbaList[np.ndarray], standardize: bool
 ) -> np.ndarray:
@@ -222,7 +241,7 @@ def _sbd_pairwise_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             distances[i, j] = sbd_distance(x[i], y[j], standardize)
     return distances

--- a/aeon/distances/_shift_scale_invariant.py
+++ b/aeon/distances/_shift_scale_invariant.py
@@ -3,10 +3,11 @@
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -160,6 +161,8 @@ def shift_scale_invariant_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
     max_shift: Optional[int] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     r"""Compute the shift-scale invariant pairwise distance between time series.
 
@@ -193,6 +196,10 @@ def shift_scale_invariant_pairwise_distance(
         Maximum shift allowed in the alignment path. If None, then max_shift is set
         to min(X.shape[-1], y.shape[-1]) or if y is None, max_shift is set to
         X.shape[-1].
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -223,6 +230,8 @@ def shift_scale_invariant_pairwise_distance(
     >>> y_univariate = np.array([11., 12., 13.])
     >>> single_pw =shift_scale_invariant_pairwise_distance(X, y_univariate)
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     if max_shift is None:
         if y is None:
             max_shift = X.shape[-1]
@@ -308,7 +317,7 @@ def shift_scale_invariant_best_shift(
     raise ValueError("x and y must be 1D or 2D")
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _shift_invariant_pairwise_distance(
     x: NumbaList[np.ndarray], y: NumbaList[np.ndarray], max_shift: int
 ) -> np.ndarray:
@@ -316,7 +325,7 @@ def _shift_invariant_pairwise_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             distances[i, j] = shift_scale_invariant_distance(x[i], y[j], max_shift)
     return distances

--- a/aeon/distances/elastic/_adtw.py
+++ b/aeon/distances/elastic/_adtw.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._squared import _univariate_squared_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -203,6 +204,8 @@ def adtw_pairwise_distance(
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
     warp_penalty: float = 1.0,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     r"""Compute the ADTW pairwise distance between a set of time series.
 
@@ -226,6 +229,10 @@ def adtw_pairwise_distance(
         Penalty for warping. A high value will mean less warping.
         warp less and if value is low then will encourage algorithm to warp
         more.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -272,6 +279,8 @@ def adtw_pairwise_distance(
            [ 44.,   0.,  87.],
            [294.,  87.,   0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -290,7 +299,7 @@ def adtw_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _adtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -306,7 +315,7 @@ def _adtw_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -319,7 +328,7 @@ def _adtw_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _adtw_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -336,7 +345,7 @@ def _adtw_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_ddtw.py
+++ b/aeon/distances/elastic/_ddtw.py
@@ -5,7 +5,7 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
@@ -15,6 +15,7 @@ from aeon.distances.elastic._dtw import (
     create_bounding_matrix,
 )
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -172,6 +173,8 @@ def ddtw_pairwise_distance(
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the DDTW pairwise distance between a set of time series.
 
@@ -191,6 +194,10 @@ def ddtw_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -237,6 +244,8 @@ def ddtw_pairwise_distance(
            [0., 0., 0.],
            [0., 0., 0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -254,7 +263,7 @@ def ddtw_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _ddtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -274,7 +283,7 @@ def _ddtw_pairwise_distance(
     for i in range(n_cases):
         X_average_of_slope.append(average_of_slope(X[i]))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X_average_of_slope[i], X_average_of_slope[j]
             if unequal_length:
@@ -287,7 +296,7 @@ def _ddtw_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _ddtw_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -313,7 +322,7 @@ def _ddtw_from_multiple_to_multiple_distance(
     for i in range(m_cases):
         y_average_of_slope.append(average_of_slope(y[i]))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x_average_of_slope[i], y_average_of_slope[j]
             if unequal_length:

--- a/aeon/distances/elastic/_edr.py
+++ b/aeon/distances/elastic/_edr.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._euclidean import _univariate_euclidean_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -235,6 +236,8 @@ def edr_pairwise_distance(
     window: Optional[float] = None,
     epsilon: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the pairwise EDR distance between a set of time series.
 
@@ -258,6 +261,10 @@ def edr_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -303,6 +310,8 @@ def edr_pairwise_distance(
            [0.75, 0.  , 0.8 ],
            [0.6 , 0.8 , 0.  ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -322,7 +331,7 @@ def edr_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _edr_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -338,7 +347,7 @@ def _edr_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -351,7 +360,7 @@ def _edr_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _edr_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -368,7 +377,7 @@ def _edr_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_erp.py
+++ b/aeon/distances/elastic/_erp.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._euclidean import _univariate_euclidean_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -255,6 +256,8 @@ def erp_pairwise_distance(
     g: float = 0.0,
     g_arr: Optional[np.ndarray] = None,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the ERP pairwise distance between a set of time series.
 
@@ -283,6 +286,10 @@ def erp_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -327,6 +334,8 @@ def erp_pairwise_distance(
            [16.,  0., 28.],
            [44., 28.,  0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -343,7 +352,7 @@ def erp_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _erp_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -361,7 +370,7 @@ def _erp_pairwise_distance(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -374,7 +383,7 @@ def _erp_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _erp_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -392,7 +401,7 @@ def _erp_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_lcss.py
+++ b/aeon/distances/elastic/_lcss.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_lcss_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._euclidean import _univariate_euclidean_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -228,6 +229,8 @@ def lcss_pairwise_distance(
     window: Optional[float] = None,
     epsilon: float = 1.0,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the LCSS pairwise distance between a set of time series.
 
@@ -250,6 +253,10 @@ def lcss_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -295,6 +302,8 @@ def lcss_pairwise_distance(
            [0.66666667, 0.        , 0.75      ],
            [1.        , 0.75      , 0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -312,7 +321,7 @@ def lcss_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _lcss_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -327,7 +336,7 @@ def _lcss_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -340,7 +349,7 @@ def _lcss_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _lcss_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -357,7 +366,7 @@ def _lcss_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_msm.py
+++ b/aeon/distances/elastic/_msm.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._squared import _univariate_squared_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -350,6 +351,8 @@ def msm_pairwise_distance(
     independent: bool = True,
     c: float = 1.0,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the msm pairwise distance between a set of time series.
 
@@ -374,6 +377,10 @@ def msm_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -419,6 +426,8 @@ def msm_pairwise_distance(
            [10.,  0., 14.],
            [17., 14.,  0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -438,7 +447,7 @@ def msm_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _msm_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -455,7 +464,7 @@ def _msm_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -468,7 +477,7 @@ def _msm_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _msm_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -486,7 +495,7 @@ def _msm_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_shape_dtw.py
+++ b/aeon/distances/elastic/_shape_dtw.py
@@ -5,7 +5,7 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
@@ -13,6 +13,7 @@ from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.elastic._dtw import _dtw_cost_matrix
 from aeon.distances.pointwise._squared import _univariate_squared_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -525,6 +526,8 @@ def shape_dtw_pairwise_distance(
     transformation_precomputed: bool = False,
     transformed_x: Optional[np.ndarray] = None,
     transformed_y: Optional[np.ndarray] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the ShapeDTW pairwise distance among a set of series.
 
@@ -563,6 +566,10 @@ def shape_dtw_pairwise_distance(
         The transformation of X, ignored if transformation_precomputed is False.
     transformed_y : np.ndarray, default = None
         The transformation of y, ignored if transformation_precomputed is False.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -609,6 +616,8 @@ def shape_dtw_pairwise_distance(
            [ 43.,   0.,  89.],
            [292.,  89.,   0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -644,7 +653,7 @@ def shape_dtw_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _shape_dtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -663,7 +672,7 @@ def _shape_dtw_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(len(X)):
+    for i in prange(len(X)):
         for j in range(i + 1, n_cases):
             x1_, x2_ = X[i], X[j]
             x1 = _pad_ts_edges(x=x1_, reach=reach)
@@ -695,7 +704,7 @@ def _shape_dtw_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _shape_dtw_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -716,7 +725,7 @@ def _shape_dtw_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1_, y1_ = x[i], y[j]
             x1 = _pad_ts_edges(x=x1_, reach=reach)

--- a/aeon/distances/elastic/_soft_dtw.py
+++ b/aeon/distances/elastic/_soft_dtw.py
@@ -5,7 +5,7 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
@@ -13,6 +13,7 @@ from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.elastic._dtw import _dtw_cost_matrix
 from aeon.distances.pointwise._squared import _univariate_squared_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -249,6 +250,8 @@ def soft_dtw_pairwise_distance(
     gamma: float = 1.0,
     window: Optional[float] = None,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     r"""Compute the soft-DTW pairwise distance between a set of time series.
 
@@ -270,6 +273,10 @@ def soft_dtw_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -316,6 +323,8 @@ def soft_dtw_pairwise_distance(
            [ 41.44055555,   0.        ,  82.43894439],
            [291.99999969,  82.43894439,   0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -334,7 +343,7 @@ def soft_dtw_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _soft_dtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -350,7 +359,7 @@ def _soft_dtw_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -363,7 +372,7 @@ def _soft_dtw_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _soft_dtw_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -380,7 +389,7 @@ def _soft_dtw_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_twe.py
+++ b/aeon/distances/elastic/_twe.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._euclidean import _univariate_euclidean_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -250,6 +251,8 @@ def twe_pairwise_distance(
     nu: float = 0.001,
     lmbda: float = 1.0,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the TWE pairwise distance between a set of time series.
 
@@ -274,6 +277,10 @@ def twe_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -319,6 +326,8 @@ def twe_pairwise_distance(
            [13.005,  0.   , 18.007],
            [19.006, 18.007,  0.   ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -336,7 +345,7 @@ def twe_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _twe_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -359,7 +368,7 @@ def _twe_pairwise_distance(
     for i in range(n_cases):
         padded_X.append(_pad_arrs(X[i]))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = padded_X[i], padded_X[j]
             if unequal_length:
@@ -372,7 +381,7 @@ def _twe_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _twe_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -399,7 +408,7 @@ def _twe_from_multiple_to_multiple_distance(
     for i in range(m_cases):
         padded_y.append(_pad_arrs(y[i]))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = padded_x[i], padded_y[j]
             if unequal_length:

--- a/aeon/distances/elastic/_wdtw.py
+++ b/aeon/distances/elastic/_wdtw.py
@@ -5,13 +5,14 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.elastic._alignment_paths import compute_min_return_path
 from aeon.distances.elastic._bounding_matrix import create_bounding_matrix
 from aeon.distances.pointwise._squared import _univariate_squared_distance
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -241,6 +242,8 @@ def wdtw_pairwise_distance(
     window: Optional[float] = None,
     g: float = 0.05,
     itakura_max_slope: Optional[float] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the WDTW pairwise distance between a set of time series.
 
@@ -263,6 +266,10 @@ def wdtw_pairwise_distance(
     itakura_max_slope : float, default=None
         Maximum slope as a proportion of the number of time points used to create
         Itakura parallelogram on the bounding matrix. Must be between 0. and 1.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -308,6 +315,8 @@ def wdtw_pairwise_distance(
            [ 20.25043711,   0.        ,  39.64543037],
            [139.70656066,  39.64543037,   0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -324,7 +333,7 @@ def wdtw_pairwise_distance(
     )
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _wdtw_pairwise_distance(
     X: NumbaList[np.ndarray],
     window: Optional[float],
@@ -340,7 +349,7 @@ def _wdtw_pairwise_distance(
         bounding_matrix = create_bounding_matrix(
             n_timepoints, n_timepoints, window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             x1, x2 = X[i], X[j]
             if unequal_length:
@@ -353,7 +362,7 @@ def _wdtw_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _wdtw_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -370,7 +379,7 @@ def _wdtw_from_multiple_to_multiple_distance(
         bounding_matrix = create_bounding_matrix(
             x[0].shape[1], y[0].shape[1], window, itakura_max_slope
         )
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             x1, y1 = x[i], y[j]
             if unequal_length:

--- a/aeon/distances/mindist/_dft_sfa.py
+++ b/aeon/distances/mindist/_dft_sfa.py
@@ -3,9 +3,10 @@ __maintainer__ = []
 from typing import Union
 
 import numpy as np
-from numba import njit, prange
+from numba import njit, prange, set_num_threads
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -86,7 +87,7 @@ def _univariate_dft_sfa_distance(
 
 
 def mindist_dft_sfa_pairwise_distance(
-    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray
+    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n_jobs: int = 1, **kwargs
 ) -> np.ndarray:
     """Compute the DFT SFA pairwise distance between a set of SFA representations.
 
@@ -98,6 +99,10 @@ def mindist_dft_sfa_pairwise_distance(
         A collection of SFA instances  of shape ``(n_instances, n_timepoints)``.
     breakpoints: np.ndarray
         The breakpoints of the SAX transformation
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -110,6 +115,8 @@ def mindist_dft_sfa_pairwise_distance(
         If X is not 2D array when only passing X.
         If X and y are not 1D, 2D arrays when passing both X and y.
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -132,7 +139,7 @@ def _dft_sfa_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, n_instances))
 
         for i in prange(n_instances):
-            for j in prange(i + 1, n_instances):
+            for j in range(i + 1, n_instances):
                 distances[i, j] = _univariate_dft_sfa_distance(X[i], X[j], breakpoints)
                 distances[j, i] = distances[i, j]
     else:
@@ -141,7 +148,7 @@ def _dft_sfa_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, m_instances))
 
         for i in prange(n_instances):
-            for j in prange(m_instances):
+            for j in range(m_instances):
                 distances[i, j] = _univariate_dft_sfa_distance(X[i], y[j], breakpoints)
 
     return distances

--- a/aeon/distances/mindist/_paa_sax.py
+++ b/aeon/distances/mindist/_paa_sax.py
@@ -1,9 +1,10 @@
 __maintainer__ = []
 
 import numpy as np
-from numba import njit, prange
+from numba import njit, prange, set_num_threads
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -91,7 +92,12 @@ def _univariate_paa_sax_distance(
 
 
 def mindist_paa_sax_pairwise_distance(
-    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n: int
+    X: np.ndarray,
+    y: np.ndarray,
+    breakpoints: np.ndarray,
+    n: int,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the PAA SAX pairwise distance between a set of SAX representations.
 
@@ -105,6 +111,10 @@ def mindist_paa_sax_pairwise_distance(
         The breakpoints of the SAX transformation
     n : int
         The original size of the time series
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -118,6 +128,8 @@ def mindist_paa_sax_pairwise_distance(
         If X and y are not 1D, 2D arrays when passing both X and y.
 
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -139,7 +151,7 @@ def _paa_sax_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, n_instances))
 
         for i in prange(n_instances):
-            for j in prange(i + 1, n_instances):
+            for j in range(i + 1, n_instances):
                 distances[i, j] = _univariate_paa_sax_distance(
                     X[i], X[j], breakpoints, n
                 )
@@ -150,7 +162,7 @@ def _paa_sax_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, m_instances))
 
         for i in prange(n_instances):
-            for j in prange(m_instances):
+            for j in range(m_instances):
                 distances[i, j] = _univariate_paa_sax_distance(
                     X[i], y[j], breakpoints, n
                 )

--- a/aeon/distances/mindist/_sax.py
+++ b/aeon/distances/mindist/_sax.py
@@ -3,9 +3,10 @@ __maintainer__ = []
 from typing import Union
 
 import numpy as np
-from numba import njit, prange
+from numba import njit, prange, set_num_threads
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -85,7 +86,12 @@ def _univariate_sax_distance(
 
 
 def mindist_sax_pairwise_distance(
-    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n: int
+    X: np.ndarray,
+    y: np.ndarray,
+    breakpoints: np.ndarray,
+    n: int,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the SAX pairwise distance between a set of SAX representations.
 
@@ -99,6 +105,10 @@ def mindist_sax_pairwise_distance(
         The breakpoints of the SAX transformation
     n : int
         The original size of the time series
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -112,6 +122,8 @@ def mindist_sax_pairwise_distance(
         If X and y are not 1D, 2D arrays when passing both X and y.
 
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion
@@ -134,7 +146,7 @@ def _sax_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, n_instances))
 
         for i in prange(n_instances):
-            for j in prange(i + 1, n_instances):
+            for j in range(i + 1, n_instances):
                 distances[i, j] = _univariate_sax_distance(X[i], X[j], breakpoints, n)
                 distances[j, i] = distances[i, j]
     else:
@@ -143,7 +155,7 @@ def _sax_from_multiple_to_multiple_distance(
         distances = np.zeros((n_instances, m_instances))
 
         for i in prange(n_instances):
-            for j in prange(m_instances):
+            for j in range(m_instances):
                 distances[i, j] = _univariate_sax_distance(X[i], y[j], breakpoints, n)
 
     return distances

--- a/aeon/distances/mindist/_sfa.py
+++ b/aeon/distances/mindist/_sfa.py
@@ -3,9 +3,10 @@ __maintainer__ = []
 from typing import Union
 
 import numpy as np
-from numba import njit, prange
+from numba import njit, prange, set_num_threads
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -78,7 +79,7 @@ def _univariate_sfa_distance(
 
 
 def mindist_sfa_pairwise_distance(
-    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray
+    X: np.ndarray, y: np.ndarray, breakpoints: np.ndarray, n_jobs: int = 1, **kwargs
 ) -> np.ndarray:
     """Compute the SFA mindist pairwise distance between a set of SFA representations.
 
@@ -90,6 +91,10 @@ def mindist_sfa_pairwise_distance(
         A collection of SFA instances  of shape ``(n_instances, n_timepoints)``.
     breakpoints: np.ndarray
         The breakpoints of the SAX transformation
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -103,6 +108,8 @@ def mindist_sfa_pairwise_distance(
         If X and y are not 1D, 2D arrays when passing both X and y.
 
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, unequal_length = _convert_collection_to_numba_list(
         X, "X", multivariate_conversion

--- a/aeon/distances/pointwise/_euclidean.py
+++ b/aeon/distances/pointwise/_euclidean.py
@@ -1,9 +1,10 @@
 __maintainer__ = []
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.distances.pointwise._squared import (
@@ -11,6 +12,7 @@ from aeon.distances.pointwise._squared import (
     squared_distance,
 )
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -72,6 +74,8 @@ def _univariate_euclidean_distance(x: np.ndarray, y: np.ndarray) -> float:
 def euclidean_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the Euclidean pairwise distance between a set of time series.
 
@@ -85,6 +89,10 @@ def euclidean_pairwise_distance(
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
         If None, then the euclidean pairwise distance between the instances of X is
         calculated.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -128,6 +136,18 @@ def euclidean_pairwise_distance(
            [ 5.19615242,  0.        ,  8.        ],
            [12.12435565,  8.        ,  0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
+    if n_jobs > 1:
+        warnings.warn(
+            "You have set n_jobs > 1. For this distance function "
+            "unless your data is very large (> 10000 time series), it is "
+            "recommended to use n_jobs=1. If this function is slower than "
+            "expected try setting n_jobs=1.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, _ = _convert_collection_to_numba_list(X, "X", multivariate_conversion)
     if y is None:
@@ -138,12 +158,12 @@ def euclidean_pairwise_distance(
     return _euclidean_from_multiple_to_multiple_distance(_X, _y)
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _euclidean_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             distances[i, j] = euclidean_distance(X[i], X[j])
             distances[j, i] = distances[i, j]
@@ -151,7 +171,7 @@ def _euclidean_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _euclidean_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray], y: NumbaList[np.ndarray]
 ) -> np.ndarray:
@@ -159,7 +179,7 @@ def _euclidean_from_multiple_to_multiple_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             distances[i, j] = euclidean_distance(x[i], y[j])
     return distances

--- a/aeon/distances/pointwise/_manhattan.py
+++ b/aeon/distances/pointwise/_manhattan.py
@@ -1,12 +1,14 @@
 __maintainer__ = []
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -77,6 +79,8 @@ def _univariate_manhattan_distance(x: np.ndarray, y: np.ndarray) -> float:
 def manhattan_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the manhattan pairwise distance between a set of time series.
 
@@ -90,6 +94,10 @@ def manhattan_pairwise_distance(
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
         If None, then the manhattan pairwise distance between the instances of X is
         calculated.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -133,6 +141,18 @@ def manhattan_pairwise_distance(
            [ 9.,  0., 16.],
            [21., 16.,  0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
+    if n_jobs > 1:
+        warnings.warn(
+            "You have set n_jobs > 1. For this distance function "
+            "unless your data is very large (> 10000 time series), it is "
+            "recommended to use n_jobs=1. If this function is slower than "
+            "expected try setting n_jobs=1.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, _ = _convert_collection_to_numba_list(X, "X", multivariate_conversion)
     if y is None:
@@ -142,12 +162,12 @@ def manhattan_pairwise_distance(
     return _manhattan_from_multiple_to_multiple_distance(_X, _y)
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _manhattan_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             distances[i, j] = manhattan_distance(X[i], X[j])
             distances[j, i] = distances[i, j]
@@ -155,7 +175,7 @@ def _manhattan_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _manhattan_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray], y: NumbaList[np.ndarray]
 ) -> np.ndarray:
@@ -163,7 +183,7 @@ def _manhattan_from_multiple_to_multiple_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             distances[i, j] = manhattan_distance(x[i], y[j])
     return distances

--- a/aeon/distances/pointwise/_minkowski.py
+++ b/aeon/distances/pointwise/_minkowski.py
@@ -3,10 +3,11 @@ __maintainer__ = []
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -131,6 +132,8 @@ def minkowski_pairwise_distance(
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
     p: float = 2.0,
     w: Optional[np.ndarray] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the Minkowski pairwise distance between a set of time series.
 
@@ -150,6 +153,10 @@ def minkowski_pairwise_distance(
     w : np.ndarray, default=None
         An array of weights, applied to each pairwise calculation.
         The weights should match the shape of the time series in X and y.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -202,6 +209,8 @@ def minkowski_pairwise_distance(
            [ 5.19615242,  0.        ,  8.        ],
            [12.12435565,  8.        ,  0.        ]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, _ = _convert_collection_to_numba_list(X, "X", multivariate_conversion)
     if y is None:
@@ -211,14 +220,14 @@ def minkowski_pairwise_distance(
     return _minkowski_from_multiple_to_multiple_distance(_X, _y, p, w)
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _minkowski_pairwise_distance(
     X: NumbaList[np.ndarray], p: float, w: Optional[np.ndarray] = None
 ) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             if w is None:
                 distances[i, j] = minkowski_distance(X[i], X[j], p)
@@ -232,7 +241,7 @@ def _minkowski_pairwise_distance(
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _minkowski_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray],
     y: NumbaList[np.ndarray],
@@ -243,7 +252,7 @@ def _minkowski_from_multiple_to_multiple_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             if w is None:
                 distances[i, j] = minkowski_distance(x[i], y[j], p)

--- a/aeon/distances/pointwise/_squared.py
+++ b/aeon/distances/pointwise/_squared.py
@@ -1,12 +1,14 @@
 __maintainer__ = []
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
-from numba import njit
+from numba import njit, prange, set_num_threads
 from numba.typed import List as NumbaList
 
 from aeon.utils.conversion._convert_collection import _convert_collection_to_numba_list
+from aeon.utils.validation import check_n_jobs
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
@@ -76,6 +78,8 @@ def _univariate_squared_distance(x: np.ndarray, y: np.ndarray) -> float:
 def squared_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
+    n_jobs: int = 1,
+    **kwargs,
 ) -> np.ndarray:
     """Compute the squared pairwise distance between a set of time series.
 
@@ -89,6 +93,10 @@ def squared_pairwise_distance(
         ``(m_cases, m_timepoints)`` or ``(m_cases, m_channels, m_timepoints)``.
         If None, then the squared pairwise distance between the instances of X is
         calculated.
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. If -1, then the number of jobs is set
+        to the number of CPU cores. If 1, then the function is executed in a single
+        thread. If greater than 1, then the function is executed in parallel.
 
     Returns
     -------
@@ -132,6 +140,17 @@ def squared_pairwise_distance(
            [ 27.,   0.,  64.],
            [147.,  64.,   0.]])
     """
+    n_jobs = check_n_jobs(n_jobs)
+    if n_jobs > 1:
+        warnings.warn(
+            "You have set n_jobs > 1. For this distance function "
+            "unless your data is very large (> 10000 time series), it is "
+            "recommended to use n_jobs=1. If this function is slower than "
+            "expected try setting n_jobs=1.",
+            UserWarning,
+            stacklevel=2,
+        )
+    set_num_threads(n_jobs)
     multivariate_conversion = _is_numpy_list_multivariate(X, y)
     _X, _ = _convert_collection_to_numba_list(X, "X", multivariate_conversion)
 
@@ -143,12 +162,12 @@ def squared_pairwise_distance(
     return _squared_from_multiple_to_multiple_distance(_X, _y)
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _squared_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     n_cases = len(X)
     distances = np.zeros((n_cases, n_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(i + 1, n_cases):
             distances[i, j] = squared_distance(X[i], X[j])
             distances[j, i] = distances[i, j]
@@ -156,7 +175,7 @@ def _squared_pairwise_distance(X: NumbaList[np.ndarray]) -> np.ndarray:
     return distances
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, parallel=True)
 def _squared_from_multiple_to_multiple_distance(
     x: NumbaList[np.ndarray], y: NumbaList[np.ndarray]
 ) -> np.ndarray:
@@ -164,7 +183,7 @@ def _squared_from_multiple_to_multiple_distance(
     m_cases = len(y)
     distances = np.zeros((n_cases, m_cases))
 
-    for i in range(n_cases):
+    for i in prange(n_cases):
         for j in range(m_cases):
             distances[i, j] = squared_distance(x[i], y[j])
     return distances


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
#1886 #1797

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR adds parallelism to the distance module. Specifically to pairwise distance computations.

To do this the n_job parameter can now be specified to any pairwise distance (aside mpdist which was excluded due to complexity) and it will use that many threads.

This PR just updates the distance module. In a follow up PR I will update all our models that use pairwise_distance and n_jobs to make use of this. 

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
