### PR TITLE
[ENH] Enable RDSTRegressor and RISTRegressor Tests After Ubuntu CI Verification

### DIFF
--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -62,8 +62,6 @@ EXCLUDED_TESTS = {
     "QuerySearch": ["check_non_state_changing_method"],
     "SeriesSearch": ["check_non_state_changing_method"],
     # Unknown issue not producing the same results
-    "RDSTRegressor": ["check_regressor_against_expected_results"],
-    "RISTRegressor": ["check_regressor_against_expected_results"],
 }
 
 # Exclude specific tests for estimators here only when numba is disabled


### PR DESCRIPTION
### Description  

This PR removes the exclusions for the `RDSTRegressor` and `RISTRegressor` tests (`check_regressor_against_expected_results`), allowing them to run on CI.  

#### Changes Implemented  
- Removed the test exclusions for:  
  - `RDSTRegressor`  
  - `RISTRegressor`  
- Verified successful test execution locally using:  
  ```sh
  pytest aeon/testing/estimator_checking/ -v

 Since [#2486](https://github.com/aeon-toolkit/aeon/pull/2486) has been merged, these tests should now pass consistently on Ubuntu in CI.

**Reference Issues/PRs:**

Fixes [#2458](https://github.com/aeon-toolkit/aeon/issues/2458)
Depends on [#2486](https://github.com/aeon-toolkit/aeon/pull/2486)

**Additional Notes:**
Please see the attached ss below for local test results.
![Screenshot from 2025-03-08 22-40-38](https://github.com/user-attachments/assets/e5ff0508-7218-47ca-956f-02ec38b81ba7)
