### PR TITLE
[BUG] add ExpSmoothingSeriesTransformer and MovingAverageSeriesTransformer to __init__

### DIFF
--- a/aeon/transformations/series/__init__.py
+++ b/aeon/transformations/series/__init__.py
@@ -6,8 +6,10 @@ __all__ = [
     "ClaSPTransformer",
     "DFTSeriesTransformer",
     "Dobin",
+    "ExpSmoothingSeriesTransformer",
     "GaussSeriesTransformer",
     "MatrixProfileSeriesTransformer",
+    "MovingAverageSeriesTransformer",
     "PLASeriesTransformer",
     "SGSeriesTransformer",
     "StatsModelsACF",
@@ -31,8 +33,10 @@ from aeon.transformations.series._boxcox import BoxCoxTransformer
 from aeon.transformations.series._clasp import ClaSPTransformer
 from aeon.transformations.series._dft import DFTSeriesTransformer
 from aeon.transformations.series._dobin import Dobin
+from aeon.transformations.series._exp_smoothing import ExpSmoothingSeriesTransformer
 from aeon.transformations.series._gauss import GaussSeriesTransformer
 from aeon.transformations.series._matrix_profile import MatrixProfileSeriesTransformer
+from aeon.transformations.series._moving_average import MovingAverageSeriesTransformer
 from aeon.transformations.series._pca import PCASeriesTransformer
 from aeon.transformations.series._pla import PLASeriesTransformer
 from aeon.transformations.series._scaled_logit import ScaledLogitSeriesTransformer

--- a/docs/api_reference/transformations.rst
+++ b/docs/api_reference/transformations.rst
@@ -165,8 +165,10 @@ Series transforms
     ClaSPTransformer
     DFTSeriesTransformer
     Dobin
+    ExpSmoothingSeriesTransformer
     GaussSeriesTransformer
     MatrixProfileSeriesTransformer
+    MovingAverageSeriesTransformer
     PLASeriesTransformer
     SGSeriesTransformer
     StatsModelsACF


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #2548.

#### What does this implement/fix? Explain your changes.

Add both class to `__init__ ` `__all__`

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

No.

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
