### PR TITLE
[BUG] Fix RDST admissible sampling point method 

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -509,7 +509,7 @@ def _get_admissible_sampling_point(current_mask, random_generator):
         for i in range(n_cases):
             _new_val = idx_choice - current_mask[i].shape[0]
             if _new_val < 0 and current_mask[i].shape[0] > 0:
-                return i, idx_choice
+                return i, current_mask[i][idx_choice]
             idx_choice = _new_val
     else:
         return -1, -1


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2759 

#### What does this implement/fix? Explain your changes.

Fix shapelet sampling point method returning the id of the choice, and not the timestamp linked to the id of the choice.

#### Any other comments?

See #2759 for performance comparison.

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.