### PR TITLE
[ENH] Added load_model functionality to InceptionTimeRegressor and LITETimeRegressor

### DIFF
--- a/aeon/regression/deep_learning/_inception_time.py
+++ b/aeon/regression/deep_learning/_inception_time.py
@@ -337,6 +337,37 @@ class InceptionTimeRegressor(BaseRegressor):
         return ypreds
 
     @classmethod
+    def load_model(cls, model_paths):
+        """
+        Load pre-trained regressors instead of fitting.
+
+        This enables full use of the estimator's functionality such as predict.
+
+        Parameters
+        ----------
+        model_paths : list of str (list of paths including the model names and extension)
+            List of file paths to the saved .keras models of each regressor.
+
+        Returns
+        -------
+        InceptionTimeRegressor
+            An instance of InceptionTimeRegressor with the pre-trained models loaded.
+        """
+        assert isinstance(model_paths, list), "model_paths should be a list of paths to the models"
+
+        regressor = cls(n_regressors=len(model_paths))
+        regressor.regressors_ = []
+
+        for i, path in enumerate(model_paths):
+            # Create a dummy model just to load into
+            ind_regressor = IndividualInceptionRegressor()
+            ind_regressor.load_model(path)
+            regressor.regressors_.append(ind_regressor)
+
+        regressor.is_fitted = True
+        return regressor
+
+    @classmethod
     def _get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
 

--- a/aeon/regression/deep_learning/_lite_time.py
+++ b/aeon/regression/deep_learning/_lite_time.py
@@ -263,6 +263,37 @@ class LITETimeRegressor(BaseRegressor):
         return vals
 
     @classmethod
+    def load_model(cls, model_paths):
+        """
+        Load pre-trained regressors instead of fitting.
+
+        This enables full use of the estimator's functionality such as predict.
+
+        Parameters
+        ----------
+        model_paths : list of str (list of paths including the model names and extension)
+            List of file paths to the saved .keras models of each regressor.
+
+        Returns
+        -------
+        LITETimeRegressor
+            An instance of LITETimeRegressor with the pre-trained models loaded.
+        """
+        assert isinstance(model_paths, list), "model_paths should be a list of paths to the models"
+
+        regressor = cls(n_regressors=len(model_paths))
+        regressor.regressors_ = []
+
+        for i, path in enumerate(model_paths):
+            # Create a dummy model just to load into
+            ind_regressor = IndividualLITERegressor()
+            ind_regressor.load_model(path)
+            regressor.regressors_.append(ind_regressor)
+
+        regressor.is_fitted = True
+        return regressor
+
+    @classmethod
     def _get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
 

--- a/aeon/regression/deep_learning/tests/test_inception_time.py
+++ b/aeon/regression/deep_learning/tests/test_inception_time.py
@@ -1,0 +1,51 @@
+"""Tests for save/load functionality of InceptionTimeRegressor."""
+
+import glob
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from aeon.regression.deep_learning import InceptionTimeRegressor
+from aeon.testing.data_generation import make_example_3d_numpy
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("tensorflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_save_load_inceptiontime_regressor():
+    """Test saving and loading for InceptionTimeRegressor."""
+    with tempfile.TemporaryDirectory() as temp:
+        temp_dir = os.path.join(temp, "")
+
+        X, y = make_example_3d_numpy(
+            n_cases=10, n_channels=1, n_timepoints=12, return_y=True, regression_target=True
+        )
+
+        model = InceptionTimeRegressor(
+            n_epochs=1,
+            random_state=42,
+            save_best_model=True,
+            file_path=temp_dir,
+            n_regressors=1,
+        )
+        model.fit(X, y)
+
+        y_pred_orig = model.predict(X)
+
+        model_files = glob.glob(os.path.join(temp_dir, f"{model.best_file_name}*.keras"))
+
+        loaded_model = InceptionTimeRegressor.load_model(
+            model_paths=model_files
+        )
+
+        assert isinstance(loaded_model, InceptionTimeRegressor)
+
+        preds = loaded_model.predict(X)
+        assert isinstance(preds, np.ndarray)
+
+        assert len(preds) == len(y)
+        np.testing.assert_array_almost_equal(preds, y_pred_orig, decimal=4)

--- a/aeon/regression/deep_learning/tests/test_lite_time.py
+++ b/aeon/regression/deep_learning/tests/test_lite_time.py
@@ -1,0 +1,51 @@
+"""Tests for save/load functionality of LITETimeRegressor."""
+
+import glob
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from aeon.regression.deep_learning import LITETimeRegressor
+from aeon.testing.data_generation import make_example_3d_numpy
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("tensorflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_save_load_litetimeregressor_regressor():
+    """Test saving and loading for LITETimeRegressor."""
+    with tempfile.TemporaryDirectory() as temp:
+        temp_dir = os.path.join(temp, "")
+
+        X, y = make_example_3d_numpy(
+            n_cases=10, n_channels=1, n_timepoints=12, return_y=True, regression_target=True
+        )
+
+        model = LITETimeRegressor(
+            n_epochs=1,
+            random_state=42,
+            save_best_model=True,
+            file_path=temp_dir,
+            n_regressors=1,
+        )
+        model.fit(X, y)
+
+        y_pred_orig = model.predict(X)
+
+        model_files = glob.glob(os.path.join(temp_dir, f"{model.best_file_name}*.keras"))
+
+        loaded_model = LITETimeRegressor.load_model(
+            model_paths=model_files
+        )
+
+        assert isinstance(loaded_model, LITETimeRegressor)
+
+        preds = loaded_model.predict(X)
+        assert isinstance(preds, np.ndarray)
+
+        assert len(preds) == len(y)
+        np.testing.assert_array_almost_equal(preds, y_pred_orig, decimal=4)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs
#2770
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
Added load_model functionality to InceptionTimeRegressor and LITETimeRegressor
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
