### PR TITLE
[BUG] SevenNumberSummary bugfix and input rename

### DIFF
--- a/aeon/transformations/collection/feature_based/_summary.py
+++ b/aeon/transformations/collection/feature_based/_summary.py
@@ -1,6 +1,6 @@
 """Summary feature transformer."""
 
-__maintainer__ = []
+__maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["SevenNumberSummary"]
 
 import numpy as np

--- a/aeon/transformations/collection/feature_based/_summary.py
+++ b/aeon/transformations/collection/feature_based/_summary.py
@@ -22,12 +22,12 @@ class SevenNumberSummary(BaseCollectionTransformer):
 
     Parameters
     ----------
-    summary_stats : ["default", "percentiles", "bowley", "tukey"], default="default"
+    summary_stats : ["default", "quantiles", "bowley", "tukey"], default="default"
         The summary statistics to compute.
         The options are as follows, with float denoting the percentile value extracted
         from the series:
             - "default": mean, std, min, max, 0.25, 0.5, 0.75
-            - "percentiles": 0.215, 0.887, 0.25, 0.5, 0.75, 0.9113, 0.9785
+            - "quantiles": 0.0215, 0.0887, 0.25, 0.5, 0.75, 0.9113, 0.9785
             - "bowley": min, max, 0.1, 0.25, 0.5, 0.75, 0.9
             - "tukey": min, max, 0.125, 0.25, 0.5, 0.75, 0.875
 
@@ -89,10 +89,10 @@ class SevenNumberSummary(BaseCollectionTransformer):
                 0.5,
                 0.75,
             ]
-        elif self.summary_stats == "percentiles":
+        elif self.summary_stats == "quantiles":
             return [
-                0.215,
-                0.887,
+                0.0215,
+                0.0887,
                 0.25,
                 0.5,
                 0.75,

--- a/aeon/transformations/collection/feature_based/tests/test_summary.py
+++ b/aeon/transformations/collection/feature_based/tests/test_summary.py
@@ -1,28 +1,21 @@
 """Test summary features transformer."""
 
+import numpy as np
 import pytest
 
 from aeon.transformations.collection.feature_based import SevenNumberSummary
 
 
-def test_summary_features():
-    """Test get functions."""
-    x = SevenNumberSummary()
-    f = x._get_functions()
-    assert len(f) == 7
-    assert callable(f[0])
-    x = SevenNumberSummary(summary_stats="percentiles")
-    f = x._get_functions()
-    assert len(f) == 7
-    assert isinstance(f[0], float)
-    assert f[1] == 0.887
-    x = SevenNumberSummary(summary_stats="bowley")
-    f = x._get_functions()
-    assert len(f) == 7
-    assert callable(f[0])
-    assert f[6] == 0.9
-    x = SevenNumberSummary(summary_stats="tukey")
-    assert len(x._get_functions()) == 7
+@pytest.mark.parametrize("summary_stats", ["default", "quantiles", "bowley", "tukey"])
+def test_summary_features(summary_stats):
+    """Test different summary_stats options."""
+    sns = SevenNumberSummary()
+    t = sns.fit_transform(np.ones((10, 2, 5)))
+    assert t.shape == (10, 14)
+
+
+def test_summary_features_invalid():
+    """Test invalid summary_stats option."""
     with pytest.raises(ValueError, match="Summary function input invalid"):
-        x = SevenNumberSummary(summary_stats="invalid")
-        x._get_functions()
+        sns = SevenNumberSummary(summary_stats="invalid")
+        sns.fit_transform(np.ones((10, 2, 5)))


### PR DESCRIPTION
Fixes the values for the "percentiles" input and renames it to "quantiles". 