### PR TITLE
[ENH] Add two forecasting tags

### DIFF
--- a/aeon/forecasting/_ets.py
+++ b/aeon/forecasting/_ets.py
@@ -92,6 +92,10 @@ class ETSForecaster(BaseForecaster):
     366.90200486015596
     """
 
+    _tags = {
+        "capability:horizon": False,
+    }
+
     def __init__(
         self,
         error_type: Union[int, str] = 1,

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -72,8 +72,8 @@ class BaseForecaster(BaseSeriesEstimator):
                 f"Horizon is set >1, but {self.__class__.__name__} cannot handle a "
                 f"horizon greater than 1"
             )
-        exog = self.get_tag("capability:exogenous")
-        if not exog and exog is not None:
+        exog_tag = self.get_tag("capability:exogenous")
+        if not exog_tag and exog is not None:
             raise ValueError(
                 f"Exogenous variables passed but {self.__class__.__name__} cannot "
                 "handle exogenous variables"

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -35,6 +35,8 @@ class BaseForecaster(BaseSeriesEstimator):
         "capability:univariate": True,
         "capability:multivariate": False,
         "capability:missing_values": False,
+        "capability:horizon": True,
+        "capability:exogenous": False,
         "fit_is_empty": False,
         "y_inner_type": "np.ndarray",
     }
@@ -64,6 +66,18 @@ class BaseForecaster(BaseSeriesEstimator):
         if self.get_tag("fit_is_empty"):
             self.is_fitted = True
             return self
+        horizon = self.get_tag("capability:horizon")
+        if not horizon and self.horizon > 1:
+            raise ValueError(
+                f"Horizon is set >1, but {self.__class__.__name__} cannot handle a "
+                f"horizon greater than 1"
+            )
+        exog = self.get_tag("capability:exogenous")
+        if not exog and exog is not None:
+            raise ValueError(
+                f"Exogenous variables passed but {self.__class__.__name__} cannot "
+                "handle exogenous variables"
+            )
 
         self._check_X(y, self.axis)
         y = self._convert_y(y, self.axis)

--- a/aeon/forecasting/tests/test_base.py
+++ b/aeon/forecasting/tests/test_base.py
@@ -18,9 +18,7 @@ def test_base_forecaster():
     p3 = f._forecast(y)
     assert p2 == p1
     assert p3 == p2
-    with pytest.raises(
-        NotImplementedError, match="Exogenous variables not yet " "supported"
-    ):
+    with pytest.raises(ValueError, match="Exogenous variables passed"):
         f.fit(y, exog=y)
 
 

--- a/aeon/utils/tags/_tags.py
+++ b/aeon/utils/tags/_tags.py
@@ -124,6 +124,16 @@ ESTIMATOR_TAGS = {
         "type": "bool",
         "description": "Can the estimator limiting max fit time?",
     },
+    "capability:exogenous": {
+        "class": ["forecastor"],
+        "type": "bool",
+        "description": "Can the forecaster accept exogenous arguments?",
+    },
+    "capability:horizon": {
+        "class": ["forecastor"],
+        "type": "bool",
+        "description": "Can the forecaster forecast a horizon beyond one?",
+    },
     "capability:inverse_transform": {
         "class": "transformer",
         "type": "bool",

--- a/aeon/utils/tags/_tags.py
+++ b/aeon/utils/tags/_tags.py
@@ -125,12 +125,12 @@ ESTIMATOR_TAGS = {
         "description": "Can the estimator limiting max fit time?",
     },
     "capability:exogenous": {
-        "class": ["forecastor"],
+        "class": ["forecaster"],
         "type": "bool",
         "description": "Can the forecaster accept exogenous arguments?",
     },
     "capability:horizon": {
-        "class": ["forecastor"],
+        "class": ["forecaster"],
         "type": "bool",
         "description": "Can the forecaster forecast a horizon beyond one?",
     },


### PR DESCRIPTION
resolves #2814 

two tags to describe forecaster boolean capabilities

"capability": "horizon" indicates if the forecaster can directly fit a model to a horizon greater than one or not. Default True, but set false for ETS and ARIMA cannot. 
"capability": "exogenous" indicates if the forecaster can use egonenous variables in the modelling. Default False

both are tested in fit in BaseForecaster. I may have to do more to add tags, not sure about testing.