### PR TITLE
Fix codeowners for AD metrics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 aeon/anomaly_detection/ @SebastianSchmidl @MatthewMiddlehurst
 
 aeon/benchmarking/ @TonyBagnall @MatthewMiddlehurst @hadifawaz1999 @dguijo
+aeon/benchmarking/metrics/anomaly_detection/ @SebastianSchmidl @MatthewMiddlehurst
 
 aeon/classification/ @MatthewMiddlehurst @TonyBagnall
 aeon/classification/deep_learning/ @hadifawaz1999 @MatthewMiddlehurst @TonyBagnall
@@ -16,8 +17,6 @@ aeon/clustering/ @chrisholder @TonyBagnall
 aeon/distances/ @chrisholder @TonyBagnall
 
 aeon/networks/ @hadifawaz1999
-
-aeon/performance_metrics/anomaly_detection/ @SebastianSchmidl @MatthewMiddlehurst
 
 aeon/regression/ @MatthewMiddlehurst @TonyBagnall @dguijo
 aeon/regression/deep_learning @hadifawaz1999 @MatthewMiddlehurst @TonyBagnall @dguijo


### PR DESCRIPTION
We moved the metrics into the `benchmarking` module. However, we forgot to update the `CODEOWNERS`-file, respectively. It's now fixed.
