### PR TITLE
[ENH] Series transformer pipeline and datatype list tidy

### DIFF
--- a/aeon/anomaly_detection/base.py
+++ b/aeon/anomaly_detection/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from aeon.base import BaseSeriesEstimator
-from aeon.base._base_series import VALID_SERIES_INPUT_TYPES
+from aeon.utils.data_types import VALID_SERIES_INPUT_TYPES
 
 
 class BaseAnomalyDetector(BaseSeriesEstimator):

--- a/aeon/base/_base_series.py
+++ b/aeon/base/_base_series.py
@@ -37,13 +37,7 @@ import numpy as np
 import pandas as pd
 
 from aeon.base._base import BaseAeonEstimator
-
-# allowed input and internal data types for Series
-VALID_SERIES_INNER_TYPES = [
-    "np.ndarray",
-    "pd.DataFrame",
-]
-VALID_SERIES_INPUT_TYPES = [pd.DataFrame, pd.Series, np.ndarray]
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
 
 
 class BaseSeriesEstimator(BaseAeonEstimator):

--- a/aeon/base/_compose.py
+++ b/aeon/base/_compose.py
@@ -5,7 +5,7 @@ __all__ = ["ComposableEstimatorMixin"]
 
 from abc import ABC, abstractmethod
 
-from aeon.base import BaseAeonEstimator
+from aeon.base import BaseAeonEstimator, BaseCollectionEstimator
 from aeon.base._base import _clone_estimator
 
 
@@ -26,8 +26,11 @@ class ComposableEstimatorMixin(ABC):
     _fitted_estimators_attr = "estimators_"
 
     @abstractmethod
-    def __init__(self):
-        super().__init__()
+    def __init__(self, axis):
+        if isinstance(self, BaseCollectionEstimator):
+            super().__init__()
+        else:
+            super().__init__(axis=axis)
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/aeon/base/_estimators/compose/_commons.py
+++ b/aeon/base/_estimators/compose/_commons.py
@@ -1,0 +1,41 @@
+"""Common compose base functions."""
+
+from inspect import signature
+
+import numpy as np
+
+
+def _get_channel(X, key):
+    """Get time series channel(s) from input data X."""
+    if isinstance(X, np.ndarray):
+        return X[:, key]
+    else:
+        li = [x[key] for x in X]
+        if li[0].ndim == 1:
+            li = [x.reshape(1, -1) for x in li]
+        return li
+
+
+def _transform_args_wrapper(estimator, method_name, X, y=None, axis=None):
+    method = getattr(estimator, method_name)
+    args = list(signature(method).parameters.keys())
+
+    has_X = "X" in args
+    has_y = "y" in args
+    has_axis = "axis" in args
+
+    # aeon transforms should always have X and y, other transforms i.e. sklearn may
+    # only have X
+    if has_X and has_y and has_axis:
+        return method(X=X, y=y, axis=axis)
+    elif has_X and has_y:
+        return method(X=X, y=y)
+    elif has_X and has_axis:
+        return method(X=X, axis=axis)
+    elif has_X:
+        return method(X=X)
+    else:
+        raise ValueError(
+            f"Method {method_name} of {estimator.__class__.__name__} "
+            "does not have the required arguments."
+        )

--- a/aeon/base/_estimators/compose/collection_channel_ensemble.py
+++ b/aeon/base/_estimators/compose/collection_channel_ensemble.py
@@ -18,6 +18,7 @@ from aeon.base import (
     ComposableEstimatorMixin,
 )
 from aeon.base._base import _clone_estimator
+from aeon.base._estimators.compose._commons import _get_channel
 
 
 class BaseCollectionChannelEnsemble(ComposableEstimatorMixin, BaseCollectionEstimator):
@@ -98,7 +99,7 @@ class BaseCollectionChannelEnsemble(ComposableEstimatorMixin, BaseCollectionEsti
             self._ensemble, clone_estimators=False
         )
 
