### PR TITLE
[BUG] Fixes a bug with SFAFast throwing an error when calling transform after fit

### DIFF
--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -329,7 +329,7 @@ class SFAFast(BaseCollectionTransformer):
         self: object
         """
         # with parallel_backend("loky", inner_max_num_threads=n_jobs):
-        self._fit_transform(X, y, return_bag_of_words=True)
+        self._fit_transform(X, y, return_bag_of_words=self.return_sparse)
         return self
 
     def _transform(self, X, y=None):

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -329,7 +329,7 @@ class SFAFast(BaseCollectionTransformer):
         self: object
         """
         # with parallel_backend("loky", inner_max_num_threads=n_jobs):
-        self._fit_transform(X, y, return_bag_of_words=False)
+        self._fit_transform(X, y, return_bag_of_words=True)
         return self
 
     def _transform(self, X, y=None):

--- a/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
@@ -5,7 +5,8 @@ import sys
 import numpy as np
 import pytest
 
-from aeon.transformations.collection.dictionary_based._sfa import SFA
+from aeon.datasets import load_classification
+from aeon.transformations.collection.dictionary_based import SFA, SFAFast
 
 
 @pytest.mark.parametrize(
@@ -224,3 +225,27 @@ def test_typed_dict():
     word_list2 = p2.bag_to_string(p2.transform(X, y)[0][0])
 
     assert word_list == word_list2
+
+
+def test_sfa_fast_transform_after_fit():
+    """Test transform called after fit returns the same result as fit_transform()."""
+    X_train, y_train = load_classification("SmoothSubspace", split="train")
+
+    # Fit, then transform
+    sfa = SFAFast()
+    sfa.fit(X_train, y_train)
+    x = sfa.transform(X_train, y_train)
+
+    # Fit_transform, then transform
+    sfa = SFAFast()
+    sfa.fit_transform(X_train, y_train)
+    y = sfa.transform(X_train, y_train)
+
+    # Assert that the two csr_matrix are equal
+    assert (
+        x.shape == y.shape
+        and x.dtype == y.dtype
+        and np.all(x.indices == y.indices)
+        and np.all(x.indptr == y.indptr)
+        and np.allclose(x.data, y.data)
+    )

--- a/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 import pytest
 
-from aeon.datasets import load_classification
+from aeon.datasets import load_unit_test
 from aeon.transformations.collection.dictionary_based import SFA, SFAFast
 
 
@@ -229,7 +229,7 @@ def test_typed_dict():
 
 def test_sfa_fast_transform_after_fit():
     """Test transform called after fit returns the same result as fit_transform()."""
-    X_train, y_train = load_classification("SmoothSubspace", split="train")
+    X_train, y_train = load_unit_test(split="train")
 
     # Fit, then transform
     sfa = SFAFast()


### PR DESCRIPTION
This PR fixes a bug with SFAFast throwing an error when calling `transform()` after `fit()`

As reported by @baraline SFAFast had the following error:

```python
from aeon.datasets import load_classification
from aeon.transformations.collection.dictionary_based import SFAFast
X_train, y_train = load_classification("SmoothSubspace", split="train")
SFAFast().fit(X_train, y_train).transform(X_train, y_train)
```

results in

```
File ~\Documents\aeon\aeon\transformations\collection\dictionary_based\_sfa_fast.py:1245, in create_bag_transform(X_index, feature_count, feature_selection, relevant_features, sfa_words, remove_repeat_words)
   1241         all_win_words[j, :] = np.bincount(
   1242             sfa_words[j][masked], minlength=feature_count
   1243         )
   1244     else:
-> 1245         all_win_words[j, :] = np.bincount(sfa_words[j], minlength=feature_count)
   1246 else:
   1247     if remove_repeat_words:

ValueError: could not broadcast input array from shape (20324,) into shape (0,)
```


This PR fixes the above problem and also adds a test case.