### PR TITLE
[GOV] Supporting Developer role

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -26,7 +26,7 @@ process.
 ### Supporting Developers
 
 Supporting developers are contributors who have been nominated by a core developer
-and granted write access to the aeon repository. No vote is required for this role,
+and granted write access to the `aeon` repository. No vote is required for this role,
 but the nominator must notify the Core Developers and create a Pull Request.
 Supporting developers can have their access revoked at any time by a core developer
 if it is determined that they are abusing this access. Access will also be removed

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -25,11 +25,11 @@ process.
 
 ### Supporting Developers
 
-Supporting developers are contributors who have been nominated by a core developer 
-and granted write access to the aeon repository. No vote is required for this role, 
-but the nominator must notify the Core Developers and create a Pull Request. 
-Supporting developers can have their access revoked at any time by a core developer 
-if it is determined that they are abusing this access. Access will also be removed 
+Supporting developers are contributors who have been nominated by a core developer
+and granted write access to the aeon repository. No vote is required for this role,
+but the nominator must notify the Core Developers and create a Pull Request.
+Supporting developers can have their access revoked at any time by a core developer
+if it is determined that they are abusing this access. Access will also be removed
 after 6 months of inactivity.
 
 ### Core Developers

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -23,7 +23,7 @@ as detailed in the contributing guide. Contributors play a crucial role in shapi
 project through participating in discussions and influencing the decision-making
 process.
 
-### Supporting Developer
+### Supporting Developers
 
 Supporting developers are contributors who have been nominated by a core developer
 and have been granted write access to the `aeon` repository. No vote is required for

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -25,11 +25,11 @@ process.
 
 ### Supporting Developers
 
-Supporting developers are contributors who have been nominated by a core developer
-and have been granted write access to the `aeon` repository. No vote is required for
-this role, but the nominator must notify Core Developers and creat a Pull Request.
-Supporting developers can have access revoked at any time by a core developer if
-determined to be abusing this access. Supporting developers will have access removed
+Supporting developers are contributors who have been nominated by a core developer 
+and granted write access to the aeon repository. No vote is required for this role, 
+but the nominator must notify the Core Developers and create a Pull Request. 
+Supporting developers can have their access revoked at any time by a core developer 
+if it is determined that they are abusing this access. Access will also be removed 
 after 6 months of inactivity.
 
 ### Core Developers

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -23,6 +23,14 @@ as detailed in the contributing guide. Contributors play a crucial role in shapi
 project through participating in discussions and influencing the decision-making
 process.
 
+### Supporting Developer
+
+Supporting developers are contributors who have been nominated by a core developer
+and have been granted write access to the `aeon` repository. No vote is required for
+this role. Supporting developers can have access revoked at any time by a core
+developer if determined to be abusing this access. Supporting developers will have
+access removed after 6 months of inactivity.
+
 ### Core Developers
 
 Core developers are community members that have made significant contributions and are

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -27,9 +27,10 @@ process.
 
 Supporting developers are contributors who have been nominated by a core developer
 and have been granted write access to the `aeon` repository. No vote is required for
-this role. Supporting developers can have access revoked at any time by a core
-developer if determined to be abusing this access. Supporting developers will have
-access removed after 6 months of inactivity.
+this role, but the nominator must notify Core Developers and creat a Pull Request.
+Supporting developers can have access revoked at any time by a core developer if
+determined to be abusing this access. Supporting developers will have access removed
+after 6 months of inactivity.
 
 ### Core Developers
 


### PR DESCRIPTION
Adds a new role which is essentially just giving a person write access. Difference from core devs:

- No access to the core developer or voting Slack channels
- Any core dev can nominate someone for the role, just have to notify other developers in Slack and make a PR
- No vote as long as there is no veto by any core developer. That veto right remains for the duration and can be invoked if anyone thinks they are a detriment (i.e. acting like an ass or abusing review powers)
- Removed with inactivity

Essentially a stepping stone between regular contributor and core dev. Main target would be stuff like PhD students, interns or just people we want to get a bit more involved in the project without going through the whole process. Of course if people want to become core devs the same process still exists.