### PR TITLE
[BUG] stop overwriting y in BaseSegmenter

### DIFF
--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -118,7 +118,7 @@ class BaseSegmenter(BaseSeriesEstimator):
             axis = self.axis
         X = self._preprocess_series(X, axis, True)
         if y is not None:
-            y = self._check_y(y)
+            self._check_y(y)
         self._fit(X=X, y=y)
         self.is_fitted = True
         return self


### PR DESCRIPTION

#### Reference Issues/PRs

#2958 

[fchavelli](https://github.com/aeon-toolkit/aeon/issues?q=is%3Aissue%20state%3Aopen%20author%3Afchavelli) spotted that y was being overwritten by check_y in the BaseSegmenter. Since we do not have any supervised/semi-supervised segmenters, we had not  noticed,  so thanks for spotting this. Simple fix

