### PR TITLE
[MNT] Lower bound keras to discard old bugged versions of early keras3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,12 +70,14 @@ all_extras = [
     "statsmodels>=0.12.1",
     "stumpy>=1.5.1",
     "tensorflow>=2.14; python_version < '3.13'",
+    "keras>=3.6.0; python_version < '3.13'",
     "torch>=1.13.1",
     "tsfresh>=0.20.0",
     "tslearn>=0.5.2",
 ]
 dl = [
     "tensorflow>=2.14; python_version < '3.13'",
+    "keras>=3.6.0; python_version < '3.13'",
 ]
 unstable_extras = [
     # requires gcc and fftw to be installed for Windows and some other OS (see http://www.fftw.org/index.html)


### PR DESCRIPTION
The beginning of keras3 had lots of bugs, logical because of the huge change, but i prefer adding a lower bound, as the more i use older version than 3.6.0 the more i notice bugs that can lead to false research results

Example:

with keras 3.0 it discards the "trainable" boolean of a tensorflow operation, making for instance LITE work differently (unreported issue).

This is to archive for future references