### PR TITLE
[ENH] Improved Test Coverage of DCNNNetwork

### DIFF
--- a/aeon/networks/tests/test_dcnn.py
+++ b/aeon/networks/tests/test_dcnn.py
@@ -30,7 +30,7 @@ def test_dcnnnetwork_init(latent_space_dim, n_layers):
         n_filters=[random.choice([50, 25, 100]) for _ in range(n_layers)],
     )
     model = dcnnnet.build_network((1000, 5))
-    assert model is not None
+    assert isinstance(model, object)
 
 
 @pytest.mark.skipif(
@@ -47,4 +47,50 @@ def test_dcnnnetwork_activations(activation):
         n_filters=[50, 50],
     )
     model = dcnnnet.build_network((150, 5))
-    assert model is not None
+    assert isinstance(model, object)
+
+
+@pytest.mark.parametrize(
+    "dilation_rate,kernel_size,activation,padding",
+    [
+        (None, None, None, None),
+        (2, 5, "relu", "causal"),
+        ([1, 2], [3, 5], ["relu", "tanh"], ["causal", "same"]),
+    ],
+)
+def test_dcnnnetwork_params(dilation_rate, kernel_size, activation, padding):
+    """Test DCNNNetwork initialization with different parameters."""
+    dcnnnet = DCNNNetwork(
+        latent_space_dim=64,
+        n_layers=2,
+        dilation_rate=dilation_rate,
+        kernel_size=kernel_size,
+        activation=activation,
+        padding=padding,
+        n_filters=[50, 50],
+    )
+    model = dcnnnet.build_network((150, 5))
+    assert isinstance(model, object)
+
+
+@pytest.mark.parametrize(
+    "dilation_rate,kernel_size,activation,padding",
+    [
+        (None, None, None, None),
+        (1, 3, "relu", "causal"),
+        ([1, 2, 1], [3, 5, 3], ["relu", "tanh", "relu"], ["causal", "same", "causal"]),
+    ],
+)
+def test_dcnnnetwork_varied_layers(dilation_rate, kernel_size, activation, padding):
+    """Test DCNNNetwork with varied layers and parameters."""
+    dcnnnet = DCNNNetwork(
+        latent_space_dim=128,
+        n_layers=3,
+        dilation_rate=dilation_rate,
+        kernel_size=kernel_size,
+        activation=activation,
+        padding=padding,
+        n_filters=[25, 50, 100],
+    )
+    model = dcnnnet.build_network((200, 10))
+    assert isinstance(model, object)

--- a/aeon/networks/tests/test_dcnn.py
+++ b/aeon/networks/tests/test_dcnn.py
@@ -51,14 +51,14 @@ def test_dcnnnetwork_activations(activation):
 
 
 @pytest.mark.parametrize(
-    "dilation_rate,kernel_size,activation,padding",
+    "dilation_rate,kernel_size,activation,padding,n_filters",
     [
-        (None, None, None, None),
-        (2, 5, "relu", "causal"),
-        ([1, 2], [3, 5], ["relu", "tanh"], ["causal", "same"]),
+        (None, None, None, None, None),
+        (2, 5, "relu", "causal", 50),
+        ([1, 2], [3, 5], ["relu", "tanh"], ["causal", "same"], [25, 50]),
     ],
 )
-def test_dcnnnetwork_params(dilation_rate, kernel_size, activation, padding):
+def test_dcnnnetwork_params(dilation_rate, kernel_size, activation, padding, n_filters):
     """Test DCNNNetwork initialization with different parameters."""
     dcnnnet = DCNNNetwork(
         latent_space_dim=64,
@@ -67,21 +67,29 @@ def test_dcnnnetwork_params(dilation_rate, kernel_size, activation, padding):
         kernel_size=kernel_size,
         activation=activation,
         padding=padding,
-        n_filters=[50, 50],
+        n_filters=n_filters,
     )
     model = dcnnnet.build_network((150, 5))
     assert isinstance(model, object)
 
 
 @pytest.mark.parametrize(
-    "dilation_rate,kernel_size,activation,padding",
+    "dilation_rate,kernel_size,activation,padding,n_filters",
     [
-        (None, None, None, None),
-        (1, 3, "relu", "causal"),
-        ([1, 2, 1], [3, 5, 3], ["relu", "tanh", "relu"], ["causal", "same", "causal"]),
+        (None, None, None, None, None),
+        (1, 3, "relu", "causal", 50),
+        (
+            [1, 2, 1],
+            [3, 5, 3],
+            ["relu", "tanh", "relu"],
+            ["causal", "same", "causal"],
+            [25, 50, 100],
+        ),
     ],
 )
-def test_dcnnnetwork_varied_layers(dilation_rate, kernel_size, activation, padding):
+def test_dcnnnetwork_varied_layers(
+    dilation_rate, kernel_size, activation, padding, n_filters
+):
     """Test DCNNNetwork with varied layers and parameters."""
     dcnnnet = DCNNNetwork(
         latent_space_dim=128,
@@ -90,7 +98,7 @@ def test_dcnnnetwork_varied_layers(dilation_rate, kernel_size, activation, paddi
         kernel_size=kernel_size,
         activation=activation,
         padding=padding,
-        n_filters=[25, 50, 100],
+        n_filters=n_filters,
     )
     model = dcnnnet.build_network((200, 10))
     assert isinstance(model, object)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
Contributes #2497 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Covers missing parameters in DCNNetwork test: dilation_rate, kernel_size, activation, padding, n_filters

![image](https://github.com/user-attachments/assets/cd9466e2-fd4b-4328-afce-7752c5b172c1)

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
