### PR TITLE
[MNT] Fixing CI issues and separate doctests from regular CI runners

### DIFF
--- a/.github/actions/cpu_all_extras/action.yml
+++ b/.github/actions/cpu_all_extras/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Install CPU TensorFlow
-      if: ${{ runner.os == 'Linux' && inputs.python_version != '3.13' }}
+      if: ${{ runner.os == 'Linux' && inputs.python_version != '3.13.5' }}
       uses: nick-fields/retry@v3
       with:
         timeout_minutes: 30

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -208,6 +208,40 @@ jobs:
           # Save cache with the current date (ENV set in numba_cache action)
           key: numba-pytest-${{ runner.os }}-${{ matrix.python-version}}-${{ env.CURRENT_DATE }}
 
+  doctests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'no numba cache') }}
+        name: Use numba cache to set env variables but not restore cache
+        uses: ./.github/actions/numba_cache
+        with:
+          cache_name: "doctests"
+          runner_os: ${{ runner.os }}
+          python_version: "3.12"
+          restore_cache: "false"
+
+      - name: Install aeon and dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: python -m pip install .[all_extras,dev]
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: python -m pytest -n logical --doctest-only
+
   codecov:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macOS-14, windows-2022 ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13.5" ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -178,7 +178,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@v1.0
         with:
-          swap-size-gb: 10
+          swap-size-gb: 8
 
       - name: Use numba cache to set env variables but not restore cache
         uses: ./.github/actions/numba_cache

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -41,7 +41,8 @@ jobs:
           runner_os: ${{ runner.os }}
           python_version: "3.12"
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "dev,binder"
 

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -76,7 +76,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@v1.0
         with:
-          swap-size-gb: 10
+          swap-size-gb: 8
 
       - if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'no numba cache') }}
         name: Restore numba cache

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -86,7 +86,8 @@ jobs:
           runner_os: ${{ runner.os }}
           python_version: ${{ matrix.python-version }}
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
         with:
           python_version: ${{ matrix.python-version }}
           additional_extras: "dev"
@@ -116,7 +117,8 @@ jobs:
       - name: Disable Numba JIT
         run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
-      - uses: ./.github/actions/cpu_all_extras
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
         with:
           additional_extras: "unstable_extras,dev"
 

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macOS-14, windows-2022 ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13.5" ]
         # skip python versions unless the PR has the 'full pytest actions' label
         pr-testing:
           - ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions')) }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
+        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --cov=aeon --cov-report=xml
 
   codecov:
     # run the code coverage job if a PR has the 'codecov actions' label

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -113,8 +113,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Disable Numba JIT
-        run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+#      - name: Disable Numba JIT
+#        run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
       - uses: ./.github/actions/cpu_all_extras
         with:
@@ -124,7 +124,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --cov=aeon --cov-report=xml --timeout 1800
+        run: python -m pytest -n logical --cov=aeon --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -158,7 +158,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --cov=aeon --cov-report=xml
+        run: python -m pytest -n logical --cov=aeon --cov-report=xml --timeout 1800
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --cov=aeon --cov-report=xml
+        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   codecov:
     # run the code coverage job if a PR has the 'codecov actions' label
@@ -113,8 +113,8 @@ jobs:
         with:
           python-version: "3.12"
 
-#      - name: Disable Numba JIT
-#        run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+      - name: Disable Numba JIT
+        run: echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
       - uses: ./.github/actions/cpu_all_extras
         with:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -99,6 +99,38 @@ jobs:
         # run the full test suit if a PR has the 'full pytest actions' label
         run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
+  doctests:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'no numba cache') }}
+        name: Restore numba cache
+        uses: ./.github/actions/numba_cache
+        with:
+          cache_name: "doctests"
+          runner_os: ${{ runner.os }}
+          python_version: "3.12"
+
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
+        with:
+          additional_extras: "dev"
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: python -m pytest -n logical --doctest-only
+
+
   codecov:
     # run the code coverage job if a PR has the 'codecov actions' label
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'codecov actions') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macOS-14, windows-2022 ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13.5" ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@v1.0
         with:
-          swap-size-gb: 10
+          swap-size-gb: 8
 
       - uses: actions/download-artifact@v4
         with:

--- a/aeon/transformations/collection/dictionary_based/_borf.py
+++ b/aeon/transformations/collection/dictionary_based/_borf.py
@@ -615,7 +615,7 @@ def _sax(
     )
     global_std = np.std(a)
     if global_std == 0:
