### PR TITLE
[ENH] Refactor forecast predict to return a single value

### DIFF
--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -196,7 +196,7 @@ class ETSForecaster(BaseForecaster):
         )
         return self
 
-    def _predict(self, y=None, exog=None):
+    def _predict(self, exog=None):
         """
         Predict the next horizon steps ahead.
 
@@ -213,7 +213,7 @@ class ETSForecaster(BaseForecaster):
         float
             single prediction self.horizon steps ahead of y.
         """
-        fitted_value = _predict(
+        fitted_value = _numba_predict(
             self._trend_type,
             self._seasonality_type,
             self.level_,
@@ -225,20 +225,6 @@ class ETSForecaster(BaseForecaster):
             self._seasonal_period,
         )
         return fitted_value
-
-    def _initialise(self, data):
-        """
-        Initialize level, trend, and seasonality values for the ETS model.
-
-        Parameters
-        ----------
-        data : array-like
-            The time series data
-            (should contain at least two full seasons if seasonality is specified)
-        """
-        self.level_, self.trend_, self.seasonality_ = _initialise(
-            self._trend_type, self._seasonality_type, self._seasonal_period, data
-        )
 
 
 @njit(fastmath=True, cache=True)
@@ -254,7 +240,7 @@ def _numba_fit(
     phi,
 ):
     n_timepoints = len(data) - seasonal_period
-    level, trend, seasonality = _initialise(
+    level, trend, seasonality = _numba_initialise(
         trend_type, seasonality_type, seasonal_period, data
     )
     avg_mean_sq_err_ = 0
@@ -314,7 +300,7 @@ def _numba_fit(
 
 
 @njit(fastmath=True, cache=True)
-def _predict(
+def _numba_predict(
     trend_type,
     seasonality_type,
     level,
@@ -343,7 +329,7 @@ def _predict(
 
 
 @njit(fastmath=True, cache=True)
-def _initialise(trend_type, seasonality_type, seasonal_period, data):
+def _numba_initialise(trend_type, seasonality_type, seasonal_period, data):
     """
     Initialize level, trend, and seasonality values for the ETS model.
 

--- a/aeon/forecasting/_naive.py
+++ b/aeon/forecasting/_naive.py
@@ -17,11 +17,6 @@ class NaiveForecaster(BaseForecaster):
         self.last_value_ = y[-1]
         return self
 
-    def _predict(self, y=None, exog=None):
+    def _predict(self, exog=None):
         """Predict using Naive forecaster."""
         return self.last_value_
-
-    def _forecast(self, y, exog=None):
-        """Forecast using dummy forecaster."""
-        y = y.squeeze()
-        return y[-1]

--- a/aeon/forecasting/_regression.py
+++ b/aeon/forecasting/_regression.py
@@ -76,7 +76,7 @@ class RegressionForecaster(BaseForecaster):
         self.regressor_.fit(X=X, y=y)
         return self
 
-    def _predict(self, y=None, exog=None):
+    def _predict(self, exog=None):
         """
         Predict the next horizon steps ahead.
 
@@ -94,32 +94,7 @@ class RegressionForecaster(BaseForecaster):
         np.ndarray
             single prediction self.horizon steps ahead of y.
         """
-        if y is None:
-            return self.regressor_.predict(self.last_)
-        last = y[:, -self.window :]
-        return self.regressor_.predict(last)
-
-    def _forecast(self, y, exog=None):
-        """
-        Forecast the next horizon steps ahead.
-
-        Parameters
-        ----------
-        y : np.ndarray
-            A time series to predict the next horizon value for.
-        exog : np.ndarray, default=None
-            Optional exogenous time series data. Included for interface
-            compatibility but ignored in this estimator.
-
-        Returns
-        -------
-        np.ndarray
-            single prediction self.horizon steps ahead of y.
-
-        NOTE: deal with horizons
-        """
-        self.fit(y, exog)
-        return self.predict()
+        return self.regressor_.predict(self.last_)
 
     @classmethod
     def _get_test_params(cls, parameter_set: str = "default"):

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -75,59 +75,26 @@ class BaseForecaster(BaseSeriesEstimator):
     @abstractmethod
     def _fit(self, y, exog=None): ...
 
-    def predict(self, y=None, exog=None):
+    def predict(self, exog=None):
         """Predict the next horizon steps ahead.
 
         Parameters
         ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
         exog : np.ndarray, default =None
             Optional exogenous time series data assumed to be aligned with y.
 
         Returns
         -------
         float
-            single prediction self.horizon steps ahead of y.
+            single prediction self.horizon steps ahead of the series y seen in fit.
         """
         self._check_is_fitted()
-        if y is not None:
-            self._check_X(y, self.axis)
-            y = self._convert_y(y, self.axis)
         if exog is not None:
             raise NotImplementedError("Exogenous variables not yet supported")
-        return self._predict(y, exog)
+        return self._predict()
 
     @abstractmethod
-    def _predict(self, y=None, exog=None): ...
-
-    def forecast(self, y, exog=None):
-        """Forecast the next horizon steps ahead.
-
-        By default this is simply fit followed by predict.
-
-        Parameters
-        ----------
-        y : np.ndarray, default = None
-            A time series to predict the next horizon value for. If None,
-            predict the next horizon value after series seen in fit.
-        exog : np.ndarray, default =None
-            Optional exogenous time series data assumed to be aligned with y.
-
-        Returns
-        -------
-        float
-            single prediction self.horizon steps ahead of y.
-        """
-        self._check_X(y, self.axis)
-        y = self._convert_y(y, self.axis)
-        return self._forecast(y, exog)
-
-    def _forecast(self, y, exog=None):
-        """Forecast values for time series X."""
-        self.fit(y, exog)
-        return self._predict(y, exog)
+    def _predict(self, exog=None): ...
 
     def _convert_y(self, y: VALID_SERIES_INNER_TYPES, axis: int):
         """Convert y to self.get_tag("y_inner_type")."""


### PR DESCRIPTION
I think we should change the model for a Forecaster, make it as simple as possible to start with then consider more complex scenarios. Points made on slack, but basis is forecasters train on a 
```python
model = MyForecaster(horizon=1)
model.fit(y)
y_hat = model.predict()
```
predict aways returns the same value, and `y_hat` is the one ahead prediction.



