### PR TITLE
[ENH] Fix data loader

### DIFF
--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -1342,7 +1342,7 @@ def load_classification(
             try_zenodo = False
             error_str = (
                 f"Invalid dataset name ={name} that is not available on extract path "
-                f"={extract_path}. Nor is it available on "
+                f"={extract_path} nor is it available on "
                 f"https://timeseriesclassification.com/ or zenodo."
             )
             try:

--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -546,7 +546,7 @@ def _load_tsc_dataset(
             except zipfile.BadZipFile as e:
                 raise ValueError(
                     f"Invalid dataset name ={name} is not available on extract path ="
-                    f"{extract_path}. Nor is it available on {url}",
+                    f"{extract_path} nor is it available on {url}",
                 ) from e
 
     return _load_saved_dataset(

--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -468,15 +468,17 @@ def _download_and_extract(url, extract_path=None):
         extract_path = os.path.join(extract_path, "%s/" % file_name.split(".")[0])
 
     try:
-        if not os.path.exists(extract_path):
+        already_exists = os.path.exists(extract_path)
+        if not already_exists:
             os.makedirs(extract_path)
         zipfile.ZipFile(zip_file_name, "r").extractall(extract_path)
         shutil.rmtree(dl_dir)
         return extract_path
     except zipfile.BadZipFile:
         shutil.rmtree(dl_dir)
-        if os.path.exists(extract_path):
-            shutil.rmtree(extract_path)
+        if not already_exists:
+            if os.path.exists(extract_path):
+                shutil.rmtree(extract_path)
         raise zipfile.BadZipFile(
             "Could not unzip dataset. Please make sure the URL is valid."
         )

--- a/aeon/datasets/tests/test_data_loaders.py
+++ b/aeon/datasets/tests/test_data_loaders.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 from urllib.error import URLError
+from zipfile import BadZipFile
 
 import numpy as np
 import pandas as pd
@@ -24,6 +25,7 @@ from aeon.datasets import (
 from aeon.datasets._data_loaders import (
     CONNECTION_ERRORS,
     _alias_datatype_check,
+    _download_and_extract,
     _get_channel_strings,
     _load_data,
     _load_header_info,
@@ -551,3 +553,21 @@ def test_load_tsc_dataset():
         assert isinstance(X, np.ndarray) and isinstance(y, np.ndarray)
         with pytest.raises(ValueError, match="Invalid dataset name"):
             _load_tsc_dataset("FOO", split="TEST", extract_path=tmp)
+
+
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of intermittent fail for read/write",
+)
+@pytest.mark.xfail(raises=(URLError, TimeoutError, ConnectionError))
+def test_download_and_extract():
+    """Test that the function does not delete a directory if already present."""
+    name = "Foo"
+    with tempfile.TemporaryDirectory() as tmp:
+        extract_path = os.path.join(tmp, name)
+        os.makedirs(extract_path)
+        url = "https://timeseriesclassification.com/aeon-toolkit/%s.zip" % name
+        try:
+            _download_and_extract(url, extract_path=extract_path)
+        except BadZipFile:
+            assert os.path.exists(extract_path)


### PR DESCRIPTION
Fixes #2755 

The data loader covers a lot of edge cases and Im sure could be completely redesigned with some benefit, but its not fun. Follows standard format of <name>/<name>_TRAIN.ts and <name>/<name>_TEST.ts 

The problem comes when trying to load local data with
```
from aeon.datasets import load_classification
X, y = load_classification(name= "FOO", extract_path="C:\\Temp\\")
```
Not its fine to load a dataset with load_from_ts_file, this is just when using load_classification, because of some assumptions and too many alternatives. The basic logic is to look in a location for the requested dataset in a directory <name> at location <extract_path>. It calls ```get_downloaded_tsc_tsr_datasets`` which returns a list of valid directories. To be valid, you need to have BOTH _train and _tesgt

The problem here arises when there is a local directory, but it does not contain train and test files. The function then tries to download the zip from tsc.com or zenodo using _download_and_extract. Here there is a case when it will create a directory if not present to put the zip in then attempt to unzip, since for legacy reasons, the zips do not internally contain a directory.

Anyway, long story short, this now only deletes the <name> directory if it was not already present and had thus been created at the attempted download

