### PR TITLE
[MNT] Skip some excected results tests when numba is disabled

### DIFF
--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -73,6 +73,10 @@ EXCLUDED_TESTS = {
 EXCLUDED_TESTS_NO_NUMBA = {
     # See issue #622
     "HIVECOTEV2": ["check_classifier_against_expected_results"],
+    # Other failures
+    "TemporalDictionaryEnsemble": ["check_classifier_against_expected_results"],
+    "OrdinalTDE": ["check_classifier_against_expected_results"],
+    "CanonicalIntervalForestRegressor": ["check_regressor_against_expected_results"],
 }
 
 


### PR DESCRIPTION
These are current causing the codecov tests to fail. IMO should skip for now, and fixing is low priority.