-        return np.zeros((n_windows, word_length), dtype=np.uint8)
+        return np.zeros((n_windows, word_length), dtype=np.uint16)
     seg_size = window_size // word_length
     n_windows = _get_n_windows(
         sequence_size=a.size, window_size=window_size, dilation=dilation, stride=stride
@@ -646,7 +646,7 @@ def _sax(
                 sigma_global=global_std,
                 sigma_threshold=min_window_to_signal_std_ratio,
             )
-    return np.digitize(out, bins).astype(np.uint8)
+    return np.digitize(out, bins).astype(np.uint16)
 
 
 @nb.njit(fastmath=True, cache=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ mypy_path = "aeon/"
 
 [tool.pytest.ini_options]
 testpaths = "aeon"
-doctest_plus = "enabled"
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "pytest-doctestplus",
     "pytest-mock",
     "pytest-randomly",
+    "pytest-remotedata",
     "pytest-rerunfailures",
     "pytest-timeout",
     "pytest-xdist[psutil]",
@@ -171,19 +172,18 @@ doctest_optionflags = [
     "ELLIPSIS",
     "FLOAT_CMP",
 ]
-addopts = '''
-    --doctest-modules
-    --durations 20
-    --timeout 600
-    --showlocals
-    --dist worksteal
-    --reruns 3
-    --reruns-delay 3
-    --rerun-except Error
-    --rerun-except Exception
-'''
-filterwarnings = '''
-    ignore::UserWarning
-    ignore:numpy.dtype size changed
-    ignore:numpy.ufunc size changed
-'''
+addopts = [
+    "--durations 20",
+    "--timeout 600",
+    "--showlocals",
+    "--dist worksteal",
+    "--reruns 3",
+    "--reruns-delay 3",
+    "--rerun-except Error",
+    "--rerun-except Exception",
+]
+filterwarnings = [
+    "ignore::UserWarning",
+    "ignore:numpy.dtype size changed",
+    "ignore:numpy.ufunc size changed",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ unstable_extras = [
 
 # development dependencies
 dev = [
-    "backoff",
-    "httpx",
     "pre-commit",
     "pytest",
     "pytest-cov",
@@ -97,7 +95,6 @@ dev = [
     "pytest-timeout",
     "pytest-xdist[psutil]",
     "pytest-rerunfailures",
-    "wheel",
 ]
 binder = [
     "notebook",
@@ -175,9 +172,9 @@ addopts = '''
     --showlocals
     --dist worksteal
     --reruns 3
-    --only-rerun "crashed while running"
-    --only-rerun "Bad magic number for file header"
-    --only-rerun "accessible `.keras` zip file."
+    --reruns-delay 3
+    --rerun-except Error
+    --rerun-except Exception
 '''
 filterwarnings = '''
     ignore::UserWarning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,9 +174,9 @@ addopts = '''
     --timeout 600
     --showlocals
     --dist worksteal
-    --reruns 2
+    --reruns 3
     --only-rerun "crashed while running"
-    --only-rerun "zipfile.BadZipFile"
+    --only-rerun "Bad magic number for file header"
     --only-rerun "accessible `.keras` zip file."
 '''
 filterwarnings = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,12 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-doctestplus",
     "pytest-mock",
     "pytest-randomly",
+    "pytest-rerunfailures",
     "pytest-timeout",
     "pytest-xdist[psutil]",
-    "pytest-rerunfailures",
 ]
 binder = [
     "notebook",
@@ -163,8 +164,13 @@ convention = "numpy"
 mypy_path = "aeon/"
 
 [tool.pytest.ini_options]
-# ignore certain folders and pytest warnings
 testpaths = "aeon"
+doctest_plus = "enabled"
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "ELLIPSIS",
+    "FLOAT_CMP",
+]
 addopts = '''
     --doctest-modules
     --durations 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,14 +173,14 @@ doctest_optionflags = [
     "FLOAT_CMP",
 ]
 addopts = [
-    "--durations 20",
-    "--timeout 600",
+    "--durations=20",
+    "--timeout=600",
     "--showlocals",
-    "--dist worksteal",
-    "--reruns 3",
-    "--reruns-delay 3",
-    "--rerun-except Error",
-    "--rerun-except Exception",
+    "--dist=worksteal",
+    "--reruns=3",
+    "--reruns-delay=3",
+    "--rerun-except=Error",
+    "--rerun-except=Exception",
 ]
 filterwarnings = [
     "ignore::UserWarning",


### PR DESCRIPTION
- Updates actions to use Python 3.13.5 where relevant to avoid an issue with numba and 3.13.4 which is now fixed. For some reason the CI was still using 3.13.4 when not specifying to use the latest.
- Reduce the amount of swap space requested as sometimes we get an error for requesting to much (this is recent. no idea why)
- Separate doctests out into its own action and stops running doctests in other workflows. This is mainly because of the coverage test failure currently happening on all codecov runs where a bunch of doctests have different output when numba is disables
   - an alternative is to just skip the doctests that are failing, but this is tedious and will probably reoccur down the line
   - another alternative is to keep doctests on all regular pytest runs and disable it only for codecov, but doing it like this makes the other workflows slightly quicker and allows us to remove a lot of the skipping done currently I believe
   - may reduce our current coverage if the only thing covering it currently is the doctest. we have not had a report uploaded in over a week so difficult to tell based on the current one which is from this or other PRs
 - use larger dtype for BORF as that was causing errors in codecov also
 - Adds some doctest config (https://docs.python.org/3/library/doctest.html#option-flags-and-directives). Should reduce the strictness or white space, floating point numbers and allow the use of ellipsis to replace any substring and still pass (can be used to reduce the size of output i.e. classes and arrays)
 - alters the pytest config a bit to hopefully help in the ever growing battle against random tensorflow crashes