### PR TITLE
[MNT] Use MacOS for examples/ workflow

### DIFF
--- a/.github/utilities/run_examples.sh
+++ b/.github/utilities/run_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/opt/homebrew/bin/bash
 
 # Script to run all example notebooks.
 set -euxo pipefail

--- a/.github/utilities/run_examples.sh
+++ b/.github/utilities/run_examples.sh
@@ -32,7 +32,7 @@ notebooks=()
 runtimes=()
 
 # Loop over all notebooks in the examples directory.
-find "examples/" -name "*.ipynb" -print0 |
+find "examples" -name "*.ipynb" -print0 |
   while IFS= read -r -d "" notebook; do
     # Skip notebooks in the excluded list.
     if printf "%s\0" "${excluded[@]}" | grep -Fxqz -- "$notebook"; then

--- a/.github/utilities/run_examples.sh
+++ b/.github/utilities/run_examples.sh
@@ -23,6 +23,7 @@ if [ "$1" = true ]; then
     "examples/classification/shapelet_based.ipynb"
     "examples/classification/convolution_based.ipynb"
     "examples/similarity_search/code_speed.ipynb"
+    "examples/transformations/signature_method.ipynb"
 
   )
 fi

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -46,12 +46,17 @@ jobs:
           extra_args: --all-files
 
   run-notebook-examples:
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install bash 5.x
+        run: |
+          brew install bash
+          /opt/homebrew/bin/bash --version
+          
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -46,7 +46,7 @@ jobs:
           extra_args: --all-files
 
   run-notebook-examples:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           brew install bash
           /opt/homebrew/bin/bash --version
-          
+
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
@@ -74,6 +74,9 @@ jobs:
         with:
           additional_extras: "dev,binder"
 
+      - name: Install esig on macOS
+        run: pip install "esig>=0.9.7,<1.0.0"
+  
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh false
         shell: bash

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -52,10 +52,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install bash 5.x
+      - name: Install latest version of bash
         run: |
           brew install bash
           /opt/homebrew/bin/bash --version
+          sudo ln -sf /opt/homebrew/bin/bash /bin/bash
+          bash --version
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
@@ -73,9 +75,6 @@ jobs:
       - uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "dev,binder"
-
-      - name: Install esig on macOS
-        run: brew install boost && pip install "esig>=0.9.7,<1.0.0"
 
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh false

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -75,8 +75,8 @@ jobs:
           additional_extras: "dev,binder"
 
       - name: Install esig on macOS
-        run: pip install "esig>=0.9.7,<1.0.0"
-  
+        run: brew install boost && pip install "esig>=0.9.7,<1.0.0"
+
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh false
         shell: bash

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -56,8 +56,6 @@ jobs:
         run: |
           brew install bash
           /opt/homebrew/bin/bash --version
-          sudo ln -sf /opt/homebrew/bin/bash /bin/bash
-          bash --version
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -19,11 +19,16 @@ concurrency:
 
 jobs:
   run-notebook-examples:
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install bash 5.x
+        run: |
+          brew install bash
+          /opt/homebrew/bin/bash --version
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -48,7 +48,7 @@ jobs:
           additional_extras: "dev,binder"
           
       - name: Install esig on macOS
-        run: pip install "esig>=0.9.7,<1.0.0"
+        run: brew install boost && pip install "esig>=0.9.7,<1.0.0"
 
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full examples run') }}

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -29,8 +29,6 @@ jobs:
         run: |
           brew install bash
           /opt/homebrew/bin/bash --version
-          sudo ln -sf /opt/homebrew/bin/bash /bin/bash
-          bash --version
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "dev,binder"
+          
+      - name: Install esig on macOS
+        run: pip install "esig>=0.9.7,<1.0.0"
 
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full examples run') }}

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   run-notebook-examples:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
       - uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "dev,binder"
-          
+
       - name: Install esig on macOS
         run: brew install boost && pip install "esig>=0.9.7,<1.0.0"
 

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install bash 5.x
+      - name: Install latest version of bash
         run: |
           brew install bash
           /opt/homebrew/bin/bash --version
+          sudo ln -sf /opt/homebrew/bin/bash /bin/bash
+          bash --version
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
@@ -46,9 +48,6 @@ jobs:
       - uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "dev,binder"
-
-      - name: Install esig on macOS
-        run: brew install boost && pip install "esig>=0.9.7,<1.0.0"
 
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full examples run') }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Fixes #2665
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
- Changed the os in the workflows for `pr_examples` and `periodic_tests` to `macos-latest`.
- Changed the workflow to install `bash 5.x` before running `run_examples.sh`
as lastpipe isnt available in `bash 3.2` which is in the github runner image for `macos-latest` (https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md).
- Also added a step to install `boost` and `esig` before the `run_examples.sh` as `esig` is not installed on Darwin since its excluded in `pyproject.toml`.


<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
