### PR TITLE
[BUG] Fix a bug in ClaSP Series Transformer when using floatXX as Input (where XX != 64)

### DIFF
--- a/aeon/transformations/series/_clasp.py
+++ b/aeon/transformations/series/_clasp.py
@@ -479,9 +479,18 @@ class ClaSPTransformer(BaseSeriesTransformer):
                 "Period-Length is larger than size of the time series", stacklevel=1
             )
 
+        if X.dtype != np.float64:
+            warnings.warn(
+                f"dtype is {X.dtype} but should be {np.float64}. "
+                f"Will apply conversion to float64 now",
+                stacklevel=1,
+            )
+
         scoring_metric_call = self._check_scoring_metric(self.scoring_metric)
 
-        X = X.flatten()
+        # The input has to be of type float64
+        X = X.flatten().astype(np.float64)
+
         Xt, _ = clasp(
             X,
             self.window_length,

--- a/aeon/transformations/series/tests/test_clasp.py
+++ b/aeon/transformations/series/tests/test_clasp.py
@@ -1,0 +1,19 @@
+"""Test ClaSP series transformer."""
+
+import numpy as np
+
+from aeon.transformations.series import ClaSPTransformer
+
+
+def test_clasp():
+    """Test ClaSP series transformer returned size."""
+    for dtype in [np.float64, np.float32, np.float16]:
+        series = np.arange(100, dtype=dtype)
+        clasp = ClaSPTransformer()
+        profile = clasp.fit_transform(series)
+
+        m = len(series) - clasp.window_length + 1
+        assert np.float64 == profile.dtype
+        assert m == len(profile)
+
+        # print(f"Input {series.dtype} Output {profile.dtype} {m==len(profile)}")


### PR DESCRIPTION
#### Reference Issues/PRs

The issue was raised in slack. 

```python

clasp = ClaSPSegmenter(period_length=dominant_period_size, n_cps=10)
found_cps = clasp.fit_predict(depth_ts) # Note this timeseries is of type float32
profiles = clasp.profiles
scores = clasp.scores

```

This causes a TypingError

#### What does this implement/fix? Explain your changes.

This fixes an issue with with using input time series of a data type different from float64. This caused an error with numba typing.

#### Does your contribution introduce a new dependency? If yes, which one?

No 