### PR TITLE
[ENH] Adds a check for consistent output for predict and predict_proba

### DIFF
--- a/aeon/testing/estimator_checking/_yield_classification_checks.py
+++ b/aeon/testing/estimator_checking/_yield_classification_checks.py
@@ -374,3 +374,10 @@ def check_classifier_output(estimator, datatype):
     # check predict proba (all classifiers have predict_proba by default)
     y_proba = estimator.predict_proba(FULL_TEST_DATA_DICT[datatype]["test"][0])
     _assert_predict_probabilities(y_proba, datatype, n_classes=len(unique_labels))
+
+    y_pred_proba = np.argmax(y_proba, axis=1)
+    _assert_predict_labels(y_pred_proba, datatype, unique_labels=unique_labels)
+
+    np.testing.assert_array_equal(
+        y_pred, y_pred_proba, err_msg="predict and predict_proba are not consistent"
+    )

--- a/aeon/testing/estimator_checking/_yield_clustering_checks.py
+++ b/aeon/testing/estimator_checking/_yield_clustering_checks.py
@@ -141,6 +141,15 @@ def check_clusterer_output(estimator, datatype):
     assert isinstance(y_proba, np.ndarray)
     np.testing.assert_almost_equal(y_proba.sum(axis=1), 1, decimal=4)
 
+    # check predict and predict_proba have consistent outputs
+    y_pred_proba = np.argmax(y_proba, axis=1)
+
+    np.testing.assert_array_equal(
+        y_pred,
+        y_pred_proba,
+        err_msg="predict and predict_proba outputs are inconsistent",
+    )
+
 
 def check_clusterer_saving_loading_deep_learning(estimator_class, datatype):
     """Test Deep Clusterer saving."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Fixed #2802 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

Adds a check to ensure that outputs produced by `predict()` and `predict_proba()` are consistent for the `classification` and `clustering` estimators.

<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

No

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
