### PR TITLE
[ENH] Test coverage for AEFCNNetwork Improved 

### DIFF
--- a/aeon/classification/dictionary_based/_cboss.py
+++ b/aeon/classification/dictionary_based/_cboss.py
@@ -93,6 +93,13 @@ class ContractableBOSS(BaseClassifier):
     weights_ :
         Weight of each classifier in the ensemble.
 
+    Raises
+    ------
+    ValueError
+        Raised when ``min_window`` is greater than ``max_window + 1``.
+        This ensures that ``min_window`` does not exceed ``max_window``,
+        preventing invalid window size configurations.
+
     See Also
     --------
     BOSSEnsemble, IndividualBOSS
@@ -305,7 +312,6 @@ class ContractableBOSS(BaseClassifier):
         -------
         1D np.ndarray
             Predicted class labels shape = (n_cases).
-
         """
         rng = check_random_state(self.random_state)
         return np.array(

--- a/aeon/networks/tests/test_ae_fcn.py
+++ b/aeon/networks/tests/test_ae_fcn.py
@@ -30,12 +30,12 @@ def test_aefcn_default():
     reason="Tensorflow soft dependency unavailable.",
 )
 @pytest.mark.parametrize("latent_space_dim", [64, 128, 256])
-def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
+def test_aefcn_latent_space(latent_space_dim):
     """Test AEFCNNetwork with different latent space dimensions."""
     import tensorflow as tf
 
-    aeattentionbigru = AEFCNNetwork(latent_space_dim=latent_space_dim)
-    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    aefcn = AEFCNNetwork(latent_space_dim=latent_space_dim)
+    encoder, decoder = aefcn.build_network((1000, 5))
     assert isinstance(encoder, tf.keras.models.Model)
     assert isinstance(decoder, tf.keras.models.Model)
 

--- a/aeon/networks/tests/test_ae_fcn.py
+++ b/aeon/networks/tests/test_ae_fcn.py
@@ -1,0 +1,288 @@
+"""Test for the AEFCNNetwork class."""
+
+import pytest
+
+from aeon.networks import AEFCNNetwork
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+def test_aefcn_default():
+    """Default testing for aefcn."""
+    model = AEFCNNetwork()
+    assert model.latent_space_dim == 128
+    assert model.temporal_latent_space is False
+    assert model.n_layers == 3
+    assert model.n_filters is None
+    assert model.kernel_size is None
+    assert model.activation == "relu"
+    assert model.padding == "same"
+    assert model.strides == 1
+    assert model.dilation_rate == 1
+    assert model.use_bias is True
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("latent_space_dim", [64, 128, 256])
+def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
+    """Test AEAttentionBiGRUNetwork with different latent space dimensions."""
+    import tensorflow as tf
+
+    aeattentionbigru = AEFCNNetwork(latent_space_dim=latent_space_dim)
+    encoder, decoder = aeattentionbigru.build_network((1000, 5))
+    assert isinstance(encoder, tf.keras.models.Model)
+    assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "kernel_size, should_raise",
+    [
+        ([8, 5, 3], False),  # Valid case
+        (3, False),  # Valid case
+        ([5, 5], True),  # Invalid case: Less than expected layers
+        ([3, 3, 3, 3], True),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_kernel_size(kernel_size, should_raise):
+    """Test AEFCNNetwork with different kernel sizes, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of kernels .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(kernel_size=kernel_size, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(kernel_size=kernel_size, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "n_filters, should_raise",
+    [
+        ([128, 256, 128], False),  # Valid case
+        (32, False),  # Valid case
+        ([32, 64], True),  # Invalid case: Less than expected layers
+        ([16, 32, 64, 128], True),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_n_filters(n_filters, should_raise):
+    """Test AEFCNNetwork with different numbers of filters, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of filters .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(n_filters=n_filters, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(n_filters=n_filters, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "dilation_rate, should_raise",
+    [
+        ([1, 2, 1], False),  # Valid case
+        (2, False),  # Valid case
+        ([1, 2], True),  # Invalid case: Less than expected layers
+        ([1, 2, 2, 1], True),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_dilation_rate(dilation_rate, should_raise):
+    """Test AEFCNNetwork with different dilation rates, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of dilations .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(dilation_rate=dilation_rate, n_layers=3).build_network(
+                (1000, 5)
+            )
+    else:
+        aefcn = AEFCNNetwork(dilation_rate=dilation_rate, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "strides, should_raise",
+    [
+        ([1, 2, 1], False),  # Valid case
+        (2, False),  # Valid case
+        ([1, 2], True),  # Invalid case: Less than expected layers
+        ([1, 2, 2, 1], True),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_strides(strides, should_raise):
+    """Test AEFCNNetwork with different stride values, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of strides .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(strides=strides, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(strides=strides, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "padding, should_raise",
+    [
+        (["same", "valid", "same"], False),  # Valid case
+        ("same", False),  # Valid case
+        (["same", "valid"], True),  # Invalid case: Less than expected layers
+        (
+            ["same", "valid", "same", "valid"],
+            True,
+        ),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_padding(padding, should_raise):
+    """Test AEFCNNetwork with different padding values, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of paddings .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(padding=padding, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(padding=padding, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "activation, should_raise",
+    [
+        (["relu", "sigmoid", "tanh"], False),  # Valid case
+        ("sigmoid", False),  # Valid case
+        (["relu", "sigmoid"], True),  # Invalid case: Less than expected layers
+        (
+            ["relu", "sigmoid", "tanh", "softmax"],
+            True,
+        ),  # Invalid case: More than expected layers
+    ],
+)
+def test_aefcnnetwork_activation(activation, should_raise):
+    """Test AEFCNNetwork with different activation functionss."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of activations .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(activation=activation, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(activation=activation, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize(
+    "use_bias, should_raise",
+    [
+        ([True, False, True], False),
+        (True, False),  # Valid case
+        ([True, False], True),
+        ([True, False, True, False], True),
+    ],
+)
+def test_aefcnnetwork_use_bias(use_bias, should_raise):
+    """Test AEFCNNetwork with different use_bias values, including invalid cases."""
+    import tensorflow as tf
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="Number of biases .* should be the same as number of layers",
+        ):
+            AEFCNNetwork(use_bias=use_bias, n_layers=3).build_network((1000, 5))
+    else:
+        aefcn = AEFCNNetwork(use_bias=use_bias, n_layers=3)
+        encoder, decoder = aefcn.build_network((1000, 5))
+        assert isinstance(encoder, tf.keras.models.Model)
+        assert isinstance(decoder, tf.keras.models.Model)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+@pytest.mark.parametrize("temporal_latent_space", [True, False])
+def test_aefcnnetwork_temporal_latent_space(temporal_latent_space):
+    """Test AEFCNNetwork with different values of temporal_latent_space."""
+    import tensorflow as tf
+
+    input_shape = (1000, 5)  # Example input shape
+
+    # Initialize the network with the parameter under test
+    aefcn = AEFCNNetwork(
+        latent_space_dim=128, temporal_latent_space=temporal_latent_space
+    )
+
+    # Build the encoder and decoder
+    encoder, decoder = aefcn.build_network(input_shape)
+
+    # Assertions to check proper model creation
+    assert isinstance(encoder, tf.keras.models.Model)
+    assert isinstance(decoder, tf.keras.models.Model)
+
+    # If temporal_latent_space is True, check if the encoder output has a Conv1D layer
+    if temporal_latent_space:
+        assert any(
+            isinstance(layer, tf.keras.layers.Conv1D) for layer in encoder.layers
+        ), "Expected Conv1D layer in encoder but not found."
+    else:
+        assert any(
+            isinstance(layer, tf.keras.layers.Dense) for layer in decoder.layers
+        ), "Expected Dense layer in decoder but not found."

--- a/aeon/networks/tests/test_ae_fcn.py
+++ b/aeon/networks/tests/test_ae_fcn.py
@@ -27,7 +27,7 @@ def test_aefcn_default():
 )
 @pytest.mark.parametrize("latent_space_dim", [64, 128, 256])
 def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
-    """Test AEAttentionBiGRUNetwork with different latent space dimensions."""
+    """Test AEFCNNetwork with different latent space dimensions."""
     import tensorflow as tf
 
     aeattentionbigru = AEFCNNetwork(latent_space_dim=latent_space_dim)
@@ -43,14 +43,14 @@ def test_aeattentionbigrunetwork_latent_space(latent_space_dim):
 @pytest.mark.parametrize(
     "kernel_size, should_raise",
     [
-        ([8, 5, 3], False),  # Valid case
-        (3, False),  # Valid case
-        ([5, 5], True),  # Invalid case: Less than expected layers
-        ([3, 3, 3, 3], True),  # Invalid case: More than expected layers
+        ([8, 5, 3], False),
+        (3, False),
+        ([5, 5], True),
+        ([3, 3, 3, 3], True),
     ],
 )
 def test_aefcnnetwork_kernel_size(kernel_size, should_raise):
-    """Test AEFCNNetwork with different kernel sizes, including invalid cases."""
+    """Test AEFCNNetwork with different kernel sizes."""
     import tensorflow as tf
 
     if should_raise:
@@ -73,14 +73,14 @@ def test_aefcnnetwork_kernel_size(kernel_size, should_raise):
 @pytest.mark.parametrize(
     "n_filters, should_raise",
     [
-        ([128, 256, 128], False),  # Valid case
-        (32, False),  # Valid case
-        ([32, 64], True),  # Invalid case: Less than expected layers
-        ([16, 32, 64, 128], True),  # Invalid case: More than expected layers
+        ([128, 256, 128], False),
+        (32, False),
+        ([32, 64], True),
+        ([16, 32, 64, 128], True),
     ],
 )
 def test_aefcnnetwork_n_filters(n_filters, should_raise):
-    """Test AEFCNNetwork with different numbers of filters, including invalid cases."""
+    """Test AEFCNNetwork with different number of filters."""
     import tensorflow as tf
 
     if should_raise:
@@ -103,14 +103,14 @@ def test_aefcnnetwork_n_filters(n_filters, should_raise):
 @pytest.mark.parametrize(
     "dilation_rate, should_raise",
     [
-        ([1, 2, 1], False),  # Valid case
-        (2, False),  # Valid case
-        ([1, 2], True),  # Invalid case: Less than expected layers
-        ([1, 2, 2, 1], True),  # Invalid case: More than expected layers
+        ([1, 2, 1], False),
+        (2, False),
+        ([1, 2], True),
+        ([1, 2, 2, 1], True),
     ],
 )
 def test_aefcnnetwork_dilation_rate(dilation_rate, should_raise):
-    """Test AEFCNNetwork with different dilation rates, including invalid cases."""
+    """Test AEFCNNetwork with different dilation rates."""
     import tensorflow as tf
 
     if should_raise:
@@ -135,14 +135,14 @@ def test_aefcnnetwork_dilation_rate(dilation_rate, should_raise):
 @pytest.mark.parametrize(
     "strides, should_raise",
     [
-        ([1, 2, 1], False),  # Valid case
-        (2, False),  # Valid case
-        ([1, 2], True),  # Invalid case: Less than expected layers
-        ([1, 2, 2, 1], True),  # Invalid case: More than expected layers
+        ([1, 2, 1], False),
+        (2, False),
+        ([1, 2], True),
+        ([1, 2, 2, 1], True),
     ],
 )
 def test_aefcnnetwork_strides(strides, should_raise):
-    """Test AEFCNNetwork with different stride values, including invalid cases."""
+    """Test AEFCNNetwork with different strides."""
     import tensorflow as tf
 
     if should_raise:
@@ -165,17 +165,17 @@ def test_aefcnnetwork_strides(strides, should_raise):
 @pytest.mark.parametrize(
     "padding, should_raise",
     [
-        (["same", "valid", "same"], False),  # Valid case
-        ("same", False),  # Valid case
-        (["same", "valid"], True),  # Invalid case: Less than expected layers
+        (["same", "valid", "same"], False),
+        ("same", False),
+        (["same", "valid"], True),
         (
             ["same", "valid", "same", "valid"],
             True,
-        ),  # Invalid case: More than expected layers
+        ),
     ],
 )
 def test_aefcnnetwork_padding(padding, should_raise):
-    """Test AEFCNNetwork with different padding values, including invalid cases."""
+    """Test AEFCNNetwork with different paddings."""
     import tensorflow as tf
 
     if should_raise:
@@ -198,17 +198,17 @@ def test_aefcnnetwork_padding(padding, should_raise):
 @pytest.mark.parametrize(
     "activation, should_raise",
     [
-        (["relu", "sigmoid", "tanh"], False),  # Valid case
-        ("sigmoid", False),  # Valid case
-        (["relu", "sigmoid"], True),  # Invalid case: Less than expected layers
+        (["relu", "sigmoid", "tanh"], False),
+        ("sigmoid", False),
+        (["relu", "sigmoid"], True),
         (
             ["relu", "sigmoid", "tanh", "softmax"],
             True,
-        ),  # Invalid case: More than expected layers
+        ),
     ],
 )
 def test_aefcnnetwork_activation(activation, should_raise):
-    """Test AEFCNNetwork with different activation functionss."""
+    """Test AEFCNNetwork with different activations."""
     import tensorflow as tf
 
     if should_raise:
@@ -232,13 +232,13 @@ def test_aefcnnetwork_activation(activation, should_raise):
     "use_bias, should_raise",
     [
         ([True, False, True], False),
-        (True, False),  # Valid case
+        (True, False),
         ([True, False], True),
         ([True, False, True, False], True),
     ],
 )
 def test_aefcnnetwork_use_bias(use_bias, should_raise):
-    """Test AEFCNNetwork with different use_bias values, including invalid cases."""
+    """Test AEFCNNetwork with different use_bias values."""
     import tensorflow as tf
 
     if should_raise:
@@ -260,24 +260,20 @@ def test_aefcnnetwork_use_bias(use_bias, should_raise):
 )
 @pytest.mark.parametrize("temporal_latent_space", [True, False])
 def test_aefcnnetwork_temporal_latent_space(temporal_latent_space):
-    """Test AEFCNNetwork with different values of temporal_latent_space."""
+    """Test for temporal latent space."""
     import tensorflow as tf
 
-    input_shape = (1000, 5)  # Example input shape
+    input_shape = (1000, 5)
 
-    # Initialize the network with the parameter under test
     aefcn = AEFCNNetwork(
         latent_space_dim=128, temporal_latent_space=temporal_latent_space
     )
 
-    # Build the encoder and decoder
     encoder, decoder = aefcn.build_network(input_shape)
 
-    # Assertions to check proper model creation
     assert isinstance(encoder, tf.keras.models.Model)
     assert isinstance(decoder, tf.keras.models.Model)
 
-    # If temporal_latent_space is True, check if the encoder output has a Conv1D layer
     if temporal_latent_space:
         assert any(
             isinstance(layer, tf.keras.layers.Conv1D) for layer in encoder.layers

--- a/aeon/networks/tests/test_ae_fcn.py
+++ b/aeon/networks/tests/test_ae_fcn.py
@@ -6,6 +6,10 @@ from aeon.networks import AEFCNNetwork
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
 def test_aefcn_default():
     """Default testing for aefcn."""
     model = AEFCNNetwork()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Contributes to #2497.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

Improves the test coverage for AEFCNNetwork.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

No
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
