### PR TITLE
[ENH] Resolve failing check_fit_deterministic

### DIFF
--- a/aeon/base/_base.py
+++ b/aeon/base/_base.py
@@ -444,5 +444,7 @@ def _clone_estimator(base_estimator, random_state=None):
 
     if random_state is not None:
         _set_random_states(estimator, random_state)
+        if hasattr(estimator, "seed"):
+            estimator.seed = random_state
 
     return estimator

--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -48,10 +48,10 @@ EXCLUDED_TESTS = {
         "check_save_estimators_to_file",
     ],
     # needs investigation
-    "SASTClassifier": ["check_fit_deterministic"],
-    "RSASTClassifier": ["check_fit_deterministic"],
-    "SAST": ["check_fit_deterministic"],
-    "RSAST": ["check_fit_deterministic"],
+    # "SASTClassifier": ["check_fit_deterministic"],
+    # "RSASTClassifier": ["check_fit_deterministic"],
+    # "SAST": ["check_fit_deterministic"],
+    # "RSAST": ["check_fit_deterministic"],
     "MatrixProfile": ["check_persistence_via_pickle"],
     # missed in legacy testing, changes state in predict/transform
     "FLUSSSegmenter": ["check_non_state_changing_method"],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Fixes #2457.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

The given classifiers fail the check_fit_deterministic() test due to wrong initialization of seed variable.
-  SASTClassifier"
- "RSASTClassifier"
- "SAST"
- "RSAST"

In the clone_estimator method I check if the given classifiers have any seed variable and initalize them with the random_state.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
