### PR TITLE
[ENH] Fix typo in forecaster docstring

### DIFF
--- a/aeon/forecasting/_tvp.py
+++ b/aeon/forecasting/_tvp.py
@@ -25,7 +25,7 @@ class TVPForecaster(BaseForecaster):
     Parameters
     ----------
     window : int
-        Number of autoregressive lags to use, called window to co-ordinate with
+        Number of autoregressive lags to use, called window to coordinate with
         RegressionForecaster.
     var : float, default=0.01
         Observation noise variance. ``var`` controls the influence of recency in the


### PR DESCRIPTION
co-ordinate to coordinate is triggering the codespell 