### PR TITLE
[BUG] Better error message for Rotation Forest with no usable attributes

### DIFF
--- a/aeon/classification/sklearn/_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/_rotation_forest_classifier.py
@@ -326,7 +326,10 @@ class RotationForestClassifier(ClassifierMixin, BaseEstimator):
 
         # remove useless attributes
         self._useful_atts = ~np.all(X[1:] == X[:-1], axis=0)
-        X = X[:, self._useful_atts]
+        if sum(self._useful_atts) == 0:
+            raise ValueError(
+                "All attributes in X contain the same value.",
+            )
 
         self._n_atts = X.shape[1]
 

--- a/aeon/classification/sklearn/tests/test_rotation_forest_classifier.py
+++ b/aeon/classification/sklearn/tests/test_rotation_forest_classifier.py
@@ -6,7 +6,6 @@ from sklearn.metrics import accuracy_score
 
 from aeon.classification.sklearn import RotationForestClassifier
 from aeon.datasets import load_unit_test
-from aeon.testing.data_generation import make_example_3d_numpy
 
 
 def test_rotf_output():
@@ -88,8 +87,10 @@ def test_rotf_fit_predict():
 def test_rotf_input():
     """Test RotF with incorrect input."""
     rotf = RotationForestClassifier()
-    X2 = rotf._check_X(np.random.random((10, 1, 100)))
-    assert X2.shape == (10, 100)
+
+    X = rotf._check_X(np.random.random((10, 1, 100)))
+    assert X.shape == (10, 100)
+
     with pytest.raises(
         ValueError, match="RotationForestClassifier is not a time series classifier"
     ):
@@ -98,4 +99,10 @@ def test_rotf_input():
         ValueError, match="RotationForestClassifier is not a time series classifier"
     ):
         rotf._check_X([[1, 2, 3], [4, 5], [6, 7, 8]])
-    X, y = make_example_3d_numpy()
+
+    X2 = np.zeros((10, 10))
+    y = np.zeros(10)
+    y[0:5] = 1
+
+    with pytest.raises(ValueError, match="All attributes in X contain the same value."):
+        rotf.fit_predict(X2, y)

--- a/aeon/regression/sklearn/_rotation_forest_regressor.py
+++ b/aeon/regression/sklearn/_rotation_forest_regressor.py
@@ -240,7 +240,10 @@ class RotationForestRegressor(RegressorMixin, BaseEstimator):
 
         # remove useless attributes
         self._useful_atts = ~np.all(X[1:] == X[:-1], axis=0)
-        X = X[:, self._useful_atts]
+        if sum(self._useful_atts) == 0:
+            raise ValueError(
+                "All attributes in X contain the same value.",
+            )
 
         self._n_atts = X.shape[1]
 

--- a/aeon/regression/sklearn/tests/test_rotation_forest_regressor.py
+++ b/aeon/regression/sklearn/tests/test_rotation_forest_regressor.py
@@ -3,6 +3,7 @@
 __maintainer__ = ["MatthewMiddlehurst"]
 
 import numpy as np
+import pytest
 from sklearn.metrics import mean_squared_error
 from sklearn.tree import DecisionTreeRegressor
 
@@ -84,3 +85,27 @@ def test_rotf_fit_predict():
     y_pred = rotf.predict(X_train)
     assert isinstance(y_pred, np.ndarray)
     assert len(y_pred) == len(y_train)
+
+
+def test_rotf_input():
+    """Test RotF with incorrect input."""
+    rotf = RotationForestRegressor()
+
+    X = rotf._check_X(np.random.random((10, 1, 100)))
+    assert X.shape == (10, 100)
+
+    with pytest.raises(
+        ValueError, match="RotationForestRegressor is not a time series regressor"
+    ):
+        rotf._check_X(np.random.random((10, 10, 100)))
+    with pytest.raises(
+        ValueError, match="RotationForestRegressor is not a time series regressor"
+    ):
+        rotf._check_X([[1, 2, 3], [4, 5], [6, 7, 8]])
+
+    X2 = np.zeros((10, 10))
+    y = np.zeros(10)
+    y[0:5] = 1
+
+    with pytest.raises(ValueError, match="All attributes in X contain the same value."):
+        rotf.fit_predict(X2, y)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2787

#### What does this implement/fix? Explain your changes.

Raises an error when there are no usable attributes and adds a test. If this happens it will fail less gracefully later down the line currently.

