### PR TITLE
[ENH] Test coverage for AEFCN Network

### DIFF
--- a/aeon/networks/tests/test_ae_fcn.py
+++ b/aeon/networks/tests/test_ae_fcn.py
@@ -1,0 +1,96 @@
+"""Tests for the AEFCN Model."""
+
+import pytest
+
+from aeon.networks import AEFCNNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_default_initialization():
+    """Test if the network initializes with proper attributes."""
+    model = AEFCNNetwork()
+    assert model.latent_space_dim == 128
+    assert model.n_layers == 3
+    assert model.n_filters is None
+    assert model.kernel_size is None
+    assert model.dilation_rate == 1
+    assert model.strides == 1
+    assert model.padding == "same"
+    assert model.activation == "relu"
+    assert model.use_bias is True
+    assert model.temporal_latent_space is False
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_custom_initialization():
+    """Test whether custom kwargs are correctly set."""
+    model = AEFCNNetwork(
+        latent_space_dim=64,
+        temporal_latent_space=True,
+        n_layers=4,
+        n_filters=[32, 64, 128, 256],
+        kernel_size=[9, 7, 5, 3],
+        activation="sigmoid",
+        dilation_rate=[1, 2, 4, 8],
+    )
+    model.build_network((100, 5))
+    assert model.latent_space_dim == 64
+    assert model.n_layers == 4
+    assert model._n_filters == [32, 64, 128, 256]
+    assert model._kernel_size == [9, 7, 5, 3]
+    assert model.dilation_rate == [1, 2, 4, 8]
+    assert model.activation == "sigmoid"
+    assert model.temporal_latent_space is True
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_edge_case_initialization():
+    """Tests edge cases with minimal values."""
+    model = AEFCNNetwork(
+        latent_space_dim=0, n_layers=0, kernel_size=0, dilation_rate=[]
+    )
+    assert model.latent_space_dim == 0
+    assert model.kernel_size == 0
+    assert model.n_layers == 0
+    assert model.dilation_rate == []
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_invalid_initialization():
+    """Test if the network raises valid exceptions or not."""
+    with pytest.raises(ValueError):
+        AEFCNNetwork(n_filters=[32, 64], n_layers=3).build_network((100, 10))
+
+    with pytest.raises(ValueError):
+        AEFCNNetwork(dilation_rate=[1, 2], n_layers=3).build_network((100, 10))
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_build_network():
+    """Test call to the build_network method."""
+    import tensorflow as tf
+
+    model = AEFCNNetwork()
+    input_shape = (100, 10)
+    encoder, decoder = model.build_network(input_shape)
+
+    assert isinstance(encoder, tf.keras.Model)
+    assert isinstance(decoder, tf.keras.Model)
+    assert encoder.input_shape == (None, 100, 10)
+    assert decoder.input_shape is not None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Fixes #2497 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Implements Test Coverages for AEFCN in networks module.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
