### PR TITLE
[MNT] Updated the release workflows

### DIFF
--- a/.github/workflows/fast_release.yml
+++ b/.github/workflows/fast_release.yml
@@ -30,6 +30,12 @@ jobs:
   upload-wheels:
     runs-on: ubuntu-24.04
 
+    environment:
+      name: release
+      url: https://pypi.org/p/aeon/
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -38,5 +44,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,12 @@ jobs:
     needs: test-wheels
     runs-on: ubuntu-24.04
 
+    environment:
+      name: release
+      url: https://pypi.org/p/aeon/
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -109,5 +115,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/developer_guide/release.md
+++ b/docs/developer_guide/release.md
@@ -41,7 +41,11 @@ The release process is as follows, on high-level:
 
 Creation of the GitHub release trigger the `pypi` release workflow.
 
-5. **Wait for the ``pypi`` release CI/CD to finish.**
+5. **Approve the release workflow.**
+   The release workflow will be automatically created in the GitHub Actions tab. This
+   must be approved by a member of the release management workgroup before it will run.
+
+6. **Wait for the ``pypi`` release CI/CD to finish.**
   If tests fail due to sporadic unrelated failure, restart. If tests fail genuinely,
   something went wrong in the above steps, investigate, fix, and repeat. If the bug
   is known and sporadic (i.e. failure to read data from an external source), the release
@@ -49,7 +53,7 @@ Creation of the GitHub release trigger the `pypi` release workflow.
   the workflow can be manually run from the GitHub Actions tab if more PRs are
   required.
 
-6. **Release workflow completion tasks.**
+7. **Release workflow completion tasks.**
   Once the release workflow has passed, check `aeon` version on `pypi`, this should be
   the new version. A validatory installation of `aeon` in a new Python environment
   should be carried out according to the installation instructions. If the installation
@@ -58,7 +62,7 @@ Creation of the GitHub release trigger the `pypi` release workflow.
 
 ## `conda-forge` release and release validation
 
-7. **Merge the ``conda-forge`` release PR.**
+8. **Merge the ``conda-forge`` release PR.**
   After some time a PR will be automatically created in the [aeon conda-forge feedstock](https://github.com/conda-forge/aeon-feedstock).
   Follow the instructions in the PR to merge it, making sure to update any dependencies
   that have changed and dependency version bounds.


### PR DESCRIPTION
Updates release workflows to use trusted publishing. I have removed the old API keys after the latest security issue and would rather update to this than add new GitHub secrets. This adds a new step the release workflow must be approved by release workgroup members.