### PR TITLE
[MNT] Use GPU installs for periodic tests

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -70,9 +70,15 @@ jobs:
           python_version: "3.11"
           restore_cache: "false"
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
         with:
-          additional_extras: "dev,binder"
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,binder,dev]
+
+      - name: Show dependencies
+        run: python -m pip list
 
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh false
@@ -182,10 +188,12 @@ jobs:
           python_version: ${{ matrix.python-version }}
           restore_cache: "false"
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install aeon and dependencies
+        uses: nick-fields/retry@v3
         with:
-          python_version: ${{ matrix.python-version }}
-          additional_extras: "dev"
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list
@@ -215,9 +223,12 @@ jobs:
       - name: Disable Numba JIT
         run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install aeon and dependencies
+        uses: nick-fields/retry@v3
         with:
-          additional_extras: "unstable_extras,dev"
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,unstable_extras,dev]
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           additional_extras: "dev,binder"
 
+      - name: Show dependencies
+        run: python -m pip list
+
       - name: Run example notebooks
         run: .github/utilities/run_examples.sh ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full examples run') }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,11 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -95,6 +97,9 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
+
+      - name: Show dependencies
+        run: python -m pip list
 
       - name: Tests
         run: python -m pytest -n logical


### PR DESCRIPTION
In PRs we use the CPU version of `torch`/`tensorflow` for faster installs. Time spent is not as important for the periodic tests, so it would be better to test the regular install use case here. It is possible that there could be subtle differences between these installs i.e. versioning for other dependencies.

May end up reverting if it turns out to be more pain than its worth.