### PR TITLE
[ENH] Add missing checks to base transformers and tidy

### DIFF
--- a/aeon/transformations/base.py
+++ b/aeon/transformations/base.py
@@ -5,6 +5,9 @@ __all__ = ["BaseTransformer"]
 
 from abc import abstractmethod
 
+import numpy as np
+import pandas as pd
+
 from aeon.base import BaseAeonEstimator
 
 
@@ -90,3 +93,22 @@ class BaseTransformer(BaseAeonEstimator):
             Additional data, e.g., labels for transformation.
         """
         ...
+
+    def _check_y(self, y, n_cases=None):
+        # Check y valid input for supervised transform
+        if not isinstance(y, (pd.Series, np.ndarray)):
+            raise TypeError(
+                f"y must be a np.array or a pd.Series, but found type: {type(y)}"
+            )
+
+        if isinstance(y, np.ndarray) and y.ndim > 1:
+            raise TypeError(f"y must be 1-dimensional, found {y.ndim} dimensions")
+
+        if n_cases is not None:
+            # Check matching number of labels
+            n_labels = y.shape[0]
+            if n_cases != n_labels:
+                raise ValueError(
+                    f"Mismatch in number of cases. Number in X = {n_cases} nos in y = "
+                    f"{n_labels}"
+                )

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -19,7 +19,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
-__maintainer__ = []
+__maintainer__ = ["MatthewMiddlehurst"]
 __all__ = [
     "BaseCollectionTransformer",
 ]
@@ -27,17 +27,15 @@ __all__ = [
 from abc import abstractmethod
 from typing import final
 
-import numpy as np
-import pandas as pd
-
 from aeon.base import BaseCollectionEstimator
 from aeon.transformations.base import BaseTransformer
+from aeon.utils.validation import get_n_cases
 
 
 class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
     """Transformer base class for collections."""
 
-    # tag values specific to CollectionTransformers
+    # default tag values for collection transformers
     _tags = {
         "input_data_type": "Collection",
         "output_data_type": "Collection",
@@ -84,22 +82,25 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         -------
         self : a fitted instance of the estimator
         """
-        if self.get_tag("requires_y"):
-            if y is None:
-                raise ValueError("Tag requires_y is true, but fit called with y=None")
-        # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
             self.is_fitted = True
             return self
+
+        if self.get_tag("requires_y"):
+            if y is None:
+                raise ValueError("Tag requires_y is true, but fit called with y=None")
+
+        # reset estimator at the start of fit
         self.reset()
 
         # input checks and datatype conversion
-        X_inner = self._preprocess_collection(X)
-        y_inner = y
-        self._fit(X=X_inner, y=y_inner)
+        X = self._preprocess_collection(X, store_metadata=True)
+        if y is not None:
+            self._check_y(y, n_cases=self.metadata_["n_cases"])
+
+        self._fit(X=X, y=y)
 
         self.is_fitted = True
-
         return self
 
     @final
@@ -139,18 +140,19 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         -------
         transformed version of X
         """
-        # check whether is fitted
-        self._check_is_fitted()
+        fit_empty = self.get_tag("fit_is_empty")
+        if not fit_empty:
+            self._check_is_fitted()
 
-        # input check and conversion for X/y
-        X_inner = self._preprocess_collection(X, store_metadata=False)
-        y_inner = y
+        # input checks and datatype conversion
+        X = self._preprocess_collection(X, store_metadata=False)
+        if y is not None:
+            self._check_y(y, n_cases=get_n_cases(X))
 
-        if not self.get_tag("fit_is_empty"):
+        if not fit_empty:
             self._check_shape(X)
 
-        Xt = self._transform(X=X_inner, y=y_inner)
-
+        Xt = self._transform(X, y)
         return Xt
 
     @final
@@ -192,14 +194,21 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         -------
         transformed version of X
         """
-        # input checks and datatype conversion
+        if self.get_tag("requires_y"):
+            if y is None:
+                raise ValueError("Tag requires_y is true, but fit called with y=None")
+
+        # reset estimator at the start of fit
         self.reset()
-        X_inner = self._preprocess_collection(X)
-        y_inner = y
-        Xt = self._fit_transform(X=X_inner, y=y_inner)
+
+        # input checks and datatype conversion
+        X = self._preprocess_collection(X, store_metadata=True)
+        if y is not None:
+            self._check_y(y, n_cases=self.metadata_["n_cases"])
+
+        Xt = self._fit_transform(X=X, y=y)
 
         self.is_fitted = True
-
         return Xt
 
     @final
@@ -297,6 +306,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         -------
         transformed version of X
         """
+        ...
 
     def _fit_transform(self, X, y=None):
         """Fit to data, then transform it.
