### PR TITLE
[DOC] Fix inconsistent docstring formatting for issue #809

### DIFF
--- a/aeon/forecasting/_dummy.py
+++ b/aeon/forecasting/_dummy.py
@@ -13,7 +13,7 @@ class DummyForecaster(BaseForecaster):
 
     def _fit(self, y, exog=None):
         """Fit ``DummyForecaster``.
-        
+
         Parameters
         ----------
         y : array-like
@@ -27,7 +27,7 @@ class DummyForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """Predict using ``DummyForecaster``.
-        
+
         Parameters
         ----------
         y : array-like, optional
@@ -44,7 +44,7 @@ class DummyForecaster(BaseForecaster):
 
     def _forecast(self, y, exog=None):
         """Forecast using ``DummyForecaster``.
-        
+
         Parameters
         ----------
         y : array-like

--- a/aeon/forecasting/_dummy.py
+++ b/aeon/forecasting/_dummy.py
@@ -7,21 +7,55 @@ class DummyForecaster(BaseForecaster):
     """Dummy forecaster always predicts the last value seen in training."""
 
     def __init__(self):
-        """Initialize DummyForecaster."""
+        """Initialize ``DummyForecaster``."""
         self.last_value_ = None
         super().__init__(horizon=1, axis=1)
 
     def _fit(self, y, exog=None):
-        """Fit dummy forecaster."""
+        """Fit ``DummyForecaster``.
+        
+        Parameters
+        ----------
+        y : array-like
+            Target values to fit the forecaster.
+        exog : array-like, optional
+            Exogenous variables (default is ``None``).
+        """
         y = y.squeeze()
         self.last_value_ = y[-1]
         return self
 
     def _predict(self, y=None, exog=None):
-        """Predict using dummy forecaster."""
+        """Predict using ``DummyForecaster``.
+        
+        Parameters
+        ----------
+        y : array-like, optional
+            Input data (default is ``None``).
+        exog : array-like, optional
+            Exogenous variables (default is ``None``).
+
+        Returns
+        -------
+        float
+            The last observed value.
+        """
         return self.last_value_
 
     def _forecast(self, y, exog=None):
-        """Forecast using dummy forecaster."""
+        """Forecast using ``DummyForecaster``.
+        
+        Parameters
+        ----------
+        y : array-like
+            Input data for forecasting.
+        exog : array-like, optional
+            Exogenous variables (default is ``None``).
+
+        Returns
+        -------
+        float
+            Forecasted value based on the last observed value.
+        """
         y = y.squeeze()
         return y[-1]

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -2,8 +2,8 @@
 
 An implementation of the exponential smoothing statistics forecasting algorithm.
 Implements additive and multiplicative error models,
-`None`, additive and multiplicative (including damped) trend and
-`None`, additive and multiplicative seasonality
+None, additive and multiplicative (including damped) trend and
+None, additive and multiplicative seasonality
 """
 
 __maintainer__ = []
@@ -26,42 +26,42 @@ class ETSForecaster(BaseForecaster):
     """Exponential Smoothing forecaster.
 
     An implementation of the exponential smoothing forecasting algorithm.
-    Implements additive and multiplicative error models, `None`, additive and
-    multiplicative (including damped) trend and `None`, additive and multiplicative
+    Implements additive and multiplicative error models, None, additive and
+    multiplicative (including damped) trend and None, additive and mutliplicative
     seasonality. See [1]_ for a description.
 
     Parameters
     ----------
-    error_type : `int`, default = `1`
-        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
-    trend_type : `int`, default = `0`
-        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
-    seasonality_type : `int`, default = `0`
-        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
-    seasonal_period : `int`, default=`1`
-        Length of seasonality period. If `seasonality_type` is `NONE`, this is assumed to
-        be `1`
-    alpha : `float`, default = `0.1`
+    error_type : int, default = 1
+        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
+    trend_type : int, default = 0
+        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
+    seasonality_type : int, default = 0
+        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
+    seasonal_period : int, default=1
+        Length of seasonality period. If seasonality_type is NONE, this is assumed to
+        be 1
+    alpha : float, default = 0.1
         Level smoothing parameter.
-    beta : `float`, default = `0.01`
-        Trend smoothing parameter. If `trend_type` is `NONE`, this is assumed to be `0.0`.
-    gamma : `float`, default = `0.01`
-        Seasonal smoothing parameter. If `seasonality` is `NONE`, this is assumed to be
-        `0.0`.
-    phi : `float`, default = `0.99`
+    beta : float, default = 0.01
+        Trend smoothing parameter. If trend_type is NONE, this is assumed to be 0.0.
+    gamma : float, default = 0.01
+        Seasonal smoothing parameter. If seasonality is NONE, this is assumed to be
+        0.0.
+    phi : float, default = 0.99
         Trend damping smoothing parameters
-    horizon : `int`, default = `1`
+    horizon : int, default = 1
         The horizon to forecast to.
 
     Attributes
     ----------
-    mean_sq_err_ : `float`
+    mean_sq_err_ : float
         Mean squared error.
-    likelihood_ : `float`
+    likelihood_ : float
         Likelihood of the fitted model based on residuals.
-    residuals_ : `arraylike`
+    residuals_ : arraylike
         List of train set differences between fitted and actual values.
-    n_timpoints_ : `int`
+    n_timpoints_ : int
         Length of the series passed to fit.
 
     References
@@ -108,25 +108,25 @@ class ETSForecaster(BaseForecaster):
         super().__init__(horizon=horizon, axis=1)
 
     def _fit(self, y, exog=None):
-        """Fit Exponential Smoothing forecaster to series ``y``.
+        """Fit Exponential Smoothing forecaster to series y.
 
-        Fit a forecaster to predict ``self.horizon`` steps ahead using ``y``.
+        Fit a forecaster to predict self.horizon steps ahead using y.
 
         Parameters
         ----------
-        y : ``np.ndarray``
-            A time series on which to learn a forecaster to predict ``horizon`` ahead
-        exog : ``np.ndarray``, default =``None``
-            Optional exogenous time series data assumed to be aligned with ``y``
+        y : np.ndarray
+            A time series on which to learn a forecaster to predict horizon ahead
+        exog : np.ndarray, default =None
+            Optional exogenous time series data assumed to be aligned with y
 
         Returns
         -------
         self
-            Fitted ``BaseForecaster``.
+            Fitted BaseForecaster.
         """
         self.n_timepoints_ = len(y)
         if self.error_type != MULTIPLICATIVE and self.error_type != ADDITIVE:
-            raise ValueError("Error must be either `additive` or `multiplicative`")
+            raise ValueError("Error must be either additive or multiplicative")
         self._seasonal_period = self.seasonal_period
         if self.seasonal_period < 1 or self.seasonality_type == NONE:
             self._seasonal_period = 1
@@ -159,20 +159,20 @@ class ETSForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """
-        Predict the next ``horizon`` steps ahead.
+        Predict the next horizon steps ahead.
 
         Parameters
         ----------
-        y : ``np.ndarray``, default = ``None``
-            A time series to predict the next ``horizon`` value for. If ``None``,
-            predict the next ``horizon`` value after series seen in ``fit``.
-        exog : ``np.ndarray``, default = ``None``
-            Optional exogenous time series data assumed to be aligned with ``y``
+        y : np.ndarray, default = None
+            A time series to predict the next horizon value for. If None,
+            predict the next horizon value after series seen in fit.
+        exog : np.ndarray, default = None
+            Optional exogenous time series data assumed to be aligned with y
 
         Returns
         -------
-        ``float``
-            single prediction ``self.horizon`` steps ahead of ``y``.
+        float
+            single prediction self.horizon steps ahead of y.
         """
         return _predict_numba(
             self.trend_type,
@@ -185,7 +185,8 @@ class ETSForecaster(BaseForecaster):
             self.n_timepoints_,
             self.seasonal_period,
         )
