### PR TITLE
[BUG] Updated sbd_distance() to handle multivariate series (#2674)

### DIFF
--- a/aeon/distances/_sbd.py
+++ b/aeon/distances/_sbd.py
@@ -98,17 +98,7 @@ def sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool = True) -> floa
     if x.ndim == 1 and y.ndim == 1:
         return _univariate_sbd_distance(x, y, standardize)
     if x.ndim == 2 and y.ndim == 2:
-        if x.shape[0] == 1 and y.shape[0] == 1:
-            _x = x.ravel()
-            _y = y.ravel()
-            return _univariate_sbd_distance(_x, _y, standardize)
-        else:
-            # independent (time series should have the same number of channels!)
-            nchannels = min(x.shape[0], y.shape[0])
-            distance = 0.0
-            for i in range(nchannels):
-                distance += _univariate_sbd_distance(x[i], y[i], standardize)
-            return distance / nchannels
+        return _multivariate_sbd_distance(x, y, standardize)
 
     raise ValueError("x and y must be 1D or 2D")
 
@@ -245,3 +235,34 @@ def _univariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) ->
 
     b = np.sqrt(np.dot(x, x) * np.dot(y, y))
     return np.abs(1.0 - np.max(a / b))
+
+@njit(cache=True, fastmath=True)
+def _multivariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) -> float:
+    x = x.astype(np.float64)
+    y = y.astype(np.float64)
+
+    x = np.transpose(x, (1, 0))
+    y = np.transpose(y, (1, 0))
+
+    if standardize:
+        if x.size == 1 or y.size == 1:
+            return 0.0
+
+        x = (x - np.mean(x)) / np.std(x)
+        y = (y - np.mean(y)) / np.std(y)
+
+    norm1 = np.linalg.norm(x)
+    norm2 = np.linalg.norm(y)
+    
+    denom = norm1 * norm2
+    if denom < 1e-9:  # Avoid NaNs
+        denom = np.inf
+
+    with objmode(cc="float64[:, :]"):
+        cc = np.array([correlate(x[:, i], y[:, i], mode="full", method="fft") for i in range(x.shape[1])]).T
+
+    sz = x.shape[0]
+    cc = np.vstack((cc[-(sz - 1):], cc[:sz]))
+    norm_cc = np.real(cc).sum(axis=-1) / denom
+
+    return np.abs(1.0 - np.max(norm_cc))

--- a/aeon/distances/_sbd.py
+++ b/aeon/distances/_sbd.py
@@ -236,8 +236,11 @@ def _univariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) ->
     b = np.sqrt(np.dot(x, x) * np.dot(y, y))
     return np.abs(1.0 - np.max(a / b))
 
+
 @njit(cache=True, fastmath=True)
-def _multivariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) -> float:
+def _multivariate_sbd_distance(
+    x: np.ndarray, y: np.ndarray, standardize: bool
+) -> float:
     x = x.astype(np.float64)
     y = y.astype(np.float64)
 
@@ -253,16 +256,21 @@ def _multivariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) 
 
     norm1 = np.linalg.norm(x)
     norm2 = np.linalg.norm(y)
-    
+
     denom = norm1 * norm2
     if denom < 1e-9:  # Avoid NaNs
         denom = np.inf
 
     with objmode(cc="float64[:, :]"):
-        cc = np.array([correlate(x[:, i], y[:, i], mode="full", method="fft") for i in range(x.shape[1])]).T
+        cc = np.array(
+            [
+                correlate(x[:, i], y[:, i], mode="full", method="fft")
+                for i in range(x.shape[1])
+            ]
+        ).T
 
     sz = x.shape[0]
-    cc = np.vstack((cc[-(sz - 1):], cc[:sz]))
+    cc = np.vstack((cc[-(sz - 1) :], cc[:sz]))
     norm_cc = np.real(cc).sum(axis=-1) / denom
 
     return np.abs(1.0 - np.max(norm_cc))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2674

#### What does this implement/fix? Explain your changes.
* Updated sbd_distance() to handle multivariate data consistently with tslearn and other implementations
* added _multivariate_sbd_distance() which finds the correlations for each of the channels and then normalizes using the norm of the multivariate series.

The earlier implementation found the average of the distance after calculating normalized_cc for each channel independenly.
```py
if x.shape[0] == 1 and y.shape[0] == 1:
    _x = x.ravel()
    _y = y.ravel()
    return _univariate_sbd_distance(_x, _y, standardize)
else:
    # independent (time series should have the same number of channels!)
    nchannels = min(x.shape[0], y.shape[0])
    distance = 0.0
    for i in range(nchannels):
        distance += _univariate_sbd_distance(x[i], y[i], standardize)
    return distance / nchannels
```

The is replaced by a new _multivariate_sbd_distance() method which normalizes using the norm of the multivariate series, as is the case with tslearn and kshape-python. 

```py
@njit(cache=True, fastmath=True)
def _multivariate_sbd_distance(x: np.ndarray, y: np.ndarray, standardize: bool) -> float:
    x = x.astype(np.float64)
    y = y.astype(np.float64)

    x = np.transpose(x, (1, 0))
    y = np.transpose(y, (1, 0))

    if standardize:
        if x.size == 1 or y.size == 1:
            return 0.0

        x = (x - np.mean(x)) / np.std(x)
        y = (y - np.mean(y)) / np.std(y)

    norm1 = np.linalg.norm(x)
    norm2 = np.linalg.norm(y)
    
    denom = norm1 * norm2
    if denom < 1e-9:  # Avoid NaNs
        denom = np.inf

    with objmode(cc="float64[:, :]"):
        cc = np.array([correlate(x[:, i], y[:, i], mode="full", method="fft") for i in range(x.shape[1])]).T

    sz = x.shape[0]
    cc = np.vstack((cc[-(sz - 1):], cc[:sz]))  # Reorganize correlation values
    norm_cc = np.real(cc).sum(axis=-1) / denom

    return np.abs(1.0 - np.max(norm_cc))

```

#### Does your contribution introduce a new dependency? If yes, which one?
Nil

#### Any other comments?
Tests need to be modified. Now the values are consistent for tslearn and kshape-python 


### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.

