### PR TITLE
[DOC] Add Raises section for invalid `weights` in KNeighborsTimeSeriesClassifier (#1766)

### DIFF
--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -52,6 +52,12 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ``-1`` means using all processors.
         for more details. Parameter for compatibility purposes, still unimplemented.
 
+    Raises
+    ------
+    ValueError
+        If ``weights`` is not among the supported values.
+        See the ``weights`` parameter description for valid options.
+
     Examples
     --------
     >>> from aeon.datasets import load_unit_test


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses part of #1766.

#### What does this implement/fix? Explain your changes.

Adds the "Raises" section to the `__init__` docstring of `KNeighborsTimeSeriesClassifier`.
Documents the verified `ValueError` raised during initialization when an unsupported string or an invalid callable is provided to the `weights` parameter.

This update improves user guidance by clarifying expected exceptions and aligns with Aeon's documentation standards.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies introduced.

#### Any other comments?

This contribution is part of my preparation and engagement for GSoC 2025, aligned with Aeon's project list.  
I am grateful for any feedback to improve this PR and my future contributions.

### PR checklist

- [x] The PR title starts with [DOC] as per contribution guidelines.
- [x] The change improves documentation clarity without introducing code changes.
- [x] No new dependencies added.
