### PR TITLE
[ENH] remove fit_is_empty tag from forecasting base

### DIFF
--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -37,7 +37,6 @@ class BaseForecaster(BaseSeriesEstimator):
         "capability:missing_values": False,
         "capability:horizon": True,
         "capability:exogenous": False,
-        "fit_is_empty": False,
         "y_inner_type": "np.ndarray",
     }
 


### PR DESCRIPTION
the way its structured currently, it makes no sense to have a tag fit_is_empty, since fit is the only place the forecaster sees the series. I dont see any use for a completely random forecaster. 