### PR TITLE
[BUG] Remove typing from numba functions

### DIFF
--- a/aeon/transformations/collection/convolution_based/_minirocket.py
+++ b/aeon/transformations/collection/convolution_based/_minirocket.py
@@ -230,7 +230,7 @@ def _static_fit(X, n_features=10_000, max_dilations_per_kernel=32, seed=None):
     )
 
 
-@vectorize("float32(float32,float32)", nopython=True, cache=True)
+@vectorize(nopython=True, cache=True)
 def _PPV(a, b):
     if a > b:
         return 1
@@ -238,8 +238,6 @@ def _PPV(a, b):
 
 
 @njit(
-    "float32[:,:](float32[:,:],Tuple((int32[:],int32[:],int32[:],int32[:],float32["
-    ":])), int32[:,:])",
     fastmath=True,
     parallel=True,
     cache=True,
@@ -305,8 +303,6 @@ def _static_transform_uni(X, parameters, indices):
 
 
 @njit(
-    "float32[:,:](float32[:,:,:],Tuple((int32[:],int32[:],int32[:],int32[:],float32["
-    ":])), int32[:,:])",
     fastmath=True,
     parallel=True,
     cache=True,
@@ -384,8 +380,6 @@ def _static_transform_multi(X, parameters, indices):
 
 
 @njit(
-    "float32[:](float32[:,:,:],int32[:],int32[:],int32[:],int32[:],float32[:],"
-    "int32[:,:],optional(int32))",  # noqa
     fastmath=True,
     parallel=False,
     cache=True,

--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -279,8 +279,6 @@ class MultiRocket(BaseCollectionTransformer):
 
 
 @njit(
-    "float32[:,:](float32[:,:],float32[:,:],Tuple((int32[:],int32[:],float32[:])),"
-    "Tuple((int32[:],int32[:],float32[:])),int32, int32[:,:],optional(int32))",
     fastmath=True,
     parallel=True,
     cache=True,
@@ -553,10 +551,6 @@ def _transform_uni(
 
 
 @njit(
-    "float32[:,:](float32[:,:,:],float32[:,:,:],"
-    "Tuple((int32[:],int32[:],int32[:],int32[:],float32[:])),"
-    "Tuple((int32[:],int32[:],int32[:],int32[:],float32[:])),int32, int32[:,:],"
-    "optional(int32))",
     fastmath=True,
     parallel=True,
     cache=True,
@@ -875,7 +869,6 @@ def _transform_multi(
 
 
 @njit(
-    "float32[:](float32[:,:],int32[:],int32[:],float32[:], int32[:,:],optional(int32))",
     fastmath=True,
     parallel=False,
     cache=True,
@@ -945,8 +938,6 @@ def _fit_biases_univariate(
 
 
 @njit(
-    "float32[:](float32[:,:,:],int32[:],int32[:],int32[:],int32[:],float32[:], "
-    "int32[:,:],optional(int32))",
     fastmath=True,
     parallel=False,
     cache=True,


### PR DESCRIPTION
Fixes https://github.com/aeon-toolkit/aeon/issues/2179

removes the typing from numba, which was slowing down the cache building considerably, see issue for discussion

seems I have corrupted my local main branch again, ignore the arima first commit