-        super().__init__()
+        super().__init__(axis=1)
 
         # can handle missing values if all estimators can
         missing = all(
@@ -241,17 +242,6 @@ class BaseCollectionChannelEnsemble(ComposableEstimatorMixin, BaseCollectionEsti
 
         # fit estimators
         for i, (_, estimator) in enumerate(self.ensemble_):
-            estimator.fit(self._get_channel(X, self.channels_[i]), y)
+            estimator.fit(_get_channel(X, self.channels_[i]), y)
 
         return self
-
-    @staticmethod
-    def _get_channel(X, key):
-        """Get time series channel(s) from input data X."""
-        if isinstance(X, np.ndarray):
-            return X[:, key]
-        else:
-            li = [x[key] for x in X]
-            if li[0].ndim == 1:
-                li = [x.reshape(1, -1) for x in li]
-            return li

--- a/aeon/base/_estimators/compose/collection_ensemble.py
+++ b/aeon/base/_estimators/compose/collection_ensemble.py
@@ -108,7 +108,7 @@ class BaseCollectionEnsemble(ComposableEstimatorMixin, BaseCollectionEstimator):
             self._ensemble, clone_estimators=False
         )
 
-        super().__init__()
+        super().__init__(axis=1)
 
         # can handle multivariate if all estimators can
         multivariate = all(

--- a/aeon/base/_estimators/compose/series_pipeline.py
+++ b/aeon/base/_estimators/compose/series_pipeline.py
@@ -1,10 +1,10 @@
-"""Base class for pipelines in collection modules.
+"""Base class for pipelines in series modules.
 
-i.e. classification, regression and clustering.
+i.e. forecasting, anomaly detection, series transforms.
 """
 
 __maintainer__ = ["MatthewMiddlehurst"]
-__all__ = ["BaseCollectionPipeline"]
+__all__ = ["BaseSeriesPipeline"]
 
 from abc import abstractmethod
 
@@ -14,15 +14,15 @@ from sklearn.utils import check_random_state
 
 from aeon.base import (
     BaseAeonEstimator,
-    BaseCollectionEstimator,
+    BaseSeriesEstimator,
     ComposableEstimatorMixin,
 )
 from aeon.base._base import _clone_estimator
 from aeon.base._estimators.compose._commons import _transform_args_wrapper
 
 
-class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
-    """Base class for composable pipelines in collection based modules.
+class BaseSeriesPipeline(ComposableEstimatorMixin, BaseSeriesEstimator):
+    """Base class for composable pipelines in series based modules.
 
     Parameters
     ----------
@@ -152,53 +152,9 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
 
         missing = all(missing_tags) or missing_rm_tag
 
-        # can handle unequal length if: estimator can and transformers can,
-        #   *or* transformer chain renders the series equal length
-        #   *or* transformer chain transforms the series to a tabular format
-        unequal_tags = [
-            (
-                e[1].get_tag(
-                    "capability:unequal_length",
-                    raise_error=False,
-                    tag_value_default=False,
-                )
-                if isinstance(e[1], BaseAeonEstimator)
-                else False
-            )
-            for e in self._steps
-        ]
-
-        unequal_rm_tag = False
-        for e in self._steps:
-            if (
-                isinstance(e[1], BaseAeonEstimator)
-                and e[1].get_tag(
-                    "capability:unequal_length",
-                    raise_error=False,
-                    tag_value_default=False,
-                )
-                and (
-                    e[1].get_tag(
-                        "removes_unequal_length",
-                        raise_error=False,
-                        tag_value_default=False,
-                    )
-                    or e[1].get_tag("output_data_type", raise_error=False) == "Tabular"
-                )
-            ):
-                unequal_rm_tag = True
-                break
-            elif not isinstance(e[1], BaseAeonEstimator) or not e[1].get_tag(
-                "capability:unequal_length", raise_error=False, tag_value_default=False
-            ):
-                break
-
-        unequal = all(unequal_tags) or unequal_rm_tag
-
         tags_to_set = {
             "capability:multivariate": multivariate,
             "capability:missing_values": missing,
-            "capability:unequal_length": unequal,
         }
         self.set_tags(**tags_to_set)
 
@@ -219,7 +175,9 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
         # fit transforms sequentially
         Xt = X
         for i in range(len(self.steps_) - 1):
-            Xt = _transform_args_wrapper(self.steps_[i][1], "fit_transform", Xt, y)
+            Xt = _transform_args_wrapper(
+                self.steps_[i][1], "fit_transform", Xt, y=y, axis=1
+            )
         # fit estimator
         self.steps_[-1][1].fit(X=Xt, y=y)
 
@@ -239,7 +197,7 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
         # transform
         Xt = X
         for i in range(len(self.steps_) - 1):
-            Xt = _transform_args_wrapper(self.steps_[i][1], "transform", Xt)
+            Xt = _transform_args_wrapper(self.steps_[i][1], "transform", Xt, axis=1)
         # predict
         return self.steps_[-1][1].predict(X=Xt)
 
@@ -261,7 +219,7 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
         # transform
         Xt = X
         for i in range(len(self.steps_) - 1):
-            Xt = _transform_args_wrapper(self.steps_[i][1], "transform", Xt)
+            Xt = _transform_args_wrapper(self.steps_[i][1], "transform", Xt, axis=1)
         # predict
         return self.steps_[-1][1].predict_proba(X=Xt)
 
@@ -281,7 +239,9 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
         # transform
         Xt = X
         for i in range(len(self.steps_)):
-            Xt = _transform_args_wrapper(self.steps_[i][1], "fit_transform", Xt, y)
+            Xt = _transform_args_wrapper(
+                self.steps_[i][1], "fit_transform", Xt, y=y, axis=1
+            )
         return Xt
 
     def _transform(self, X, y=None) -> np.ndarray:
@@ -298,7 +258,9 @@ class BaseCollectionPipeline(ComposableEstimatorMixin, BaseCollectionEstimator):
         # transform
         Xt = X
         for i in range(len(self.steps_)):
-            Xt = _transform_args_wrapper(self.steps_[i][1], "transform", Xt, y)
+            Xt = _transform_args_wrapper(
+                self.steps_[i][1], "transform", Xt, y=y, axis=1
+            )
         return Xt
 
     def _clone_steps(self):

--- a/aeon/classification/compose/_channel_ensemble.py
+++ b/aeon/classification/compose/_channel_ensemble.py
@@ -10,6 +10,7 @@ __all__ = ["ClassifierChannelEnsemble"]
 import numpy as np
 from sklearn.utils import check_random_state
 
+from aeon.base._estimators.compose._commons import _get_channel
 from aeon.base._estimators.compose.collection_channel_ensemble import (
     BaseCollectionChannelEnsemble,
 )
@@ -114,14 +115,14 @@ class ClassifierChannelEnsemble(BaseCollectionChannelEnsemble, BaseClassifier):
             # Call predict on each classifier, add the predictions to the
             # current probabilities
             for i, (_, clf) in enumerate(self.ensemble_):
-                preds = clf.predict(X=self._get_channel(X, self.channels_[i]))
+                preds = clf.predict(X=_get_channel(X, self.channels_[i]))
                 for n in range(X.shape[0]):
                     dists[n, self._class_dictionary[preds[n]]] += 1
         else:
             # Call predict_proba on each classifier, then add them to the current
             # probabilities
             for i, (_, clf) in enumerate(self.ensemble_):
-                dists += clf.predict_proba(X=self._get_channel(X, self.channels_[i]))
+                dists += clf.predict_proba(X=_get_channel(X, self.channels_[i]))
 
         # Make each instances probability array sum to 1 and return
         y_proba = dists / dists.sum(axis=1, keepdims=True)

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from aeon.base import BaseSeriesEstimator
-from aeon.base._base_series import VALID_SERIES_INNER_TYPES
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
 
 
 class BaseForecaster(BaseSeriesEstimator):

--- a/aeon/pipeline/_sklearn_to_aeon.py
+++ b/aeon/pipeline/_sklearn_to_aeon.py
@@ -1,6 +1,7 @@
 """Sklearn to aeon coercion utility."""
 
 __maintainer__ = ["MatthewMiddlehurst"]
+__all__ = ["sklearn_to_aeon"]
 
 from aeon.pipeline._make_pipeline import make_pipeline
 from aeon.transformations.collection import Tabularizer
@@ -9,19 +10,19 @@ from aeon.transformations.collection import Tabularizer
 def sklearn_to_aeon(estimator):
     """Coerces an sklearn estimator to the aeon pipeline interface.
 
-    Creates a pipeline of two elements, the identity transformer and the estimator.
-    The identity transformer acts as adapter and holds aeon base class logic.
+    Creates a pipeline of two elements, the Tabularizer transformer and the estimator.
+    The Tabularizer transformer acts as adapter and holds aeon base class logic, as
+    well as converting aeon datatypes to a feature vector format. Multivariate series
+    will be concatenated into a single feature vector. Data must be of equal length.
 
     Parameters
     ----------
     estimator : sklearn compatible estimator
-        can be classifier, regressor, transformer, clusterer
+        Can be a classifier, regressor, clusterer, or transformer.
 
     Returns
     -------
-    pipe : aeon estimator of corresponding time series type
-        classifiers, regressors, clusterers are converted to time series counterparts
-        by flattening time series. Assumes equal length time series.
-        transformers are converted to time series transformer by application per series
+    pipe : aeon pipeline estimator
+        A pipeline of the Tabularizer transformer and input estimator.
     """
     return make_pipeline(Tabularizer(), estimator)

--- a/aeon/pipeline/tests/test_sklearn_to_aeon.py
+++ b/aeon/pipeline/tests/test_sklearn_to_aeon.py
@@ -5,6 +5,7 @@ from sklearn.cluster import KMeans
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.preprocessing import StandardScaler
 
+from aeon.base import BaseAeonEstimator
 from aeon.pipeline import sklearn_to_aeon
 from aeon.testing.data_generation import make_example_3d_numpy
 
@@ -23,11 +24,12 @@ def test_sklearn_to_aeon(estimator):
     X, y = make_example_3d_numpy()
 
     est = sklearn_to_aeon(estimator)
+
+    assert isinstance(est, BaseAeonEstimator)
+
     est.fit(X, y)
 
     if hasattr(est, "predict"):
         est.predict(X)
     else:
         est.transform(X)
-
-    assert est._estimator_type == getattr(estimator, "_estimator_type", "transformer")

--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from aeon.base import BaseSeriesEstimator
-from aeon.base._base_series import VALID_SERIES_INPUT_TYPES
+from aeon.utils.data_types import VALID_SERIES_INPUT_TYPES
 
 
 class BaseSegmenter(BaseSeriesEstimator):

--- a/aeon/testing/estimator_checking/_yield_anomaly_detection_checks.py
+++ b/aeon/testing/estimator_checking/_yield_anomaly_detection_checks.py
@@ -5,8 +5,8 @@ from functools import partial
 import numpy as np
 
 from aeon.base._base import _clone_estimator
-from aeon.base._base_series import VALID_SERIES_INNER_TYPES
 from aeon.testing.testing_data import FULL_TEST_DATA_DICT
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
 
 
 def _yield_anomaly_detection_checks(estimator_class, estimator_instances, datatypes):

--- a/aeon/testing/estimator_checking/_yield_forecasting_checks.py
+++ b/aeon/testing/estimator_checking/_yield_forecasting_checks.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 
 from aeon.base._base import _clone_estimator
-from aeon.base._base_series import VALID_SERIES_INPUT_TYPES
+from aeon.utils.data_types import VALID_SERIES_INPUT_TYPES
 
 
 def _yield_forecasting_checks(estimator_class, estimator_instances, datatypes):

--- a/aeon/testing/estimator_checking/_yield_segmentation_checks.py
+++ b/aeon/testing/estimator_checking/_yield_segmentation_checks.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 
 from aeon.base._base import _clone_estimator
-from aeon.base._base_series import VALID_SERIES_INNER_TYPES
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
 
 
 def _yield_segmentation_checks(estimator_class, estimator_instances, datatypes):

--- a/aeon/testing/estimator_checking/_yield_transformation_checks.py
+++ b/aeon/testing/estimator_checking/_yield_transformation_checks.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_array_almost_equal
 from sklearn.utils._testing import set_random_state
 
 from aeon.base._base import _clone_estimator
-from aeon.base._base_series import VALID_SERIES_INNER_TYPES
 from aeon.datasets import load_basic_motions, load_unit_test
 from aeon.testing.expected_results.expected_transform_outputs import (
     basic_motions_result,
@@ -20,7 +19,7 @@ from aeon.testing.utils.deep_equals import deep_equals
 from aeon.testing.utils.estimator_checks import _run_estimator_method
 from aeon.transformations.collection.channel_selection.base import BaseChannelSelector
 from aeon.transformations.series import BaseSeriesTransformer
-from aeon.utils.data_types import COLLECTIONS_DATA_TYPES
+from aeon.utils.data_types import COLLECTIONS_DATA_TYPES, VALID_SERIES_INNER_TYPES
 
 
 def _yield_transformation_checks(estimator_class, estimator_instances, datatypes):
@@ -199,4 +198,5 @@ def check_transform_inverse_transform_equivalent(estimator, datatype):
     if isinstance(Xit, (np.ndarray, pd.DataFrame)):
         Xit = Xit.squeeze()
 
-    assert deep_equals(X, Xit, ignore_index=True)
+    eq, msg = deep_equals(X, Xit, ignore_index=True, return_msg=True)
+    assert eq, msg

--- a/aeon/testing/utils/estimator_checks.py
+++ b/aeon/testing/utils/estimator_checks.py
@@ -2,8 +2,7 @@
 
 __maintainer__ = ["MatthewMiddlehurst"]
 
-import inspect
-from inspect import isclass
+from inspect import isclass, signature
 
 import numpy as np
 
@@ -14,7 +13,7 @@ from aeon.utils.validation import get_n_cases
 
 def _run_estimator_method(estimator, method_name, datatype, split):
     method = getattr(estimator, method_name)
-    args = inspect.getfullargspec(method)[0]
+    args = list(signature(method).parameters.keys())
     try:
         # forecasting
         if "y" in args and "exog" in args:

--- a/aeon/transformations/__init__.py
+++ b/aeon/transformations/__init__.py
@@ -1,1 +1,7 @@
-"""Transformations."""
+"""Time series transformations."""
+
+__all__ = [
+    "BaseTransformer",
+]
+
+from aeon.transformations.base import BaseTransformer

--- a/aeon/transformations/series/__init__.py
+++ b/aeon/transformations/series/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "GaussSeriesTransformer",
     "MatrixProfileSeriesTransformer",
     "MovingAverageSeriesTransformer",
+    "LogTransformer",
     "PLASeriesTransformer",
     "SGSeriesTransformer",
     "StatsModelsACF",
@@ -35,6 +36,7 @@ from aeon.transformations.series._dft import DFTSeriesTransformer
 from aeon.transformations.series._dobin import Dobin
 from aeon.transformations.series._exp_smoothing import ExpSmoothingSeriesTransformer
 from aeon.transformations.series._gauss import GaussSeriesTransformer
+from aeon.transformations.series._log import LogTransformer
 from aeon.transformations.series._matrix_profile import MatrixProfileSeriesTransformer
 from aeon.transformations.series._moving_average import MovingAverageSeriesTransformer
 from aeon.transformations.series._pca import PCASeriesTransformer

--- a/aeon/transformations/series/_boxcox.py
+++ b/aeon/transformations/series/_boxcox.py
@@ -1,7 +1,7 @@
-"""Box-Cox and Log Transformations."""
+"""Box-Cox transformation."""
 
 __maintainer__ = ["TonyBagnall"]
-__all__ = ["BoxCoxTransformer", "LogTransformer"]
+__all__ = ["BoxCoxTransformer"]
 
 import numpy as np
 from scipy import optimize, special, stats
@@ -181,90 +181,6 @@ class BoxCoxTransformer(BaseSeriesTransformer):
             inverse transformed version of X
         """
         Xt = inv_boxcox(X, self.lambda_)
-        return Xt
-
-
-class LogTransformer(BaseSeriesTransformer):
-    """Natural logarithm transformation.
-
-    The Natural logarithm transformation can be used to make the data more normally
-    distributed and stabilize its variance.
-
-    Transforms each data point x to log(scale *(x+offset))
-
-    Parameters
-    ----------
-    offset : float , default = 0
-             Additive constant applied to all the data.
-    scale  : float , default = 1
-             Multiplicative scaling constant applied to all the data.
-
-
-    Notes
-    -----
-    The log transformation is applied as :math:`ln(y)`.
-
-    Examples
-    --------
-    >>> from aeon.transformations.series._boxcox import LogTransformer
-    >>> from aeon.datasets import load_airline
-    >>> y = load_airline()
-    >>> transformer = LogTransformer()
-    >>> y_hat = transformer.fit_transform(y)
-    """
-
-    _tags = {
-        "X_inner_type": "np.ndarray",
-        "fit_is_empty": True,
-        "capability:multivariate": True,
-        "capability:inverse_transform": True,
-    }
-
-    def __init__(self, offset=0, scale=1):
-        self.offset = offset
-        self.scale = scale
-        super().__init__(axis=1)
-
-    def _transform(self, X, y=None):
-        """Transform X and return a transformed version.
-
-        private _transform containing the core logic, called from transform
-
-        Parameters
-        ----------
-        X : 2D np.ndarray
-            Data to be transformed
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        Xt : 2D np.ndarray
-            transformed version of X
-        """
-        offset = self.offset
-        scale = self.scale
-        Xt = np.log(scale * (X + offset))
-        return Xt
-
-    def _inverse_transform(self, X, y=None):
-        """Inverse transform X and return an inverse transformed version.
-
-        core logic
-
-        Parameters
-        ----------
-        X : 2D np.ndarray
-            Data to be transformed
-        y : ignored argument for interface compatibility
-            Additional data, e.g., labels for transformation
-
-        Returns
-        -------
-        Xt : 2D np.ndarray
-            inverse transformed version of X
-        """
-        Xt = (np.exp(X) / self.scale) - self.offset
         return Xt
 
 

--- a/aeon/transformations/series/_log.py
+++ b/aeon/transformations/series/_log.py
@@ -1,0 +1,92 @@
+"""Log transformation."""
+
+__maintainer__ = ["TonyBagnall"]
+__all__ = ["LogTransformer"]
+
+import numpy as np
+
+from aeon.transformations.series.base import BaseSeriesTransformer
+
+
+class LogTransformer(BaseSeriesTransformer):
+    """Natural logarithm transformation.
+
+    The Natural logarithm transformation can be used to make the data more normally
+    distributed and stabilize its variance.
+
+    Transforms each data point x to log(scale *(x+offset))
+
+    Parameters
+    ----------
+    offset : float , default = 0
+             Additive constant applied to all the data.
+    scale  : float , default = 1
+             Multiplicative scaling constant applied to all the data.
+
+
+    Notes
+    -----
+    The log transformation is applied as :math:`ln(y)`.
+
+    Examples
+    --------
+    >>> from aeon.transformations.series._log import LogTransformer
+    >>> from aeon.datasets import load_airline
+    >>> y = load_airline()
+    >>> transformer = LogTransformer()
+    >>> y_hat = transformer.fit_transform(y)
+    """
+
+    _tags = {
+        "X_inner_type": "np.ndarray",
+        "fit_is_empty": True,
+        "capability:multivariate": True,
+        "capability:inverse_transform": True,
+    }
+
+    def __init__(self, offset=0, scale=1):
+        self.offset = offset
+        self.scale = scale
+        super().__init__(axis=1)
+
+    def _transform(self, X, y=None):
+        """Transform X and return a transformed version.
+
+        private _transform containing the core logic, called from transform
+
+        Parameters
+        ----------
+        X : 2D np.ndarray
+            Data to be transformed
+        y : ignored argument for interface compatibility
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        Xt : 2D np.ndarray
+            transformed version of X
+        """
+        offset = self.offset
+        scale = self.scale
+        Xt = np.log(scale * (X + offset))
+        return Xt
+
+    def _inverse_transform(self, X, y=None):
+        """Inverse transform X and return an inverse transformed version.
+
+        core logic
+
+        Parameters
+        ----------
+        X : 2D np.ndarray
+            Data to be transformed
+        y : ignored argument for interface compatibility
+            Additional data, e.g., labels for transformation
+
+        Returns
+        -------
+        Xt : 2D np.ndarray
+            inverse transformed version of X
+        """
+        Xt = (np.exp(X) / self.scale) - self.offset
+        return Xt

--- a/aeon/transformations/series/compose/__init__.py
+++ b/aeon/transformations/series/compose/__init__.py
@@ -1,0 +1,9 @@
+"""Compositions for series transforms."""
+
+__all__ = [
+    "SeriesTransformerPipeline",
+    "SeriesId",
+]
+
+from aeon.transformations.series.compose._identity import SeriesId
+from aeon.transformations.series.compose._pipeline import SeriesTransformerPipeline

--- a/aeon/transformations/series/compose/_identity.py
+++ b/aeon/transformations/series/compose/_identity.py
@@ -1,0 +1,25 @@
+"""Identity transformer."""
+
+from aeon.transformations.series import BaseSeriesTransformer
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
+
+
+class SeriesId(BaseSeriesTransformer):
+    """Identity transformer, returns data unchanged in transform/inverse_transform."""
+
+    _tags = {
+        "X_inner_type": VALID_SERIES_INNER_TYPES,
+        "fit_is_empty": True,
+        "capability:inverse_transform": True,
+        "capability:multivariate": True,
+        "capability:missing_values": True,
+    }
+
+    def __init__(self):
+        super().__init__(axis=1)
+
+    def _transform(self, X, y=None):
+        return X
+
+    def _inverse_transform(self, X, y=None):
+        return X

--- a/aeon/transformations/series/compose/_pipeline.py
+++ b/aeon/transformations/series/compose/_pipeline.py
@@ -1,18 +1,18 @@
-"""Pipeline with collection transformers."""
+"""Pipeline with series transformers."""
 
 __maintainer__ = ["MatthewMiddlehurst"]
-__all__ = ["CollectionTransformerPipeline"]
+__all__ = ["SeriesTransformerPipeline"]
+
+from aeon.base._estimators.compose.series_pipeline import BaseSeriesPipeline
+from aeon.transformations.series import BaseSeriesTransformer
+from aeon.transformations.series.compose import SeriesId
+from aeon.utils.data_types import VALID_SERIES_INNER_TYPES
 
 
-from aeon.base._estimators.compose.collection_pipeline import BaseCollectionPipeline
-from aeon.transformations.collection import BaseCollectionTransformer
-from aeon.transformations.collection.compose import CollectionId
+class SeriesTransformerPipeline(BaseSeriesPipeline, BaseSeriesTransformer):
+    """Pipeline of series transformers.
 
-
-class CollectionTransformerPipeline(BaseCollectionPipeline, BaseCollectionTransformer):
-    """Pipeline of collection transformers.
-
-    The `CollectionTransformerPipeline` compositor chains transformers.
+    The `SeriesTransformerPipeline` compositor chains transformers.
     The pipeline is constructed with a list of aeon transformers,
         i.e., estimators following the BaseTransformer interface.
     The transformer list can be unnamed - a simple list of transformers -
@@ -48,29 +48,28 @@ class CollectionTransformerPipeline(BaseCollectionPipeline, BaseCollectionTransf
 
     Examples
     --------
-    >>> from aeon.transformations.collection import Resizer
-    >>> from aeon.transformations.collection.feature_based import SevenNumberSummary
-    >>> from aeon.datasets import load_unit_test
-    >>> from aeon.transformations.collection.compose import (
-    ...                                                 CollectionTransformerPipeline)
-    >>> X, y = load_unit_test(split="train")
-    >>> pipeline = CollectionTransformerPipeline(
-    ...     [Resizer(length=10), SevenNumberSummary()]
+    >>> from aeon.transformations.series import LogTransformer
+    >>> from aeon.transformations.series import MovingAverageSeriesTransformer
+    >>> from aeon.datasets import load_airline
+    >>> from aeon.transformations.series.compose import SeriesTransformerPipeline
+    >>> X = load_airline()
+    >>> pipeline = SeriesTransformerPipeline(
+    ...     [LogTransformer(), MovingAverageSeriesTransformer()]
     ... )
-    >>> pipeline.fit(X, y)
-    CollectionTransformerPipeline(...)
-    >>> Xt = pipeline.transform(X, y)
+    >>> pipeline.fit(X)
+    SeriesTransformerPipeline(...)
+    >>> Xt = pipeline.transform(X)
     """
 
     _tags = {
-        "X_inner_type": ["np-list", "numpy3D"],
+        "X_inner_type": VALID_SERIES_INNER_TYPES,
     }
 
     def __init__(self, transformers):
         if not isinstance(transformers, list):
-            transformers = [CollectionId(), transformers]
+            transformers = [SeriesId(), transformers]
         elif len(transformers) < 2:
-            transformers = [CollectionId(), transformers[0]]
+            transformers = [SeriesId(), transformers[0]]
 
         super().__init__(transformers=transformers, _estimator=None)
 
@@ -91,12 +90,14 @@ class CollectionTransformerPipeline(BaseCollectionPipeline, BaseCollectionTransf
             Each dict are parameters to construct an "interesting" test instance, i.e.,
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
         """
-        from aeon.transformations.collection import Truncator
-        from aeon.transformations.collection.feature_based import SevenNumberSummary
+        from aeon.transformations.series import (
+            LogTransformer,
+            MovingAverageSeriesTransformer,
+        )
 
         return {
             "transformers": [
-                Truncator(truncated_length=5),
-                SevenNumberSummary(),
+                LogTransformer(),
+                MovingAverageSeriesTransformer(),
             ]
         }

--- a/aeon/transformations/series/compose/tests/__init__.py
+++ b/aeon/transformations/series/compose/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for composable series transformers."""

--- a/aeon/transformations/series/compose/tests/test_pipeline.py
+++ b/aeon/transformations/series/compose/tests/test_pipeline.py
@@ -1,7 +1,5 @@
 """Unit tests for clustering pipeline."""
 
-__maintainer__ = ["MatthewMiddlehurst"]
-
 import pytest
 from numpy.testing import assert_array_almost_equal
 from sklearn.preprocessing import StandardScaler

--- a/aeon/transformations/series/tests/test_boxcox.py
+++ b/aeon/transformations/series/tests/test_boxcox.py
@@ -1,8 +1,5 @@
 """Tests for BoxCoxTransformer."""
 
-__maintainer__ = []
-__all__ = []
-
 import numpy as np
 import pytest
 from scipy.stats import boxcox

--- a/aeon/transformations/series/tests/test_wrapper.py
+++ b/aeon/transformations/series/tests/test_wrapper.py
@@ -1,0 +1,24 @@
+"""Tests for SeriesToCollectionBroadcaster transformer."""
+
+from aeon.testing.mock_estimators import MockCollectionTransformer
+from aeon.transformations.series import CollectionToSeriesWrapper
+
+
+def test_broadcaster_tag_inheritance():
+    """Test the ability to inherit tags from the BaseCollectionTransformer.
+
+    The broadcaster should always keep some tags related to single series
+    """
+    trans = MockCollectionTransformer()
+    class_tags = CollectionToSeriesWrapper._tags
+
+    bc = CollectionToSeriesWrapper(trans)
+
+    post_constructor_tags = bc.get_tags()
+    mock_tags = trans.get_tags()
+    # constructor_tags should match class_tags or, if not present, tags in transformer
+    for key in post_constructor_tags:
+        if key in class_tags:
+            assert post_constructor_tags[key] == class_tags[key]
+        elif key in mock_tags:
+            assert post_constructor_tags[key] == mock_tags[key]

--- a/aeon/utils/data_types.py
+++ b/aeon/utils/data_types.py
@@ -7,52 +7,99 @@ since there are internal constraints on some representations, for example in ter
 the index.
 
 Checks of input data are handled in the `aeon.utils.validation` module,
-and conversion  is handled in the `aeon.utils.conversion` module.
+and conversion is handled in the `aeon.utils.conversion` module.
 """
 
-SERIES_DATA_TYPES = [
-    "pd.Series",  # univariate time series of shape (n_timepoints)
-    "pd.DataFrame",  # uni/multivariate time series of shape (n_timepoints,
-    # n_channels) by default or (n_channels, n_timepoints) if set by axis == 1
-    "np.ndarray",  # uni/multivariate time series of shape (n_timepoints,
-    # n_channels) by default or (n_channels, n_timepoints) if set by axis ==1
+__all__ = [
+    "SERIES_DATA_TYPES",
+    "SERIES_MULTIVARIATE_DATA_TYPES",
+    "VALID_SERIES_INNER_TYPES",
+    "VALID_SERIES_INPUT_TYPES",
+    "COLLECTIONS_DATA_TYPES",
+    "COLLECTIONS_MULTIVARIATE_DATA_TYPES",
+    "COLLECTIONS_UNEQUAL_DATA_TYPES",
+    "VALID_COLLECTIONS_INNER_TYPES",
+    "VALID_COLLECTIONS_INPUT_TYPES",
+    "HIERARCHICAL_DATA_TYPES",
+    "ALL_TIME_SERIES_TYPES",
 ]
 
+import numpy as np
+import pandas as pd
+
+# SERIES
+
+SERIES_DATA_TYPES = [
+    "pd.Series",  # univariate 1D pandas Series time series of shape (n_timepoints)
+    "pd.DataFrame",  # uni/multivariate 2D pandas DataFrame time series of shape
+    # (n_channels, n_timepoints) by default, or (n_timepoints, n_channels) if set by
+    # axis == 0
+    "np.ndarray",  # uni/multivariate 2D numpy ndarray time series of shape
+    # (n_channels, n_timepoints) by default, or (n_timepoints, n_channels) if set by
+    # axis == 0
+]
+
+# subset of series dtypes capable of handling multivariate time series
+SERIES_MULTIVARIATE_DATA_TYPES = [
+    "pd.DataFrame",
+    "np.ndarray",
+]
+
+# datatypes which are valid for BaseSeriesEstimator estimators
+VALID_SERIES_INNER_TYPES = [
+    "np.ndarray",
+    "pd.DataFrame",
+]
+
+VALID_SERIES_INPUT_TYPES = [pd.Series, pd.DataFrame, np.ndarray]
+
+# COLLECTIONS
 
 COLLECTIONS_DATA_TYPES = [
-    "numpy3D",  # 3D np.ndarray of format (n_cases, n_channels, n_timepoints)
-    "np-list",  # python list of 2D np.ndarray of length [n_cases],
-    # each of shape (n_channels, n_timepoints_i)
-    "df-list",  # python list of 2D pd.DataFrames of length [n_cases], each
-    # of shape (n_channels, n_timepoints_i)
-    "numpy2D",  # 2D np.ndarray of shape (n_cases, n_timepoints)
-    "pd-wide",  # 2D pd.DataFrame of shape (n_cases, n_timepoints)
-    "pd-multiindex",  # pd.DataFrame with MultiIndex, index [case, timepoint],
-    # columns [channel]
+    "numpy3D",  # uni/multivariate 3D numpy ndarray of shape
+    # (n_cases, n_channels, n_timepoints)
+    "np-list",  # uni/multivariate length [n_cases] Python list of 2D numpy ndarray
+    # with shape (n_channels, n_timepoints_i)
+    "df-list",  # uni/multivariate length [n_cases] Python list of 2D pandas DataFrame
+    # with shape (n_channels, n_timepoints_i)
+    "numpy2D",  # univariate 2D numpy ndarray of shape (n_cases, n_timepoints)
+    "pd-wide",  # univariate 2D pandas DataFrame of shape (n_cases, n_timepoints)
+    "pd-multiindex",  # uni/multivariate pandas DataFrame with MultiIndex,
+    # index [case, timepoint], columns [channel]
 ]
 
-# subset of collections capable of handling multivariate time series
+# subset of collection dtypes capable of handling multivariate time series
 COLLECTIONS_MULTIVARIATE_DATA_TYPES = [
-    "numpy3D",  # 3D np.ndarray of format (n_cases, n_channels, n_timepoints)
-    "np-list",  # python list of 2D np.ndarray of length [n_cases],
-    # each of shape (n_channels, n_timepoints_i)
-    "df-list",  # python list of 2D pd.DataFrames of length [n_cases], each
-    # of shape (n_channels, n_timepoints_i)
-    "pd-multiindex",  # pd.DataFrame with MultiIndex, index [case, timepoint],
-    # columns [channel]
+    "numpy3D",
+    "np-list",
+    "df-list",
+    "pd-multiindex",
 ]
 
-# subset of collections capable of handling unequal length time series
+# subset of collection dtypes capable of handling unequal length time series
 COLLECTIONS_UNEQUAL_DATA_TYPES = [
-    "np-list",  # python list of 2D np.ndarray of length [n_cases],
-    # each of shape (n_channels, n_timepoints_i)
-    "df-list",  # python list of 2D pd.DataFrames of length [n_cases], each
-    # of shape (n_channels, n_timepoints_i)
-    "pd-multiindex",  # pd.DataFrame with MultiIndex, index [case, timepoint],
-    # columns [channel]
+    "np-list",
+    "df-list",
+    "pd-multiindex",
 ]
+
+# datatypes which are valid for BaseCollectionEstimator estimators
+VALID_COLLECTIONS_INNER_TYPES = [
+    "numpy3D",
+    "np-list",
+    "df-list",
+    "numpy2D",
+    "pd-wide",
+    "pd-multiindex",
+]
+
+VALID_COLLECTIONS_INPUT_TYPES = [list, pd.DataFrame, np.ndarray]
+
+# HIERARCHICAL
 
 HIERARCHICAL_DATA_TYPES = ["pd_multiindex_hier"]  # pd.DataFrame
+
+# ALL
 
 ALL_TIME_SERIES_TYPES = (
     SERIES_DATA_TYPES + COLLECTIONS_DATA_TYPES + HIERARCHICAL_DATA_TYPES


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Implements a pipeline for series transforms, including an Id transform and testing. Also:

- Tidies up and structures the datatypes lists. These should now all be located in `utils`. Most of the file changes are refactoring this
- For some reason `LogTransformer` was in the boxcox file and unavailable locally, I have separated this and included it in the init as i use it for examples