### PR TITLE
[DOC] Add SomtoOnyekwelu to .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2701,6 +2701,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "SomtoOnyekwelu",
+      "name": "Somtochukwu Benedict Onyekwelu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/117727947?v=4",
+      "profile": "https://github.com/SomtoOnyekwelu",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "commitType": "docs"


### PR DESCRIPTION
#### Reference Issues/PRs

#2764 

#### What does this implement/fix? Explain your changes.

It includes SomtoOnyekwelu to the list of aeon contributors, following the merging of #2764 .

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?
aeon, I am grateful for this opportunity to contribute to open source.

### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x ] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions


##### For developers with write access

