### PR TITLE
[ENH]Use n_jobs parameter in KNeighborsTimeSeriesClassifier.

### DIFF
--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -17,6 +17,7 @@ from joblib import Parallel, delayed
 
 from aeon.classification.base import BaseClassifier
 from aeon.distances import get_distance_function
+from aeon.utils.validation import check_n_jobs
 
 WEIGHTS_SUPPORTED = ["uniform", "distance"]
 
@@ -141,7 +142,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             The class probabilities of the input samples. Classes are ordered
             by lexicographic order.
         """
-        preds = Parallel(n_jobs=self.n_jobs, backend=self.parallel_backend)(
+        n_jobs = check_n_jobs(self.n_jobs)
+        preds = Parallel(n_jobs=n_jobs, backend=self.parallel_backend)(
             delayed(self._proba_row)(x) for x in X
         )
         return np.array(preds)
@@ -162,7 +164,8 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         y : array of shape (n_cases)
             Class labels for each data sample.
         """
-        preds = Parallel(n_jobs=self.n_jobs, backend=self.parallel_backend)(
+        n_jobs = check_n_jobs(self.n_jobs)
+        preds = Parallel(n_jobs=n_jobs, backend=self.parallel_backend)(
             delayed(self._predict_row)(x) for x in X
         )
         return np.array(preds, dtype=self.classes_.dtype)

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -47,11 +47,10 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         n_timepoints)`` as input and returns a float.
     distance_params : dict, default = None
         Dictionary for metric parameters for the case that distance is a str.
-    n_jobs : int, default = None
+    n_jobs : int, default = 1
         The number of parallel jobs to run for neighbors search.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
-        for more details. Parameter for compatibility purposes, still unimplemented.
 
     Examples
     --------
@@ -135,7 +134,6 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             The class probabilities of the input samples. Classes are ordered
             by lexicographic order.
         """
-        self._check_is_fitted()
         preds = Parallel(n_jobs=self.n_jobs)(delayed(self._proba_row)(x) for x in X)
         return np.array(preds)
 
@@ -155,7 +153,6 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         y : array of shape (n_cases)
             Class labels for each data sample.
         """
-        self._check_is_fitted()
         preds = Parallel(n_jobs=self.n_jobs)(delayed(self._predict_row)(x) for x in X)
         return np.array(preds, dtype=self.classes_.dtype)
 

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -141,7 +141,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             The class probabilities of the input samples. Classes are ordered
             by lexicographic order.
         """
-        preds = Parallel(n_jobs=self.n_jobs, parallel_backend=self.parallel_backend)(
+        preds = Parallel(n_jobs=self.n_jobs, backend=self.parallel_backend)(
             delayed(self._proba_row)(x) for x in X
         )
         return np.array(preds)
@@ -162,7 +162,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         y : array of shape (n_cases)
             Class labels for each data sample.
         """
-        preds = Parallel(n_jobs=self.n_jobs, parallel_backend=self.parallel_backend)(
+        preds = Parallel(n_jobs=self.n_jobs, backend=self.parallel_backend)(
             delayed(self._predict_row)(x) for x in X
         )
         return np.array(preds, dtype=self.classes_.dtype)

--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -137,7 +137,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         """
         self._check_is_fitted()
         preds = Parallel(n_jobs=self.n_jobs)(delayed(self._proba_row)(x) for x in X)
-        return np.array(preds, dtype=self.classes_.dtype)
+        return np.array(preds)
 
     def _predict(self, X):
         """


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2478. See also #2545 and #2578.

#### What does this implement/fix? Explain your changes.
Uses n_jobs parameter in `_predict` and `predict_proba` of `KNeighborsTimeSeriesClassifier`. Parallelization is done in these methods instead of `_kneighbors` to potentially allow speedup through upper bounding the distance. 

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.