### PR TITLE
[DOC] A fix to inconsistent double tick quote for the classification.distance_based module

### DIFF
--- a/aeon/classification/distance_based/_elastic_ensemble.py
+++ b/aeon/classification/distance_based/_elastic_ensemble.py
@@ -32,14 +32,14 @@ class ElasticEnsemble(BaseClassifier):
     """The Elastic Ensemble (EE) of time series distance measures.
 
     The Elastic Ensemble [1]_ is an ensemble of 1-NN classifiers using elastic
-    distances (as defined in aeon.distances). By default, each 1-NN classifier
-    is tuned over 100 parameter values and the ensemble vote is weighted by
+    distances (as defined in `aeon.distances`). By default, each 1-NN classifier
+    is tuned over `100` parameter values and the ensemble vote is weighted by
     an estimate of accuracy formed on the train set.
 
     Parameters
     ----------
     distance_measures : str or list of str, default="all"
-      A list of strings identifying which distance measures to include. Valid values
+      A ``list`` of strings identifying which distance measures to include. Valid values
       are one or more of: ``euclidean``, ``dtw``, ``wdtw``, ``ddtw``, ``wddtw``,
       ``lcss``, ``erp``, ``msm``, ``twe``. The default value ``all`` means that all
       the previously listed distances are used.
@@ -50,19 +50,19 @@ class ElasticEnsemble(BaseClassifier):
     proportion_train_for_test : float, default=1
       The proportion of the train set to use in classifying new cases optional.
     n_jobs : int, default=1
-      The number of jobs to run in parallel for both `fit` and `predict`.
-      ``-1`` means using all processors.
+      The number of jobs to run in parallel for both ``fit`` and ``predict``.
+      `-1` means using all processors.
     random_state : int, default=0
-        If `int`, random_state is the seed used by the random number generator;
+        If ``int``, `random_state` is the seed used by the random number generator;
     verbose : int, default=0
-      If ``>0``, then prints out debug information.
+      If `>0`, then prints out debug information.
     majority_vote: boolean, default = False
       Whether to use majority vote or weighted vote.
 
     Attributes
     ----------
     estimators_ : list
-      A list storing all classifiers.
+      A ``list`` storing all classifiers.
     train_accs_by_classifier_ : np.ndarray
       Store the train accuracies of the classifiers.
     constituent_build_times_ : array of float
@@ -125,7 +125,7 @@ class ElasticEnsemble(BaseClassifier):
         super().__init__()
 
     def _fit(self, X, y):
-        """Build an ensemble of 1-NN classifiers from the training set (X, y).
+        """Build an ensemble of 1-NN classifiers from the training set `(X, y)`.
 
         Parameters
         ----------
@@ -334,7 +334,7 @@ class ElasticEnsemble(BaseClassifier):
         return self
 
     def _predict_proba(self, X) -> np.ndarray:
-        """Predict class probabilities for n instances in X.
+        """Predict class probabilities for `n` instances in `X`.
 
         Parameters
         ----------
@@ -344,7 +344,7 @@ class ElasticEnsemble(BaseClassifier):
         Returns
         -------
         y : array-like, shape = (n_cases, n_classes_)
-            Predicted probabilities using the ordering in classes_.
+            Predicted probabilities using the ordering in `classes_`.
         """
         if self._distance_measures.__contains__(
             "ddtw"
@@ -404,7 +404,7 @@ class ElasticEnsemble(BaseClassifier):
         Returns
         -------
         params : dict
-            The distance measures and the list of their parameter values.
+            The distance measures and the ``list`` of their parameter values.
         """
         return {
             self._distance_measures[dm]: str(self.estimators_[dm]._distance_params)
@@ -413,7 +413,7 @@ class ElasticEnsemble(BaseClassifier):
 
     @staticmethod
     def _get_100_param_options(distance_measure: str, train_x=None):
-        """Generate 100 parameter values for each classifier.
+        """Generate `100` parameter values for each classifier.
 
         Parameters
         ----------
@@ -500,9 +500,9 @@ class ElasticEnsemble(BaseClassifier):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
+            special parameters are defined for a value, will return ``"default"`` set.
             ElasticEnsemble provides the following special sets:
-                 "results_comparison" - used in some classifiers to compare against
+                 ``"results_comparison"`` - used in some classifiers to compare against
                     previously generated results where the default set of parameters
                     cannot produce suitable probability estimates
 
@@ -510,8 +510,10 @@ class ElasticEnsemble(BaseClassifier):
         -------
         params : dict or list of dict, default={}
             Parameters to create testing instances of the class.
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            Each ``dict`` are parameters to construct an ``"interesting"`` test instance
+            , i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
         """
         if parameter_set == "results_comparison":
             return {

--- a/aeon/classification/distance_based/_proximity_forest.py
+++ b/aeon/classification/distance_based/_proximity_forest.py
@@ -28,28 +28,31 @@ class ProximityForest(BaseClassifier):
     Parameters
     ----------
     n_trees: int, default = 100
-        The number of trees, by default an ensemble of 100 trees is formed.
+        The number of trees, by default an ensemble of `100` trees is formed.
     n_splitters: int, default = 5
         The number of candidate splitters to be evaluated at each node.
     max_depth: int, default = None
-        The maximum depth of the tree. If None, then nodes are expanded until all
-        leaves are pure or until all leaves contain less than min_samples_split samples.
+        The maximum depth of the tree. If ``None``, then nodes are expanded until all
+        leaves are pure or until all leaves contain less than ``min_samples_split``
+        samples.
     min_samples_split: int, default = 2
         The minimum number of samples required to split an internal node.
     random_state : int, RandomState instance or None, default=None
-        If `int`, random_state is the seed used by the random number generator;
-        If `RandomState` instance, random_state is the random number generator;
-        If `None`, the random number generator is the `RandomState` instance used
-        by `np.random`.
+        If ``int``, `random_state` is the seed used by the random number generator;
+        If ``RandomState`` instance, `random_state` is the random number generator;
+        If ``None``, the random number generator is the ``RandomState`` instance used
+        by ``np.random``.
     n_jobs : int, default = 1
         The number of parallel jobs to run for neighbors search.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors.
+        ``None`` means `1` unless in a :obj:`joblib.parallel_backend` context.
+        `-1` means using all processors.
         for more details. Parameter for compatibility purposes, still unimplemented.
     parallel_backend : str, ParallelBackendBase instance or None, default=None
-        Specify the parallelisation backend implementation in joblib, if None a 'prefer'
-        value of "threads" is used by default.
-        Valid options are "loky", "multiprocessing", "threading" or a custom backend.
+        Specify the parallelisation backend implementation in joblib, if ``None``
+        a 'prefer'
+        value of ``"threads"`` is used by default.
+        Valid options are ``"loky"``, ``"multiprocessing"``, ``"threading"`` or a
+        custom backend.
         See the joblib Parallel documentation for more details.
 
     Notes

--- a/aeon/classification/distance_based/_proximity_tree.py
+++ b/aeon/classification/distance_based/_proximity_tree.py
@@ -21,11 +21,11 @@ class _Node:
     Parameters
     ----------
     node_id: str
-        The id of node, root node has id 0.
+        The id of node, root node has id `0`.
     _is_leaf: bool
         To identify leaf nodes.
     label: int, str or None
-        Contains the class label of leaf node, None otherwise.
+        Contains the class label of leaf node, ``None`` otherwise.
     splitter: dict
         The splitter used to split the node.
     class_distribution: dict
@@ -73,15 +73,16 @@ class ProximityTree(BaseClassifier):
     n_splitters: int, default = 5
         The number of candidate splitters to be evaluated at each node.
     max_depth: int, default = None
-        The maximum depth of the tree. If None, then nodes are expanded until all
-        leaves are pure or until all leaves contain less than min_samples_split samples.
+        The maximum depth of the tree. If ``None``, then nodes are expanded until all
+        leaves are pure or until all leaves contain less than ``min_samples_split``
+        samples.
     min_samples_split: int, default = 2
         The minimum number of samples required to split an internal node.
     random_state : int, RandomState instance or None, default=None
-        If `int`, random_state is the seed used by the random number generator;
-        If `RandomState` instance, random_state is the random number generator;
-        If `None`, the random number generator is the `RandomState` instance used
-        by `np.random`.
+        If ``int``, `random_state` is the seed used by the random number generator;
+        If ``RandomState`` instance, `random_state` is the random number generator;
+        If ``None``, the random number generator is the ``RandomState`` instance used
+        by ``np.random``.
 
     Notes
     -----
@@ -420,13 +421,13 @@ def gini(y) -> float:
     Parameters
     ----------
     y : 1d numpy array
-        array of class labels
+        ``array`` of class labels
 
     Returns
     -------
     score : float
         gini score for the set of class labels (i.e. how pure they are). A
-        larger score means more impurity. Zero means
+        larger score means more impurity. `Zero` means
         pure.
     """
     # get number instances at node
@@ -459,9 +460,9 @@ def gini_gain(y, y_subs) -> float:
     Parameters
     ----------
     y : 1d array
-        array of class labels at parent
+        ``array`` of class labels at parent
     y_subs : list of 1d array like
-        list of array of class labels, one array per child
+        ``list`` of array of class labels, one ``array`` per child
 
     Returns
     -------

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -31,25 +31,25 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
     Parameters
     ----------
     n_neighbors : int, default = 1
-        Set k for knn.
+        Set `k` for knn.
     weights : str or callable, default = 'uniform'
         Mechanism for weighting a vote one of: 'uniform', 'distance', or a callable
         function.
     distance : str or callable, default ='dtw'
         Distance measure between time series.
-        Distance metric to compute similarity between time series. A list of valid
+        Distance metric to compute similarity between time series. A ``list`` of valid
         strings for metrics can be found in the documentation for
         :func:`aeon.distances.get_distance_function` or through calling
         :func:`aeon.distances.get_distance_function_names`. If a
-        callable is passed it must be
-        a function that takes two 2d numpy arrays of shape ``(n_channels,
-        n_timepoints)`` as input and returns a float.
+        ``callable`` is passed it must be
+        a function that takes two 2d numpy arrays of shape `(n_channels,
+        n_timepoints)` as input and returns a ``float``.
     distance_params : dict, default = None
-        Dictionary for metric parameters for the case that distance is a str.
+        Dictionary for metric parameters for the case that distance is a ``str``.
     n_jobs : int, default = None
         The number of parallel jobs to run for neighbors search.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors.
+        ``None`` means `1` unless in a :obj:`joblib.parallel_backend` context.
+        `-1` means using all processors.
         for more details. Parameter for compatibility purposes, still unimplemented.
 
     Examples
@@ -106,8 +106,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ----------
         X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
         shape [n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
-        If the series are all equal length, a numpy3D will be passed. If unequal,
-        a list of 2D numpy arrays is passed, which may have different lengths.
+        If the series are all equal length, a ``numpy3D`` will be passed. If unequal,
+        a ``list`` of 2D numpy arrays is passed, which may have different lengths.
         y : array-like, shape = (n_cases)
             The class labels.
         """
@@ -124,8 +124,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ----------
         X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
         shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
-                If the series are all equal length, a numpy3D will be passed. If
-                unequal, a list of 2D numpy arrays is passed, which may have
+                If the series are all equal length, a ``numpy3D`` will be passed. If
+                unequal, a ``list`` of 2D numpy arrays is passed, which may have
                 different lengths.
 
         Returns
@@ -153,7 +153,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ----------
         X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or list of
         shape[n_cases] of 2D arrays shape (n_channels,n_timepoints_i)
-        If the series are all equal length, a numpy3D will be passed. If unequal, a list
+        If the series are all equal length, a ``numpy3D`` will be passed. If unequal,
+        a ``list``
         of 2D numpy arrays is passed, which may have different lengths.
 
         Returns
@@ -184,14 +185,14 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         Parameters
         ----------
         X : np.ndarray
-            A single time series instance if shape = (n_channels, n_timepoints)
+            A `single time series` instance if shape = `(n_channels, n_timepoints)`
 
         Returns
         -------
         ind : array
             Indices of the nearest points in the population matrix.
         ws : array
-            Array representing the weights of each neighbor.
+            ``Array`` representing the weights of each neighbor.
         """
         distances = np.array(
             [
@@ -229,14 +230,16 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ----------
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
+            special parameters are defined for a value, will return ``"default"`` set.
 
         Returns
         -------
         params : dict or list of dict, default={}
             Parameters to create testing instances of the class.
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            Each ``dict`` are parameters to construct an `"interesting"` test instance,
+            i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
         """
         # non-default distance and algorithm
         params1 = {"distance": "euclidean"}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Fixes #809 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR fixes the inconsistent use of double tick quotes in docstring https://github.com/aeon-toolkit/aeon/issues/809
In the Classification.distance_based module i fixed all the misusage of tick quotes.
for example:
```
n_jobs : int, default=1
      The number of jobs to run in parallel for both ``fit`` and ``predict``.
      `-1` means using all processors.

```
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
None
<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