-        
+
+
 @njit(nogil=NOGIL, cache=CACHE)
 def _fit_numba(
     data,
@@ -205,7 +206,7 @@ def _fit_numba(
     mse = 0
     lhood = 0
     mul_likelihood_pt2 = 0
-    res = np.zeros(n_timepoints)  # `1` Less residual than data points
+    res = np.zeros(n_timepoints)  # 1 Less residual than data points
     for t, data_item in enumerate(data[seasonal_period:]):
         # Calculate level, trend, and seasonal components
         fitted_value, error, level, trend, seasonality[t % seasonal_period] = (
@@ -233,6 +234,7 @@ def _fit_numba(
         lhood += 2 * mul_likelihood_pt2
     return level, trend, seasonality, res, mse, lhood
 
+
 def _predict_numba(
     trend_type,
     seasonality_type,
@@ -248,7 +250,7 @@ def _predict_numba(
     if phi == 1:  # No damping case
         phi_h = float(horizon)
     else:
-        # Geometric series formula for calculating `phi + phi^2 + ... + phi^h`
+        # Geometric series formula for calculating phi + phi^2 + ... + phi^h
         phi_h = phi * (1 - phi**horizon) / (1 - phi)
     seasonal_index = (n_timepoints + horizon) % seasonal_period
     return _predict_value(
@@ -259,6 +261,7 @@ def _predict_numba(
         seasonality[seasonal_index],
         phi_h,
     )[0]
+
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _initialise(trend_type, seasonality_type, seasonal_period, data):
@@ -301,6 +304,7 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
         seasonality = np.zeros(1)
     return level, trend, seasonality
 
+
 @njit(nogil=NOGIL, cache=CACHE)
 def _update_states(
     error_type,
@@ -322,9 +326,9 @@ def _update_states(
 
     Parameters
     ----------
-    data_item: `float`
+    data_item: float
         The current value of the time series.
-    seasonal_index: `int`
+    seasonal_index: int
         The index to update the seasonal component.
     """
     # Retrieve the current state values
@@ -372,26 +376,27 @@ def _update_states(
 @njit(nogil=NOGIL, cache=CACHE)
 def _predict_value(trend_type, seasonality_type, level, trend, seasonality, phi):
     """
+
     Generate various useful values, including the next fitted value.
 
     Parameters
     ----------
-    trend : `float`
+    trend : float
         The current trend value for the model
-    level : `float`
+    level : float
         The current level value for the model
-    seasonality : `float`
+    seasonality : float
         The current seasonality value for the model
-    phi : `float`
+    phi : float
         The damping parameter for the model
 
     Returns
     -------
-    fitted_value : `float`
+    fitted_value : float
         single prediction based on the current state variables.
-    damped_trend : `float`
+    damped_trend : float
         The damping parameter combined with the trend dependant on the model type
-    trend_level_combination : `float`
+    trend_level_combination : float
         Combination of the trend and level based on the model type.
     """
     # Apply damping parameter and

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -1,10 +1,12 @@
-"""ETSForecaster class.
-
-An implementation of the exponential smoothing statistics forecasting algorithm.
-Implements additive and multiplicative error models,
-None, additive and multiplicative (including damped) trend and
-None, additive and multiplicative seasonality
 """
+ETSForecaster class.
+
+An implementation of the Exponential Smoothing (ETS) statistical forecasting algorithm.  
+Supports additive and multiplicative error models,  
+as well as ``None``, additive, and multiplicative (including damped) trend,  
+and ``None``, additive, and multiplicative seasonality.
+"""
+
 
 __maintainer__ = []
 __all__ = ["ETSForecaster", "NONE", "ADDITIVE", "MULTIPLICATIVE"]
@@ -23,51 +25,49 @@ MULTIPLICATIVE = 2
 
 
 class ETSForecaster(BaseForecaster):
-    """Exponential Smoothing forecaster.
+    """
+    Exponential Smoothing forecaster.
 
-    An implementation of the exponential smoothing forecasting algorithm.
-    Implements additive and multiplicative error models, None, additive and
-    multiplicative (including damped) trend and None, additive and mutliplicative
-    seasonality. See [1]_ for a description.
+    An implementation of the Exponential Smoothing (ETS) forecasting algorithm.  
+    Supports additive and multiplicative error models, as well as ``None``, additive,  
+    and multiplicative (including damped) trend and seasonality. See [1]_ for a detailed description.
 
     Parameters
     ----------
-    error_type : int, default = 1
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    trend_type : int, default = 0
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    seasonality_type : int, default = 0
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    seasonal_period : int, default=1
-        Length of seasonality period. If seasonality_type is NONE, this is assumed to
-        be 1
-    alpha : float, default = 0.1
+    error_type : ``int``, default=``1``
+        Either ``NONE (0)``, ``ADDITIVE (1)``, or ``MULTIPLICATIVE (2)``.
+    trend_type : ``int``, default=``0``
+        Either ``NONE (0)``, ``ADDITIVE (1)``, or ``MULTIPLICATIVE (2)``.
+    seasonality_type : ``int``, default=``0``
+        Either ``NONE (0)``, ``ADDITIVE (1)``, or ``MULTIPLICATIVE (2)``.
+    seasonal_period : ``int``, default=``1``
+        Length of the seasonal period. If ``seasonality_type`` is ``NONE``, this is assumed to be ``1``.
+    alpha : ``float``, default=``0.1``
         Level smoothing parameter.
-    beta : float, default = 0.01
-        Trend smoothing parameter. If trend_type is NONE, this is assumed to be 0.0.
-    gamma : float, default = 0.01
-        Seasonal smoothing parameter. If seasonality is NONE, this is assumed to be
-        0.0.
-    phi : float, default = 0.99
-        Trend damping smoothing parameters
-    horizon : int, default = 1
-        The horizon to forecast to.
+    beta : ``float``, default=``0.01``
+        Trend smoothing parameter. If ``trend_type`` is ``NONE``, this is assumed to be ``0.0``.
+    gamma : ``float``, default=``0.01``
+        Seasonal smoothing parameter. If ``seasonality_type`` is ``NONE``, this is assumed to be ``0.0``.
+    phi : ``float``, default=``0.99``
+        Trend damping smoothing parameter.
+    horizon : ``int``, default=``1``
+        The horizon to forecast.
 
     Attributes
     ----------
-    mean_sq_err_ : float
+    mean_sq_err_ : ``float``
         Mean squared error.
-    likelihood_ : float
+    likelihood_ : ``float``
         Likelihood of the fitted model based on residuals.
-    residuals_ : arraylike
-        List of train set differences between fitted and actual values.
-    n_timpoints_ : int
-        Length of the series passed to fit.
+    residuals_ : ``array-like``
+        List of training set differences between fitted and actual values.
+    n_timpoints_ : ``int``
+        Length of the series passed to ``fit``.
 
     References
     ----------
     .. [1] R. J. Hyndman and G. Athanasopoulos,
-        Forecasting: Principles and Practice. Melbourne, Australia: OTexts, 2014.
+        *Forecasting: Principles and Practice.* Melbourne, Australia: OTexts, 2014.
 
     Examples
     --------
@@ -80,6 +80,7 @@ class ETSForecaster(BaseForecaster):
     >>> forecaster.predict()
     449.9435566831507
     """
+
 
     def __init__(
         self,
@@ -108,22 +109,24 @@ class ETSForecaster(BaseForecaster):
         super().__init__(horizon=horizon, axis=1)
 
     def _fit(self, y, exog=None):
-        """Fit Exponential Smoothing forecaster to series y.
+        """
+        Fit Exponential Smoothing forecaster to a time series.
 
-        Fit a forecaster to predict self.horizon steps ahead using y.
+        Trains the forecaster to predict ``self.horizon`` steps ahead using ``y``.
 
         Parameters
         ----------
-        y : np.ndarray
-            A time series on which to learn a forecaster to predict horizon ahead
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y
+        y : ``np.ndarray``
+            A time series used to train the forecaster for predicting ``horizon`` steps ahead.
+        exog : ``np.ndarray``, default=``None``
+            Optional exogenous time series data, assumed to be aligned with ``y``.
 
         Returns
         -------
         self
-            Fitted BaseForecaster.
+            Fitted ``BaseForecaster`` instance.
         """
+
         self.n_timepoints_ = len(y)
         if self.error_type != MULTIPLICATIVE and self.error_type != ADDITIVE:
             raise ValueError("Error must be either additive or multiplicative")
@@ -159,21 +162,22 @@ class ETSForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """
-        Predict the next horizon steps ahead.
+        Predict the next ``horizon`` steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default = None
-            Optional exogenous time series data assumed to be aligned with y
+        y : ``np.ndarray``, default=``None``
+            A time series used to predict the next ``horizon`` value.  
+            If ``None``, predicts the next ``horizon`` value after the series seen in ``fit``.
+        exog : ``np.ndarray``, default=``None``
+            Optional exogenous time series data, assumed to be aligned with ``y``.
 
         Returns
         -------
-        float
-            single prediction self.horizon steps ahead of y.
+        ``float``
+            Single prediction ``self.horizon`` steps ahead of ``y``.
         """
+
         return _predict_numba(
             self.trend_type,
             self.seasonality_type,
@@ -270,10 +274,11 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
 
     Parameters
     ----------
-    data : array-like
-        The time series data
-        (should contain at least two full seasons if seasonality is specified)
+    data : ``array-like``
+        The time series data.  
+        Should contain at least two full seasons if seasonality is specified.
     """
+
     # Initial Level: Mean of the first season
     level = np.mean(data[:seasonal_period])
     # Initial Trend
@@ -320,17 +325,16 @@ def _update_states(
     phi,
 ):
     """
-    Update level, trend, and seasonality components.
-
-    Using state space equations for an ETS model.
+    Update level, trend, and seasonality components using state-space equations for an ETS model.
 
     Parameters
     ----------
-    data_item: float
+    data_item : ``float``
         The current value of the time series.
-    seasonal_index: int
+    seasonal_index : ``int``
         The index to update the seasonal component.
     """
+
     # Retrieve the current state values
     curr_level = level
     curr_seasonality = seasonality
@@ -376,29 +380,30 @@ def _update_states(
 @njit(nogil=NOGIL, cache=CACHE)
 def _predict_value(trend_type, seasonality_type, level, trend, seasonality, phi):
     """
-
     Generate various useful values, including the next fitted value.
 
     Parameters
     ----------
-    trend : float
-        The current trend value for the model
-    level : float
-        The current level value for the model
-    seasonality : float
-        The current seasonality value for the model
-    phi : float
-        The damping parameter for the model
+    trend : ``float``
+        The current trend value for the model.
+    level : ``float``
+        The current level value for the model.
+    seasonality : ``float``
+        The current seasonality value for the model.
+    phi : ``float``
+        The damping parameter for the model.
 
     Returns
     -------
-    fitted_value : float
-        single prediction based on the current state variables.
-    damped_trend : float
-        The damping parameter combined with the trend dependant on the model type
-    trend_level_combination : float
+    fitted_value : ``float``
+        Single prediction based on the current state variables.
+    damped_trend : ``float``
+        The damping parameter combined with the trend, depending on the model type.
+    trend_level_combination : ``float``
         Combination of the trend and level based on the model type.
     """
+
+
     # Apply damping parameter and
     # calculate commonly used combination of trend and level components
     if trend_type == MULTIPLICATIVE:

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -81,90 +81,6 @@ class ETSForecaster(BaseForecaster):
     449.9435566831507
     """
 
-
-"""ETSForecaster class.
-
-An implementation of the exponential smoothing statistics forecasting algorithm.
-Implements additive and multiplicative error models,
-``None``, additive and multiplicative (including damped) trend and
-``None``, additive and multiplicative seasonality
-"""
-
-__maintainer__ = []
-__all__ = ["ETSForecaster", "NONE", "ADDITIVE", "MULTIPLICATIVE"]
-
-import numpy as np
-from numba import njit
-
-from aeon.forecasting.base import BaseForecaster
-
-NOGIL = False
-CACHE = True
-
-NONE = 0
-ADDITIVE = 1
-MULTIPLICATIVE = 2
-
-
-class ETSForecaster(BaseForecaster):
-    """Exponential Smoothing forecaster.
-
-    An implementation of the exponential smoothing forecasting algorithm.
-    Implements additive and multiplicative error models, ``None``, additive and
-    multiplicative (including damped) trend and ``None``, additive and multiplicative
-    seasonality. See [1]_ for a description.
-
-    Parameters
-    ----------
-    error_type : ``int``, default = ``1``
-        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
-    trend_type : ``int``, default = ``0``
-        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
-    seasonality_type : ``int``, default = ``0``
-        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
-    seasonal_period : ``int``, default=``1``
-        Length of seasonality period. If ``seasonality_type`` is ``NONE``, this is assumed to
-        be ``1``
-    alpha : ``float``, default = ``0.1``
-        Level smoothing parameter.
-    beta : ``float``, default = ``0.01``
-        Trend smoothing parameter. If ``trend_type`` is ``NONE``, this is assumed to be ``0.0``.
-    gamma : ``float``, default = ``0.01``
-        Seasonal smoothing parameter. If ``seasonality`` is ``NONE``, this is assumed to be
-        ``0.0``.
-    phi : ``float``, default = ``0.99``
-        Trend damping smoothing parameters
-    horizon : ``int``, default = ``1``
-        The horizon to forecast to.
-
-    Attributes
-    ----------
-    mean_sq_err_ : ``float``
-        Mean squared error.
-    likelihood_ : ``float``
-        Likelihood of the fitted model based on residuals.
-    residuals_ : ``arraylike``
-        List of train set differences between fitted and actual values.
-    n_timpoints_ : ``int``
-        Length of the series passed to fit.
-
-    References
-    ----------
-    .. [1] R. J. Hyndman and G. Athanasopoulos,
-        Forecasting: Principles and Practice. Melbourne, Australia: OTexts, 2014.
-
-    Examples
-    --------
-    >>> from aeon.forecasting import ETSForecaster
-    >>> from aeon.datasets import load_airline
-    >>> y = load_airline()
-    >>> forecaster = ETSForecaster(alpha=0.4, beta=0.2, gamma=0.5, phi=0.8, horizon=1)
-    >>> forecaster.fit(y)
-    ETSForecaster(alpha=0.4, beta=0.2, gamma=0.5, phi=0.8)
-    >>> forecaster.predict()
-    449.9435566831507
-    """
-
     def __init__(
         self,
         error_type=ADDITIVE,
@@ -269,8 +185,7 @@ class ETSForecaster(BaseForecaster):
             self.n_timepoints_,
             self.seasonal_period,
         )
-
-
+        
 @njit(nogil=NOGIL, cache=CACHE)
 def _fit_numba(
     data,
@@ -318,7 +233,6 @@ def _fit_numba(
         lhood += 2 * mul_likelihood_pt2
     return level, trend, seasonality, res, mse, lhood
 
-
 def _predict_numba(
     trend_type,
     seasonality_type,
@@ -345,7 +259,6 @@ def _predict_numba(
         seasonality[seasonal_index],
         phi_h,
     )[0]
-
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _initialise(trend_type, seasonality_type, seasonal_period, data):
@@ -387,7 +300,6 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
         # No seasonality
         seasonality = np.zeros(1)
     return level, trend, seasonality
-
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _update_states(

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -1,12 +1,11 @@
 """
 ETSForecaster class.
 
-An implementation of the Exponential Smoothing (ETS) statistical forecasting algorithm.  
-Supports additive and multiplicative error models,  
-as well as ``None``, additive, and multiplicative (including damped) trend,  
+An implementation of the Exponential Smoothing (ETS) statistical forecasting algorithm.
+Supports additive and multiplicative error models,
+as well as ``None``, additive, and multiplicative (including damped) trend,
 and ``None``, additive, and multiplicative seasonality.
 """
-
 
 __maintainer__ = []
 __all__ = ["ETSForecaster", "NONE", "ADDITIVE", "MULTIPLICATIVE"]
@@ -28,8 +27,8 @@ class ETSForecaster(BaseForecaster):
     """
     Exponential Smoothing forecaster.
 
-    An implementation of the Exponential Smoothing (ETS) forecasting algorithm.  
-    Supports additive and multiplicative error models, as well as ``None``, additive,  
+    An implementation of the Exponential Smoothing (ETS) forecasting algorithm.
+    Supports additive and multiplicative error models, as well as ``None``, additive,
     and multiplicative (including damped) trend and seasonality. See [1]_ for a detailed description.
 
     Parameters
@@ -81,7 +80,6 @@ class ETSForecaster(BaseForecaster):
     449.9435566831507
     """
 
-
     def __init__(
         self,
         error_type=ADDITIVE,
@@ -126,7 +124,6 @@ class ETSForecaster(BaseForecaster):
         self
             Fitted ``BaseForecaster`` instance.
         """
-
         self.n_timepoints_ = len(y)
         if self.error_type != MULTIPLICATIVE and self.error_type != ADDITIVE:
             raise ValueError("Error must be either additive or multiplicative")
@@ -167,7 +164,7 @@ class ETSForecaster(BaseForecaster):
         Parameters
         ----------
         y : ``np.ndarray``, default=``None``
-            A time series used to predict the next ``horizon`` value.  
+            A time series used to predict the next ``horizon`` value.
             If ``None``, predicts the next ``horizon`` value after the series seen in ``fit``.
         exog : ``np.ndarray``, default=``None``
             Optional exogenous time series data, assumed to be aligned with ``y``.
@@ -177,7 +174,6 @@ class ETSForecaster(BaseForecaster):
         ``float``
             Single prediction ``self.horizon`` steps ahead of ``y``.
         """
-
         return _predict_numba(
             self.trend_type,
             self.seasonality_type,
@@ -275,10 +271,9 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
     Parameters
     ----------
     data : ``array-like``
-        The time series data.  
+        The time series data.
         Should contain at least two full seasons if seasonality is specified.
     """
-
     # Initial Level: Mean of the first season
     level = np.mean(data[:seasonal_period])
     # Initial Trend
@@ -334,7 +329,6 @@ def _update_states(
     seasonal_index : ``int``
         The index to update the seasonal component.
     """
-
     # Retrieve the current state values
     curr_level = level
     curr_seasonality = seasonality
@@ -402,8 +396,6 @@ def _predict_value(trend_type, seasonality_type, level, trend, seasonality, phi)
     trend_level_combination : ``float``
         Combination of the trend and level based on the model type.
     """
-
-
     # Apply damping parameter and
     # calculate commonly used combination of trend and level components
     if trend_type == MULTIPLICATIVE:

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -2,8 +2,8 @@
 
 An implementation of the exponential smoothing statistics forecasting algorithm.
 Implements additive and multiplicative error models,
-None, additive and multiplicative (including damped) trend and
-None, additive and multiplicative seasonality
+`None`, additive and multiplicative (including damped) trend and
+`None`, additive and multiplicative seasonality
 """
 
 __maintainer__ = []
@@ -26,42 +26,124 @@ class ETSForecaster(BaseForecaster):
     """Exponential Smoothing forecaster.
 
     An implementation of the exponential smoothing forecasting algorithm.
-    Implements additive and multiplicative error models, None, additive and
-    multiplicative (including damped) trend and None, additive and mutliplicative
+    Implements additive and multiplicative error models, `None`, additive and
+    multiplicative (including damped) trend and `None`, additive and multiplicative
     seasonality. See [1]_ for a description.
 
     Parameters
     ----------
-    error_type : int, default = 1
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    trend_type : int, default = 0
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    seasonality_type : int, default = 0
-        Either NONE (0), ADDITIVE (1) or MULTIPLICATIVE (2).
-    seasonal_period : int, default=1
-        Length of seasonality period. If seasonality_type is NONE, this is assumed to
-        be 1
-    alpha : float, default = 0.1
+    error_type : `int`, default = `1`
+        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
+    trend_type : `int`, default = `0`
+        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
+    seasonality_type : `int`, default = `0`
+        Either `NONE` (`0`), `ADDITIVE` (`1`) or `MULTIPLICATIVE` (`2`).
+    seasonal_period : `int`, default=`1`
+        Length of seasonality period. If `seasonality_type` is `NONE`, this is assumed to
+        be `1`
+    alpha : `float`, default = `0.1`
         Level smoothing parameter.
-    beta : float, default = 0.01
-        Trend smoothing parameter. If trend_type is NONE, this is assumed to be 0.0.
-    gamma : float, default = 0.01
-        Seasonal smoothing parameter. If seasonality is NONE, this is assumed to be
-        0.0.
-    phi : float, default = 0.99
+    beta : `float`, default = `0.01`
+        Trend smoothing parameter. If `trend_type` is `NONE`, this is assumed to be `0.0`.
+    gamma : `float`, default = `0.01`
+        Seasonal smoothing parameter. If `seasonality` is `NONE`, this is assumed to be
+        `0.0`.
+    phi : `float`, default = `0.99`
         Trend damping smoothing parameters
-    horizon : int, default = 1
+    horizon : `int`, default = `1`
         The horizon to forecast to.
 
     Attributes
     ----------
-    mean_sq_err_ : float
+    mean_sq_err_ : `float`
         Mean squared error.
-    likelihood_ : float
+    likelihood_ : `float`
         Likelihood of the fitted model based on residuals.
-    residuals_ : arraylike
+    residuals_ : `arraylike`
         List of train set differences between fitted and actual values.
-    n_timpoints_ : int
+    n_timpoints_ : `int`
+        Length of the series passed to fit.
+
+    References
+    ----------
+    .. [1] R. J. Hyndman and G. Athanasopoulos,
+        Forecasting: Principles and Practice. Melbourne, Australia: OTexts, 2014.
+
+    Examples
+    --------
+    >>> from aeon.forecasting import ETSForecaster
+    >>> from aeon.datasets import load_airline
+    >>> y = load_airline()
+    >>> forecaster = ETSForecaster(alpha=0.4, beta=0.2, gamma=0.5, phi=0.8, horizon=1)
+    >>> forecaster.fit(y)
+    ETSForecaster(alpha=0.4, beta=0.2, gamma=0.5, phi=0.8)
+    >>> forecaster.predict()
+    449.9435566831507
+    """
+"""ETSForecaster class.
+
+An implementation of the exponential smoothing statistics forecasting algorithm.
+Implements additive and multiplicative error models,
+``None``, additive and multiplicative (including damped) trend and
+``None``, additive and multiplicative seasonality
+"""
+
+__maintainer__ = []
+__all__ = ["ETSForecaster", "NONE", "ADDITIVE", "MULTIPLICATIVE"]
+
+import numpy as np
+from numba import njit
+
+from aeon.forecasting.base import BaseForecaster
+
+NOGIL = False
+CACHE = True
+
+NONE = 0
+ADDITIVE = 1
+MULTIPLICATIVE = 2
+
+
+class ETSForecaster(BaseForecaster):
+    """Exponential Smoothing forecaster.
+
+    An implementation of the exponential smoothing forecasting algorithm.
+    Implements additive and multiplicative error models, ``None``, additive and
+    multiplicative (including damped) trend and ``None``, additive and multiplicative
+    seasonality. See [1]_ for a description.
+
+    Parameters
+    ----------
+    error_type : ``int``, default = ``1``
+        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
+    trend_type : ``int``, default = ``0``
+        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
+    seasonality_type : ``int``, default = ``0``
+        Either ``NONE`` (``0``), ``ADDITIVE`` (``1``) or ``MULTIPLICATIVE`` (``2``).
+    seasonal_period : ``int``, default=``1``
+        Length of seasonality period. If ``seasonality_type`` is ``NONE``, this is assumed to
+        be ``1``
+    alpha : ``float``, default = ``0.1``
+        Level smoothing parameter.
+    beta : ``float``, default = ``0.01``
+        Trend smoothing parameter. If ``trend_type`` is ``NONE``, this is assumed to be ``0.0``.
+    gamma : ``float``, default = ``0.01``
+        Seasonal smoothing parameter. If ``seasonality`` is ``NONE``, this is assumed to be
+        ``0.0``.
+    phi : ``float``, default = ``0.99``
+        Trend damping smoothing parameters
+    horizon : ``int``, default = ``1``
+        The horizon to forecast to.
+
+    Attributes
+    ----------
+    mean_sq_err_ : ``float``
+        Mean squared error.
+    likelihood_ : ``float``
+        Likelihood of the fitted model based on residuals.
+    residuals_ : ``arraylike``
+        List of train set differences between fitted and actual values.
+    n_timpoints_ : ``int``
         Length of the series passed to fit.
 
     References
@@ -108,25 +190,25 @@ class ETSForecaster(BaseForecaster):
         super().__init__(horizon=horizon, axis=1)
 
     def _fit(self, y, exog=None):
-        """Fit Exponential Smoothing forecaster to series y.
+        """Fit Exponential Smoothing forecaster to series ``y``.
 
-        Fit a forecaster to predict self.horizon steps ahead using y.
+        Fit a forecaster to predict ``self.horizon`` steps ahead using ``y``.
 
         Parameters
         ----------
-        y : np.ndarray
-            A time series on which to learn a forecaster to predict horizon ahead
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y
+        y : ``np.ndarray``
+            A time series on which to learn a forecaster to predict ``horizon`` ahead
+        exog : ``np.ndarray``, default =``None``
+            Optional exogenous time series data assumed to be aligned with ``y``
 
         Returns
         -------
         self
-            Fitted BaseForecaster.
+            Fitted ``BaseForecaster``.
         """
         self.n_timepoints_ = len(y)
         if self.error_type != MULTIPLICATIVE and self.error_type != ADDITIVE:
-            raise ValueError("Error must be either additive or multiplicative")
+            raise ValueError("Error must be either `additive` or `multiplicative`")
         self._seasonal_period = self.seasonal_period
         if self.seasonal_period < 1 or self.seasonality_type == NONE:
             self._seasonal_period = 1
@@ -159,20 +241,20 @@ class ETSForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """
-        Predict the next horizon steps ahead.
+        Predict the next ``horizon`` steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default = None
-            Optional exogenous time series data assumed to be aligned with y
+        y : ``np.ndarray``, default = ``None``
+            A time series to predict the next ``horizon`` value for. If ``None``,
+            predict the next ``horizon`` value after series seen in ``fit``.
+        exog : ``np.ndarray``, default = ``None``
+            Optional exogenous time series data assumed to be aligned with ``y``
 
         Returns
         -------
-        float
-            single prediction self.horizon steps ahead of y.
+        ``float``
+            single prediction ``self.horizon`` steps ahead of ``y``.
         """
         return _predict_numba(
             self.trend_type,
@@ -185,8 +267,7 @@ class ETSForecaster(BaseForecaster):
             self.n_timepoints_,
             self.seasonal_period,
         )
-
-
+        
 @njit(nogil=NOGIL, cache=CACHE)
 def _fit_numba(
     data,
@@ -206,7 +287,7 @@ def _fit_numba(
     mse = 0
     lhood = 0
     mul_likelihood_pt2 = 0
-    res = np.zeros(n_timepoints)  # 1 Less residual than data points
+    res = np.zeros(n_timepoints)  # `1` Less residual than data points
     for t, data_item in enumerate(data[seasonal_period:]):
         # Calculate level, trend, and seasonal components
         fitted_value, error, level, trend, seasonality[t % seasonal_period] = (
@@ -234,7 +315,6 @@ def _fit_numba(
         lhood += 2 * mul_likelihood_pt2
     return level, trend, seasonality, res, mse, lhood
 
-
 def _predict_numba(
     trend_type,
     seasonality_type,
@@ -250,7 +330,7 @@ def _predict_numba(
     if phi == 1:  # No damping case
         phi_h = float(horizon)
     else:
-        # Geometric series formula for calculating phi + phi^2 + ... + phi^h
+        # Geometric series formula for calculating `phi + phi^2 + ... + phi^h`
         phi_h = phi * (1 - phi**horizon) / (1 - phi)
     seasonal_index = (n_timepoints + horizon) % seasonal_period
     return _predict_value(
@@ -261,7 +341,6 @@ def _predict_numba(
         seasonality[seasonal_index],
         phi_h,
     )[0]
-
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _initialise(trend_type, seasonality_type, seasonal_period, data):
@@ -304,7 +383,6 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
         seasonality = np.zeros(1)
     return level, trend, seasonality
 
-
 @njit(nogil=NOGIL, cache=CACHE)
 def _update_states(
     error_type,
@@ -326,9 +404,9 @@ def _update_states(
 
     Parameters
     ----------
-    data_item: float
+    data_item: `float`
         The current value of the time series.
-    seasonal_index: int
+    seasonal_index: `int`
         The index to update the seasonal component.
     """
     # Retrieve the current state values
@@ -376,27 +454,26 @@ def _update_states(
 @njit(nogil=NOGIL, cache=CACHE)
 def _predict_value(trend_type, seasonality_type, level, trend, seasonality, phi):
     """
-
     Generate various useful values, including the next fitted value.
 
     Parameters
     ----------
-    trend : float
+    trend : `float`
         The current trend value for the model
-    level : float
+    level : `float`
         The current level value for the model
-    seasonality : float
+    seasonality : `float`
         The current seasonality value for the model
-    phi : float
+    phi : `float`
         The damping parameter for the model
 
     Returns
     -------
-    fitted_value : float
+    fitted_value : `float`
         single prediction based on the current state variables.
-    damped_trend : float
+    damped_trend : `float`
         The damping parameter combined with the trend dependant on the model type
-    trend_level_combination : float
+    trend_level_combination : `float`
         Combination of the trend and level based on the model type.
     """
     # Apply damping parameter and

--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -80,6 +80,8 @@ class ETSForecaster(BaseForecaster):
     >>> forecaster.predict()
     449.9435566831507
     """
+
+
 """ETSForecaster class.
 
 An implementation of the exponential smoothing statistics forecasting algorithm.
@@ -267,7 +269,8 @@ class ETSForecaster(BaseForecaster):
             self.n_timepoints_,
             self.seasonal_period,
         )
-        
+
+
 @njit(nogil=NOGIL, cache=CACHE)
 def _fit_numba(
     data,
@@ -315,6 +318,7 @@ def _fit_numba(
         lhood += 2 * mul_likelihood_pt2
     return level, trend, seasonality, res, mse, lhood
 
+
 def _predict_numba(
     trend_type,
     seasonality_type,
@@ -341,6 +345,7 @@ def _predict_numba(
         seasonality[seasonal_index],
         phi_h,
     )[0]
+
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _initialise(trend_type, seasonality_type, seasonal_period, data):
@@ -382,6 +387,7 @@ def _initialise(trend_type, seasonality_type, seasonal_period, data):
         # No seasonality
         seasonality = np.zeros(1)
     return level, trend, seasonality
+
 
 @njit(nogil=NOGIL, cache=CACHE)
 def _update_states(

--- a/aeon/forecasting/_regression.py
+++ b/aeon/forecasting/_regression.py
@@ -17,23 +17,22 @@ class RegressionForecaster(BaseForecaster):
 
     Container for forecaster that reduces forecasting to regression through a
     window. Form a collection of sub series of length `window` through a sliding
-    winodw to form X, take `horizon` points ahead to form `y`, then apply an aeon or
+    window to form `X`, take `horizon` points ahead to form `y`, then apply an aeon or
     sklearn regressor.
-
 
     Parameters
     ----------
-    window : int
+    window : `int`
         The window prior to the current time point to use in forecasting. So if
-        horizon is one, forecaster will train using points $i$ to $window+i-1$ to
-        predict value $window+i$. If horizon is 4, forecaster will used points $i$
-        to $window+i-1$ to predict value $window+i+3$. If None, the algorithm will
+        `horizon` is one, forecaster will train using points `i` to `window+i-1` to
+        predict value `window+i`. If `horizon` is 4, forecaster will use points `i`
+        to `window+i-1` to predict value `window+i+3`. If `None`, the algorithm will
         internally determine what data to use to predict `horizon` steps ahead.
-    horizon : int, default =1
-        The number of time steps ahead to forecast. If horizon is one, the forecaster
-        will learn to predict one point ahead
-    regressor : object, default =None
-        Regression estimator that implements BaseRegressor or is otherwise compatible
+    horizon : `int`, default=`1`
+        The number of time steps ahead to forecast. If `horizon` is one, the forecaster
+        will learn to predict one point ahead.
+    regressor : `object`, default=`None`
+        Regression estimator that implements `BaseRegressor` or is otherwise compatible
         with sklearn regressors.
     """
 
@@ -45,14 +44,14 @@ class RegressionForecaster(BaseForecaster):
     def _fit(self, y, exog=None):
         """Fit forecaster to time series.
 
-        Split X into windows of length window and train the forecaster on each window
-        to predict the horizon ahead.
+        Split `X` into windows of length `window` and train the forecaster on each window
+        to predict the `horizon` ahead.
 
         Parameters
         ----------
-        y : np.ndarray
-            A time series on which to learn a forecaster to predict horizon ahead.
-        exog : np.ndarray, default=None
+        y : `np.ndarray`
+            A time series on which to learn a forecaster to predict `horizon` ahead.
+        exog : `np.ndarray`, default=`None`
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
@@ -68,9 +67,9 @@ class RegressionForecaster(BaseForecaster):
             self.regressor_ = self.regressor
         y = y.squeeze()
         X = np.lib.stride_tricks.sliding_window_view(y, window_shape=self.window)
-        # Ignore the final horizon values: need to store these for pred with empty y
+        # Ignore the final `horizon` values: need to store these for pred with empty `y`
         X = X[: -self.horizon]
-        # Extract y
+        # Extract `y`
         y = y[self.window + self.horizon - 1 :]
         self.last_ = y[-self.window :]
         self.last_ = self.last_.reshape(1, -1)
@@ -79,21 +78,21 @@ class RegressionForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """
-        Predict the next horizon steps ahead.
+        Predict the next `horizon` steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default=None
+        y : `np.ndarray`, default=`None`
+            A time series to predict the next `horizon` value for. If `None`,
+            predict the next `horizon` value after series seen in `fit`.
+        exog : `np.ndarray`, default=`None`
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
         Returns
         -------
-        np.ndarray
-            single prediction self.horizon steps ahead of y.
+        `np.ndarray`
+            Single prediction `self.horizon` steps ahead of `y`.
         """
         if y is None:
             return self.regressor_.predict(self.last_)
@@ -102,22 +101,22 @@ class RegressionForecaster(BaseForecaster):
 
     def _forecast(self, y, exog=None):
         """
-        Forecast the next horizon steps ahead.
+        Forecast the next `horizon` steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray
-            A time series to predict the next horizon value for.
-        exog : np.ndarray, default=None
+        y : `np.ndarray`
+            A time series to predict the next `horizon` value for.
+        exog : `np.ndarray`, default=`None`
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
         Returns
         -------
-        np.ndarray
-            single prediction self.horizon steps ahead of y.
+        `np.ndarray`
+            Single prediction `self.horizon` steps ahead of `y`.
 
-        NOTE: deal with horizons
+        NOTE: deal with `horizon`s.
         """
         self.fit(y, exog)
         return self.predict()
@@ -128,12 +127,12 @@ class RegressionForecaster(BaseForecaster):
 
         Parameters
         ----------
-        parameter_set : str, default='default'
+        parameter_set : `str`, default=`'default'`
             Name of the parameter set to return.
 
         Returns
         -------
-        dict
+        `dict`
             Dictionary of testing parameter settings.
         """
         return {"window": 4}

--- a/aeon/forecasting/_regression.py
+++ b/aeon/forecasting/_regression.py
@@ -5,7 +5,6 @@ regressor. Simply forms a collection of windows from the time series and trains 
 predict the next.
 """
 
-
 import numpy as np
 from sklearn.linear_model import LinearRegression
 
@@ -38,7 +37,6 @@ class RegressionForecaster(BaseForecaster):
         with ``scikit-learn`` regressors.
     """
 
-
     def __init__(self, window, horizon=1, regressor=None):
         self.window = window
         self.regressor = regressor
@@ -63,7 +61,6 @@ class RegressionForecaster(BaseForecaster):
         self
             Fitted estimator.
         """
-
         # Window data
         if self.regressor is None:
             self.regressor_ = LinearRegression()
@@ -98,7 +95,6 @@ class RegressionForecaster(BaseForecaster):
         ``np.ndarray``
             Single prediction ``self.horizon`` steps ahead of ``y``.
         """
-
         if y is None:
             return self.regressor_.predict(self.last_)
         last = y[:, -self.window :]
@@ -123,7 +119,6 @@ class RegressionForecaster(BaseForecaster):
 
         NOTE: Deal with ``horizon`` values properly.
         """
-
         self.fit(y, exog)
         return self.predict()
 
@@ -142,5 +137,4 @@ class RegressionForecaster(BaseForecaster):
         ``dict``
             Dictionary of testing parameter settings.
         """
-
         return {"window": 4}

--- a/aeon/forecasting/_regression.py
+++ b/aeon/forecasting/_regression.py
@@ -1,9 +1,10 @@
 """Window-based regression forecaster.
 
-General purpose forecaster to use with any scikit learn or aeon compatible
+General-purpose forecaster to use with any ``scikit-learn`` or ``aeon``-compatible
 regressor. Simply forms a collection of windows from the time series and trains to
-predict the next
+predict the next.
 """
+
 
 import numpy as np
 from sklearn.linear_model import LinearRegression
@@ -13,28 +14,30 @@ from aeon.forecasting.base import BaseForecaster
 
 class RegressionForecaster(BaseForecaster):
     """
-    Regression based forecasting.
+    Regression-based forecasting.
 
-    Container for forecaster that reduces forecasting to regression through a
-    window. Form a collection of sub series of length `window` through a sliding
-    window to form `X`, take `horizon` points ahead to form `y`, then apply an aeon or
-    sklearn regressor.
+    Container for a forecaster that reduces forecasting to regression through a
+    window. Forms a collection of sub-series of length ``window`` through a sliding
+    window to form ``X``, takes ``horizon`` points ahead to form ``y``, then applies an
+    ``aeon`` or ``scikit-learn`` regressor.
 
     Parameters
     ----------
-    window : `int`
+    window : ``int``
         The window prior to the current time point to use in forecasting. So if
-        `horizon` is one, forecaster will train using points `i` to `window+i-1` to
-        predict value `window+i`. If `horizon` is 4, forecaster will use points `i`
-        to `window+i-1` to predict value `window+i+3`. If `None`, the algorithm will
-        internally determine what data to use to predict `horizon` steps ahead.
-    horizon : `int`, default=`1`
-        The number of time steps ahead to forecast. If `horizon` is one, the forecaster
+        ``horizon`` is one, the forecaster will train using points ``i`` to ``window+i-1``
+        to predict value ``window+i``. If ``horizon`` is 4, the forecaster will use
+        points ``i`` to ``window+i-1`` to predict value ``window+i+3``. If ``None``, the
+        algorithm will internally determine what data to use to predict ``horizon``
+        steps ahead.
+    horizon : ``int``, default=``1``
+        The number of time steps ahead to forecast. If ``horizon`` is one, the forecaster
         will learn to predict one point ahead.
-    regressor : `object`, default=`None`
-        Regression estimator that implements `BaseRegressor` or is otherwise compatible
-        with sklearn regressors.
+    regressor : ``object``, default=``None``
+        Regression estimator that implements ``BaseRegressor`` or is otherwise compatible
+        with ``scikit-learn`` regressors.
     """
+
 
     def __init__(self, window, horizon=1, regressor=None):
         self.window = window
@@ -44,22 +47,23 @@ class RegressionForecaster(BaseForecaster):
     def _fit(self, y, exog=None):
         """Fit forecaster to time series.
 
-        Split `X` into windows of length `window` and train the forecaster on each window
-        to predict the `horizon` ahead.
+        Split ``X`` into windows of length ``window`` and train the forecaster on each window
+        to predict the ``horizon`` ahead.
 
         Parameters
         ----------
-        y : `np.ndarray`
-            A time series on which to learn a forecaster to predict `horizon` ahead.
-        exog : `np.ndarray`, default=`None`
+        y : ``np.ndarray``
+            A time series on which to learn a forecaster to predict ``horizon`` ahead.
+        exog : ``np.ndarray``, default=``None``
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
         Returns
         -------
         self
-            Fitted estimator
+            Fitted estimator.
         """
+
         # Window data
         if self.regressor is None:
             self.regressor_ = LinearRegression()
@@ -78,22 +82,23 @@ class RegressionForecaster(BaseForecaster):
 
     def _predict(self, y=None, exog=None):
         """
-        Predict the next `horizon` steps ahead.
+        Predict the next ``horizon`` steps ahead.
 
         Parameters
         ----------
-        y : `np.ndarray`, default=`None`
-            A time series to predict the next `horizon` value for. If `None`,
-            predict the next `horizon` value after series seen in `fit`.
-        exog : `np.ndarray`, default=`None`
+        y : ``np.ndarray``, default=``None``
+            A time series to predict the next ``horizon`` value for. If ``None``,
+            predict the next ``horizon`` value after the series seen in ``fit``.
+        exog : ``np.ndarray``, default=``None``
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
         Returns
         -------
-        `np.ndarray`
-            Single prediction `self.horizon` steps ahead of `y`.
+        ``np.ndarray``
+            Single prediction ``self.horizon`` steps ahead of ``y``.
         """
+
         if y is None:
             return self.regressor_.predict(self.last_)
         last = y[:, -self.window :]
@@ -101,38 +106,41 @@ class RegressionForecaster(BaseForecaster):
 
     def _forecast(self, y, exog=None):
         """
-        Forecast the next `horizon` steps ahead.
+        Forecast the next ``horizon`` steps ahead.
 
         Parameters
         ----------
-        y : `np.ndarray`
-            A time series to predict the next `horizon` value for.
-        exog : `np.ndarray`, default=`None`
+        y : ``np.ndarray``
+            A time series to predict the next ``horizon`` value for.
+        exog : ``np.ndarray``, default=``None``
             Optional exogenous time series data. Included for interface
             compatibility but ignored in this estimator.
 
         Returns
         -------
-        `np.ndarray`
-            Single prediction `self.horizon` steps ahead of `y`.
+        ``np.ndarray``
+            Single prediction ``self.horizon`` steps ahead of ``y``.
 
-        NOTE: deal with `horizon`s.
+        NOTE: Deal with ``horizon`` values properly.
         """
+
         self.fit(y, exog)
         return self.predict()
 
     @classmethod
     def _get_test_params(cls, parameter_set="default"):
-        """Return testing parameter settings for the estimator.
+        """
+        Return testing parameter settings for the estimator.
 
         Parameters
         ----------
-        parameter_set : `str`, default=`'default'`
+        parameter_set : ``str``, default=``'default'``
             Name of the parameter set to return.
 
         Returns
         -------
-        `dict`
+        ``dict``
             Dictionary of testing parameter settings.
         """
+
         return {"window": 4}

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -19,12 +19,12 @@ class BaseForecaster(BaseSeriesEstimator):
 
     The base forecaster specifies the methods and method signatures that all
     forecasters have to implement. Attributes with an underscore suffix are set in the
-    method fit.
+    method `fit`.
 
     Parameters
     ----------
-    horizon : int, default =1
-        The number of time steps ahead to forecast. If horizon is one, the forecaster
+    horizon : `int`, default =`1`
+        The number of time steps ahead to forecast. If `horizon` is `1`, the forecaster
         will learn to predict one point ahead.
     """
 
@@ -42,21 +42,21 @@ class BaseForecaster(BaseSeriesEstimator):
         super().__init__(axis)
 
     def fit(self, y, exog=None):
-        """Fit forecaster to series y.
+        """Fit forecaster to series `y`.
 
-        Fit a forecaster to predict self.horizon steps ahead using y.
+        Fit a forecaster to predict `self.horizon` steps ahead using `y`.
 
         Parameters
         ----------
-        y : np.ndarray
-            A time series on which to learn a forecaster to predict horizon ahead.
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y.
+        y : `np.ndarray`
+            A time series on which to learn a forecaster to predict `horizon` ahead.
+        exog : `np.ndarray`, default =`None`
+            Optional exogenous time series data assumed to be aligned with `y`.
 
         Returns
         -------
         self
-            Fitted BaseForecaster.
+            Fitted `BaseForecaster`.
         """
         if self.get_tag("fit_is_empty"):
             self.is_fitted = True
@@ -73,20 +73,20 @@ class BaseForecaster(BaseSeriesEstimator):
     def _fit(self, y, exog=None): ...
 
     def predict(self, y=None, exog=None):
-        """Predict the next horizon steps ahead.
+        """Predict the next `horizon` steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y.
+        y : `np.ndarray`, default = `None`
+            A time series to predict the next `horizon` value for. If `None`,
+            predict the next `horizon` value after series seen in `fit`.
+        exog : `np.ndarray`, default =`None`
+            Optional exogenous time series data assumed to be aligned with `y`.
 
         Returns
         -------
-        float
-            single prediction self.horizon steps ahead of y.
+        `float`
+            single prediction `self.horizon` steps ahead of `y`.
         """
         self._check_is_fitted()
         if y is not None:
@@ -100,36 +100,36 @@ class BaseForecaster(BaseSeriesEstimator):
     def _predict(self, y=None, exog=None): ...
 
     def forecast(self, y, exog=None):
-        """Forecast the next horizon steps ahead.
+        """Forecast the next `horizon` steps ahead.
 
-        By default this is simply fit followed by predict.
+        By default this is simply `fit` followed by `predict`.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y.
+        y : `np.ndarray`, default = `None`
+            A time series to predict the next `horizon` value for. If `None`,
+            predict the next `horizon` value after series seen in `fit`.
+        exog : `np.ndarray`, default =`None`
+            Optional exogenous time series data assumed to be aligned with `y`.
 
         Returns
         -------
-        float
-            single prediction self.horizon steps ahead of y.
+        `float`
+            single prediction `self.horizon` steps ahead of `y`.
         """
         self._check_X(y, self.axis)
         y = self._convert_y(y, self.axis)
         return self._forecast(y, exog)
 
     def _forecast(self, y, exog=None):
-        """Forecast values for time series X."""
+        """Forecast values for time series `X`."""
         self.fit(y, exog)
         return self._predict(y, exog)
 
     def _convert_y(self, y: VALID_SERIES_INNER_TYPES, axis: int):
-        """Convert y to self.get_tag("y_inner_type")."""
+        """Convert `y` to `self.get_tag("y_inner_type")`."""
         if axis > 1 or axis < 0:
-            raise ValueError(f"Input axis should be 0 or 1, saw {axis}")
+            raise ValueError(f"Input axis should be `0` or `1`, saw {axis}")
 
         inner_type = self.get_tag("y_inner_type")
         if not isinstance(inner_type, list):
@@ -150,7 +150,7 @@ class BaseForecaster(BaseSeriesEstimator):
                     y = y.T
             else:
                 raise ValueError(
-                    f"Unsupported inner type {inner_names[0]} derived from {inner_type}"
+                    f"Unsupported inner type `{inner_names[0]}` derived from `{inner_type}`"
                 )
         if y.ndim > 1 and self.axis != axis:
             y = y.T

--- a/examples/distances/sklearn_distances.ipynb
+++ b/examples/distances/sklearn_distances.ipynb
@@ -1030,7 +1030,7 @@
     "# Make predictions\n",
     "predictions_reg = knn_regressor.predict(X_test_2D_flat[:5])\n",
     "\n",
-    "print(f\"kNN Regressor with DTW distance on time series data: {predictions_reg}\")\n"
+    "print(f\"kNN Regressor with DTW distance on time series data: {predictions_reg}\")"
    ]
   },
   {
@@ -1061,8 +1061,8 @@
     }
    ],
    "source": [
-    "from aeon.distances import pairwise_distance\n",
     "from aeon.datasets import load_arrow_head  # Use a working dataset\n",
+    "from aeon.distances import pairwise_distance\n",
     "\n",
     "# Load example dataset (3D time-series format)\n",
     "X_train_3D, y_train = load_arrow_head(split=\"train\")\n",
@@ -1073,8 +1073,12 @@
     "X_test_2D = X_test_3D.reshape(X_test_3D.shape[0], -1)\n",
     "\n",
     "# Compute DTW distance matrices using \"dtw\" as a method\n",
-    "X_train_dist = pairwise_distance(X_train_3D, X_train_3D, method=\"dtw\")  # ✅ Use \"method\"\n",
-    "X_test_dist = pairwise_distance(X_test_3D, X_train_3D, method=\"dtw\")    # ✅ Ensure consistent shape\n",
+    "X_train_dist = pairwise_distance(\n",
+    "    X_train_3D, X_train_3D, method=\"dtw\"\n",
+    ")  # ✅ Use \"method\"\n",
+    "X_test_dist = pairwise_distance(\n",
+    "    X_test_3D, X_train_3D, method=\"dtw\"\n",
+    ")  # ✅ Ensure consistent shape\n",
     "\n",
     "# Create classifier using computed distances\n",
     "clf = KNeighborsClassifier(n_neighbors=3, metric=\"precomputed\")\n",
@@ -1082,7 +1086,7 @@
     "\n",
     "# Predict and evaluate\n",
     "y_pred = clf.predict(X_test_dist)\n",
-    "print(\"Classification Accuracy:\", accuracy_score(y_test, y_pred))\n"
+    "print(\"Classification Accuracy:\", accuracy_score(y_test, y_pred))"
    ]
   },
   {
@@ -1114,17 +1118,18 @@
    ],
    "source": [
     "from sklearn.cluster import KMeans\n",
+    "\n",
     "from aeon.distances import pairwise_distance\n",
     "\n",
     "# Compute DTW distance matrix\n",
-    "X_dist = pairwise_distance(X_train_3D, X_train_3D, method=\"dtw\")  \n",
+    "X_dist = pairwise_distance(X_train_3D, X_train_3D, method=\"dtw\")\n",
     "\n",
     "# Apply K-Means clustering with precomputed distances\n",
     "kmeans = KMeans(n_clusters=3, random_state=42)\n",
     "labels = kmeans.fit_predict(X_dist)\n",
     "\n",
     "# Display results\n",
-    "print(\"Cluster labels:\", labels)\n"
+    "print(\"Cluster labels:\", labels)"
    ]
   },
   {
@@ -1169,7 +1174,7 @@
     "# Cross-validation on classification pipeline\n",
     "scores = cross_val_score(clf, X_train_dist, y_train, cv=5, scoring=\"accuracy\")\n",
     "print(\"Cross-validation scores:\", scores)\n",
-    "print(\"Mean accuracy:\", scores.mean())\n"
+    "print(\"Mean accuracy:\", scores.mean())"
    ]
   }
  ],

--- a/examples/distances/sklearn_distances.ipynb
+++ b/examples/distances/sklearn_distances.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:23.882870Z",
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:24.416318Z",
@@ -83,7 +83,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training set shape = (50, 1, 150) -> this works with sklearn\n",
+      "Training set shape = (50, 150) -> this works with sklearn\n",
       "kNN with manhattan distance on 2D time series data ['1' '2' '2' '1' '1']\n",
       "\n",
       "Training set shape = (50, 1, 150) -> sklearn will crash as is a 3D array\n",
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:26.806946Z",
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -193,12 +193,12 @@
      "text": [
       "Graph of neighbors for the first pattern in testing set with EDR distance on 2Dtime series data:\n",
       "[[0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.         0.01333333\n",
+      "  0.         0.         0.         0.         0.         0.\n",
+      "  0.         0.         0.         0.         0.01333333 0.\n",
+      "  0.         0.         0.         0.01333333 0.         0.\n",
       "  0.         0.         0.         0.         0.         0.\n",
       "  0.         0.         0.         0.         0.         0.\n",
-      "  0.         0.         0.         0.         0.         0.\n",
-      "  0.         0.         0.         0.         0.         0.\n",
-      "  0.         0.         0.         0.         0.00666667 0.00666667\n",
-      "  0.00666667 0.         0.         0.         0.         0.\n",
       "  0.         0.         0.         0.         0.         0.\n",
       "  0.         0.        ]]\n",
       "Note that [i,j] has the weight of edge that connects i to j.\n",
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:31.418483Z",
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -357,14 +357,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "aeon kNN with MSM distance on 3D MTSC time series data ['standing' 'walking' 'running' 'standing' 'standing']\n",
+      "aeon kNN with MSM distance on 3D MTSC time series data ['standing' 'badminton' 'running' 'standing' 'standing']\n",
       "sklearn kNN with MSM distance on 2D MTSC time series data ['standing' 'badminton' 'running' 'standing' 'standing']\n"
      ]
     }
@@ -404,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:32.354262Z",
@@ -552,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:32.360245Z",
@@ -643,8 +643,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SVC with TWE first five predictions =  ['2' '1' '1' '2' '1']\n",
-      "Time with callable function: 2.102813597768545\n"
+      "SVC with TWE first five predictions =  ['2' '1' '1' '2' '1']\n"
      ]
     }
    ],
@@ -668,15 +667,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SVC with precomputed TWE first five predictions =  ['2' '1' '1' '2' '1']\n",
-      "Time with precomputed distances: 12.786979459226131\n"
+      "SVC with precomputed TWE first five predictions =  ['2' '1' '1' '2' '1']\n"
      ]
     }
    ],
@@ -702,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -768,7 +766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:40.488336Z",
@@ -798,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:41.393371Z",
@@ -866,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:41.472132Z",
@@ -881,7 +879,7 @@
      "text": [
       "Shape (FunctionTransformer) = (67, 67)\n",
       "Shape (msm_pairwise_distance) = (67, 67)\n",
-      "These values are the same 7.595223506000001,  7.595223506000001 and 7.595223506000001.\n"
+      "These values are the same 7.595223506000001, 7.595223506000001 and 7.595223506000001.\n"
      ]
     }
    ],
@@ -919,7 +917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-06-17T23:21:41.503125Z",
@@ -949,6 +947,230 @@
     "    pipe.predict(X)[:5],\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Formatting Guidance\n",
+    "`aeon` works with **3D time-series data**, where:  \n",
+    "- `n_cases` represents the number of samples (time series instances).  \n",
+    "- `n_channels` refers to the number of features or variables measured.  \n",
+    "- `n_timepoints` is the number of time steps in each series.  \n",
+    "\n",
+    "However, **scikit-learn (`sklearn`) algorithms expect 2D input** in the shape of `(n_samples, n_features)`. Since most `sklearn` models cannot directly process 3D time-series data, we must **flatten** each time series from `(n_cases, n_channels, n_timepoints)` into a **2D format** of shape `(n_cases, n_channels * n_timepoints)`.  \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original shape: (50, 1, 150)\n",
+      "Converted shape (for sklearn): (50, 150)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# aeon works with 3D time-series data: (n_cases, n_channels, n_timepoints)\n",
+    "print(f\"Original shape: {X_train_3D.shape}\")\n",
+    "\n",
+    "# Convert 3D to 2D for sklearn compatibility (flatten time series)\n",
+    "X_train_2D_flat = X_train_3D.reshape(X_train_3D.shape[0], -1)\n",
+    "X_test_2D_flat = X_test_3D.reshape(X_test_3D.shape[0], -1)\n",
+    "\n",
+    "print(f\"Converted shape (for sklearn): {X_train_2D_flat.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_train_3D = y_train_3D.astype(float)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using aeon distances in sklearn regression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We apply k-Nearest Neighbors Regression using Dynamic Time Warping (DTW) as the distance metric. The model learns from the preprocessed dataset and predicts continuous values for test instances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kNN Regressor with DTW distance on time series data: [1.  1.8 2.  1.  1.6]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Apply KNeighborsRegressor with DTW distance\n",
+    "knn_regressor = KNeighborsRegressor(metric=dtw_distance)\n",
+    "knn_regressor.fit(X_train_2D_flat, y_train_3D)\n",
+    "\n",
+    "# Make predictions\n",
+    "predictions_reg = knn_regressor.predict(X_test_2D_flat[:5])\n",
+    "\n",
+    "print(f\"kNN Regressor with DTW distance on time series data: {predictions_reg}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using aeon with sklearn for Classification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use k-Nearest Neighbors Classification with Dynamic Time Warping (DTW) to measure similarity between time series data. The classifier is trained on distance matrices and predicts class labels for test samples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classification Accuracy: 0.7085714285714285\n"
+     ]
+    }
+   ],
+   "source": [
+    "from aeon.distances import pairwise_distance\n",
+    "from aeon.datasets import load_arrow_head  # Use a working dataset\n",
+    "\n",
+    "# Load example dataset (3D time-series format)\n",
+    "X_train_3D, y_train = load_arrow_head(split=\"train\")\n",
+    "X_test_3D, y_test = load_arrow_head(split=\"test\")\n",
+    "\n",
+    "# Convert 3D data into 2D (Flatten)\n",
+    "X_train_2D = X_train_3D.reshape(X_train_3D.shape[0], -1)\n",
+    "X_test_2D = X_test_3D.reshape(X_test_3D.shape[0], -1)\n",
+    "\n",
+    "# Compute DTW distance matrices using \"dtw\" as a method\n",
+    "X_train_dist = pairwise_distance(X_train_3D, X_train_3D, method=\"dtw\")  # ✅ Use \"method\"\n",
+    "X_test_dist = pairwise_distance(X_test_3D, X_train_3D, method=\"dtw\")    # ✅ Ensure consistent shape\n",
+    "\n",
+    "# Create classifier using computed distances\n",
+    "clf = KNeighborsClassifier(n_neighbors=3, metric=\"precomputed\")\n",
+    "clf.fit(X_train_dist, y_train)\n",
+    "\n",
+    "# Predict and evaluate\n",
+    "y_pred = clf.predict(X_test_dist)\n",
+    "print(\"Classification Accuracy:\", accuracy_score(y_test, y_pred))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using aeon with sklearn for Clustering"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section applies K-Means clustering to time-series data using the Dynamic Time Warping (DTW) distance as a similarity measure. Instead of raw data, we use precomputed distance matrices, ensuring compatibility with clustering algorithms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cluster labels: [0 0 0 1 0 0 1 0 0 1 0 0 1 0 2 1 2 2 1 0 0 0 0 1 1 0 1 0 0 0 0 0 2 1 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.cluster import KMeans\n",
+    "from aeon.distances import pairwise_distance\n",
+    "\n",
+    "# Compute DTW distance matrix\n",
+    "X_dist = pairwise_distance(X_train_3D, X_train_3D, method=\"dtw\")  \n",
+    "\n",
+    "# Apply K-Means clustering with precomputed distances\n",
+    "kmeans = KMeans(n_clusters=3, random_state=42)\n",
+    "labels = kmeans.fit_predict(X_dist)\n",
+    "\n",
+    "# Display results\n",
+    "print(\"Cluster labels:\", labels)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cross-validation with aeon and sklearn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates **cross-validation** for a classification model using **Dynamic Time Warping (DTW) distances**. Cross-validation helps evaluate model performance by testing on different subsets of the dataset.  \n",
+    "\n",
+    "Steps:  \n",
+    "1. Use **5-fold cross-validation** to train and test the **kNN classifier** with precomputed **DTW distances**.  \n",
+    "2. Compute **accuracy scores** for each fold.  \n",
+    "3. Calculate the **mean accuracy** to assess overall model performance.  \n",
+    "\n",
+    "This ensures a robust evaluation by reducing variance and preventing overfitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cross-validation scores: [0.625      0.85714286 0.71428571 0.57142857 0.57142857]\n",
+      "Mean accuracy: 0.6678571428571429\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example: Cross-validation using aeon distances in sklearn\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "\n",
+    "# Cross-validation on classification pipeline\n",
+    "scores = cross_val_score(clf, X_train_dist, y_train, cv=5, scoring=\"accuracy\")\n",
+    "print(\"Cross-validation scores:\", scores)\n",
+    "print(\"Mean accuracy:\", scores.mean())\n"
+   ]
   }
  ],
  "metadata": {
@@ -967,7 +1189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/examples/forecasting/forecasting.ipynb
+++ b/examples/forecasting/forecasting.ipynb
@@ -350,7 +350,7 @@
     "\n",
     "ets = ETSForecaster()\n",
     "ets.fit(y)\n",
-    "ets.predict()\n"
+    "ets.predict()"
    ],
    "metadata": {
     "collapsed": false,

--- a/examples/transformations/minirocket.ipynb
+++ b/examples/transformations/minirocket.ipynb
@@ -2176,7 +2176,7 @@
     "\n",
     "minirocket_pipeline.score(X_test, y_test)\n",
     "minirocket_pipeline.fit(X_train, y_train)\n",
-    "pred = minirocket_pipeline.predict(X_test)\n"
+    "pred = minirocket_pipeline.predict(X_test)"
    ],
    "outputs": [],
    "execution_count": 18


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #809. This PR addresses inconsistencies in docstring formatting in the `aeon.forecasting` module.

#### What does this implement/fix? Explain your changes.

This pull request resolves an issue with inconsistent use of single and double ticks for code references within docstrings across several files. The issue caused references to code elements like `int`, `RandomState`, and `None` to be inconsistently formatted, leading to confusion in the documentation. All references have now been standardized to use double ticks for consistency and clarity in the documentation. The affected files are:

- `aeon/forecasting/_dummy.py`
- `aeon/forecasting/_ets.py`
- `aeon/forecasting/_regression.py`
- `aeon/forecasting/base.py`

The changes improve the readability and accuracy of the API documentation.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies 

#### Any other comments?

This PR solely focuses on fixing the formatting issues in the docstrings. No functionality has been changed.

### PR checklist

##### For all contributions
- [x] I've added myself to the [[list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc)](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc).
- [x] The PR title starts with [DOC] indicating that it is related to documentation improvements.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [[API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html)](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [[CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS)](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.