@@ -340,42 +350,4 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support inverse_transform"
-        )
-
-    def _update(self, X, y=None):
-        """Update transformer with X and y.
-
-        private _update containing the core logic, called from update
-
-        Parameters
-        ----------
-        X : Input data
-            Data to fit transform to, of valid collection type.
-        y : Target variable, default=None
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        self: a fitted instance of the estimator.
-        """
-        # standard behaviour: no update takes place, new data is ignored
-        return self
-
-
-def _check_y(self, y, n_cases):
-    if y is None:
-        return None
-    # Check y valid input for collection transformations
-    if not isinstance(y, (pd.Series, np.ndarray)):
-        raise TypeError(
-            f"y must be a np.array or a pd.Series, but found type: {type(y)}"
-        )
-    if isinstance(y, np.ndarray) and y.ndim > 1:
-        raise TypeError(f"y must be 1-dimensional, found {y.ndim} dimensions")
-    # Check matching number of labels
-    n_labels = y.shape[0]
-    if n_cases != n_labels:
-        raise ValueError(
-            f"Mismatch in number of cases. Number in X = {n_cases} nos in y = "
-            f"{n_labels}"
         )

--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -11,9 +11,6 @@ fit & transform - fit_transform(self, X, y=None)
 from abc import abstractmethod
 from typing import final
 
-import numpy as np
-import pandas as pd
-
 from aeon.base import BaseSeriesEstimator
 from aeon.transformations.base import BaseTransformer
 
@@ -21,7 +18,7 @@ from aeon.transformations.base import BaseTransformer
 class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
     """Transformer base class for collections."""
 
-    # tag values specific to SeriesTransformers
+    # default tag values for series transformers
     _tags = {
         "input_data_type": "Series",
         "output_data_type": "Series",
@@ -58,19 +55,24 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
         -------
         self : a fitted instance of the estimator
         """
-        # skip the rest if fit_is_empty is True
         if self.get_tag("fit_is_empty"):
             self.is_fitted = True
             return self
+
         if self.get_tag("requires_y"):
             if y is None:
                 raise ValueError("Tag requires_y is true, but fit called with y=None")
+
         # reset estimator at the start of fit
         self.reset()
+
+        # input checks and datatype conversion
         X = self._preprocess_series(X, axis=axis, store_metadata=True)
         if y is not None:
             self._check_y(y)
+
         self._fit(X=X, y=y)
+
         self.is_fitted = True
         return self
 
@@ -101,9 +103,18 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
         transformed version of X with the same axis as passed by the user, if axis
         not None.
         """
-        # check whether is fitted
-        self._check_is_fitted()
+        fit_empty = self.get_tag("fit_is_empty")
+        if not fit_empty:
+            self._check_is_fitted()
+
         X = self._preprocess_series(X, axis=axis, store_metadata=False)
+        if y is not None:
+            self._check_y(y)
+
+        # #2768
+        # if not fit_empty:
+        #     self._check_shape(X)
+
         Xt = self._transform(X, y)
         return self._postprocess_series(Xt, axis=axis)
 
@@ -137,10 +148,20 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
         transformed version of X with the same axis as passed by the user, if axis
         not None.
         """
-        # input checks and datatype conversion, to avoid doing in both fit and transform
+        if self.get_tag("requires_y"):
+            if y is None:
+                raise ValueError("Tag requires_y is true, but fit called with y=None")
+
+        # reset estimator at the start of fit
         self.reset()
+
+        # input checks and datatype conversion
         X = self._preprocess_series(X, axis=axis, store_metadata=True)
+        if y is not None:
+            self._check_y(y)
+
         Xt = self._fit_transform(X=X, y=y)
+
         self.is_fitted = True
         return self._postprocess_series(Xt, axis=axis)
 
@@ -263,7 +284,8 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
         """
         # Non-optimized default implementation; override when a better
         # method is possible for a given algorithm.
-        return self._fit(X, y)._transform(X, y)
+        self._fit(X, y)
+        return self._transform(X, y)
 
     def _inverse_transform(self, X, y=None):
         """Inverse transform X and return an inverse transformed version.
@@ -325,12 +347,3 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
             return Xt
         else:
             return Xt.T
-
-    def _check_y(self, y):
-        # Check y valid input for supervised transform
-        if not isinstance(y, (pd.Series, np.ndarray)):
-            raise TypeError(
-                f"y must be a np.array or a pd.Series, but found type: {type(y)}"
-            )
-        if isinstance(y, np.ndarray) and y.ndim > 1:
-            raise TypeError(f"y must be 1-dimensional, found {y.ndim} dimensions")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Adds some missing checks to transformers i.e. `_check_y` and a call to `self.get_tag("fit_is_empty")` in transform before checking if fitted (allows use of just `transform` when the tag is true).

Formats the fit and transform methods similarly for both classes.


