### PR TITLE
[ENH] Implement K-Shape clusterer

### DIFF
--- a/aeon/clustering/_k_shape.py
+++ b/aeon/clustering/_k_shape.py
@@ -143,15 +143,7 @@ class TimeSeriesKShape(BaseClusterer):
                 raise EmptyClusterError
 
     def _compute_inertia(self, distances, assignments, squared=True):
-        """Derive inertia from pre-computed distances and assignments.
-
-        Examples
-        --------
-        >>> dists = numpy.array([[1., 2., 0.5], [0., 3., 1.]])
-        >>> assign = numpy.array([2, 0])
-        >>> _compute_inertia(dists, assign)
-        0.125
-        """
+        """Derive inertia from pre-computed distances and assignments."""
         n_ts = distances.shape[0]
         if squared:
             return np.sum(distances[np.arange(n_ts), assignments] ** 2) / n_ts


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #2661

#### What does this implement/fix? Explain your changes.
Implements the K-shape clutterer in aeon instead of wrapping the tslearn clusterer 

#### Does your contribution introduce a new dependency? If yes, which one?

#### Any other comments?

### PR checklist



##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
