### PR TITLE
[ENH] Update testing data dictionary with series testing data

### DIFF
--- a/aeon/testing/data_generation/__init__.py
+++ b/aeon/testing/data_generation/__init__.py
@@ -14,6 +14,8 @@ __all__ = [
     "make_example_2d_numpy_series",
     "make_example_pandas_series",
     "make_example_dataframe_series",
+    # labels
+    "make_anomaly_detection_labels",
 ]
 
 
@@ -26,6 +28,7 @@ from aeon.testing.data_generation._collection import (
     make_example_dataframe_list,
     make_example_multi_index_dataframe,
 )
+from aeon.testing.data_generation._labels import make_anomaly_detection_labels
 from aeon.testing.data_generation._series import (
     make_example_1d_numpy,
     make_example_2d_numpy_series,

--- a/aeon/testing/data_generation/_labels.py
+++ b/aeon/testing/data_generation/_labels.py
@@ -10,7 +10,8 @@ def make_anomaly_detection_labels(
 ) -> np.ndarray:
     """Generate anomaly detection labels.
 
-    Generates a simple 0/1 anomaly labels for testing purposes.
+    Creates a boolean array of length ``n_labels`` with ``ceil(anomaly_rate*n_labels)`` 
+    anomalies at random positions.
 
     Parameters
     ----------
@@ -31,6 +32,6 @@ def make_anomaly_detection_labels(
     rng = np.random.RandomState(random_state)
     n_anomalies = np.ceil(n_labels * anomaly_rate)
     anomaly_indices = rng.choice(n_labels, size=int(n_anomalies), replace=False)
-    y = np.zeros(n_labels, dtype=int)
+    y = np.zeros(n_labels, dtype=bool)
     y[anomaly_indices] = 1
     return y

--- a/aeon/testing/data_generation/_labels.py
+++ b/aeon/testing/data_generation/_labels.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import numpy as np
+
+
+def make_anomaly_detection_labels(
+    n_labels: int,
+    anomaly_rate: float = 0.01,
+    random_state: Optional[int] = None,
+) -> np.ndarray:
+    """Generate anomaly detection labels.
+
+    Generates a simple 0/1 anomaly labels for testing purposes.
+
+    Parameters
+    ----------
+    n_labels : int
+        The number of labels to generate.
+    anomaly_rate : float, default=0.01
+        The proportion of anomalies in the generated labels, between 0 and 1.
+        For example, if `anomaly_rate` is 0.01, then approximately 1% of the labels
+        will be anomalies (1s).
+    random_state : int or None, default=None
+        Seed for random number generation.
+
+    Returns
+    -------
+    y : np.ndarray
+        An array of labels indicating anomalies.
+    """
+    rng = np.random.RandomState(random_state)
+    n_anomalies = np.ceil(n_labels * anomaly_rate)
+    anomaly_indices = rng.choice(n_labels, size=int(n_anomalies), replace=False)
+    y = np.zeros(n_labels, dtype=int)
+    y[anomaly_indices] = 1
+    return y

--- a/aeon/testing/data_generation/_labels.py
+++ b/aeon/testing/data_generation/_labels.py
@@ -10,7 +10,7 @@ def make_anomaly_detection_labels(
 ) -> np.ndarray:
     """Generate anomaly detection labels.
 
-    Creates a boolean array of length ``n_labels`` with ``ceil(anomaly_rate*n_labels)`` 
+    Creates a boolean array of length ``n_labels`` with ``ceil(anomaly_rate*n_labels)``
     anomalies at random positions.
 
     Parameters

--- a/aeon/testing/data_generation/_series.py
+++ b/aeon/testing/data_generation/_series.py
@@ -64,7 +64,7 @@ def make_example_1d_numpy(
     if return_y is not None:
         if return_y == "anomaly" or return_y == "anomaly_detection":
             y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
-            anomaly = y == 1
+            anomaly = [i for i in range(len(y)) if y[i] == 1]
             X[anomaly] = -X[anomaly]
         else:
             raise ValueError(
@@ -142,7 +142,7 @@ def make_example_2d_numpy_series(
     if return_y is not None:
         if return_y == "anomaly" or return_y == "anomaly_detection":
             y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
-            anomaly = y == 1
+            anomaly = [i for i in range(len(y)) if y[i] == 1]
             if axis == 1:
                 X[:, anomaly] = -X[:, anomaly]
             else:
@@ -215,7 +215,7 @@ def make_example_pandas_series(
     if return_y is not None:
         if return_y == "anomaly" or return_y == "anomaly_detection":
             y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
-            anomaly = y == 1
+            anomaly = [i for i in range(len(y)) if y[i] == 1]
             X[anomaly] = -X[anomaly]
         else:
             raise ValueError(
@@ -307,11 +307,11 @@ def make_example_dataframe_series(
     if return_y is not None:
         if return_y == "anomaly" or return_y == "anomaly_detection":
             y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
-            anomaly = y == 1
+            anomaly = [i for i in range(len(y)) if y[i] == 1]
             if axis == 1:
-                X[:, anomaly] = -X[:, anomaly]
+                X.iloc[:, anomaly] = -X.iloc[:, anomaly]
             else:
-                X[anomaly, :] = -X[anomaly, :]
+                X.iloc[anomaly, :] = -X.iloc[anomaly, :]
         else:
             raise ValueError(
                 f"{return_y} value for return_y is not supported, see the docstring "

--- a/aeon/testing/data_generation/_series.py
+++ b/aeon/testing/data_generation/_series.py
@@ -8,16 +8,19 @@ __all__ = [
     "make_example_dataframe_series",
 ]
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
 
+from aeon.testing.data_generation import make_anomaly_detection_labels
+
 
 def make_example_1d_numpy(
     n_timepoints: int = 12,
-    random_state: Union[int, None] = None,
-) -> np.ndarray:
+    random_state: Optional[int] = None,
+    return_y: Optional[str] = None,
+) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
     """Randomly generate 1D numpy X.
 
     Generates data in 1D 'np.ndarray' format.
@@ -28,11 +31,21 @@ def make_example_1d_numpy(
         The number of features/series length to generate.
     random_state : int or None, default=None
         Seed for random number generation.
+    return_y : str or None, default=None
+        If not None, returns an array of relevant labels alongside the generated data.
+        Valid options are None and "anomaly".
 
     Returns
     -------
     X : np.ndarray
         Randomly generated 1D data.
+    y : np.ndarray, optional
+        If `return_y` is not None, returns an array of relevant labels.
+
+    Raises
+    ------
+    ValueError
+        If `return_y` is not None and not one of the valid options.
 
     Examples
     --------
@@ -46,15 +59,30 @@ def make_example_1d_numpy(
      0.43758721 0.891773  ]
     """
     rng = np.random.RandomState(random_state)
-    return rng.uniform(size=(n_timepoints,))
+    X = rng.uniform(size=(n_timepoints,))
+
+    if return_y is not None:
+        if return_y == "anomaly" or return_y == "anomaly_detection":
+            y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
+            anomaly = y == 1
+            X[anomaly] = -X[anomaly]
+        else:
+            raise ValueError(
+                f"{return_y} value for return_y is not supported, see the docstring "
+                f"for valid options."
+            )
+
+        return X, y
+    return X
 
 
 def make_example_2d_numpy_series(
     n_timepoints: int = 12,
     n_channels: int = 1,
-    random_state: Union[int, None] = None,
+    random_state: Optional[int] = None,
     axis: int = 1,
-) -> np.ndarray:
+    return_y: Optional[str] = None,
+) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
     """Randomly generate 2D numpy X.
 
     Generates data in 2D 'np.ndarray' format.
@@ -70,11 +98,21 @@ def make_example_2d_numpy_series(
     axis : int, default=1
         The axis to for the series timepoints. If 1, returns the shape
         (n_channels, n_timepoints). If 0, returns the shape (n_timepoints, n_channels).
+    return_y : str or None, default=None
+        If not None, returns an array of relevant labels alongside the generated data.
+        Valid options are None and "anomaly".
 
     Returns
     -------
     X : np.ndarray
         Randomly generated 2D data.
+    y : np.ndarray, optional
+        If `return_y` is not None, returns an array of relevant labels.
+
+    Raises
+    ------
+    ValueError
+        If `return_y` is not None and not one of the valid options.
 
     Examples
     --------
@@ -95,18 +133,36 @@ def make_example_2d_numpy_series(
     """
     rng = np.random.RandomState(random_state)
     if axis == 1:
-        return rng.uniform(size=(n_channels, n_timepoints))
+        X = rng.uniform(size=(n_channels, n_timepoints))
     elif axis == 0:
-        return rng.uniform(size=(n_timepoints, n_channels))
+        X = rng.uniform(size=(n_timepoints, n_channels))
     else:
         raise ValueError(f"axis: {axis} is not supported, please use 0 or 1.")
+
+    if return_y is not None:
+        if return_y == "anomaly" or return_y == "anomaly_detection":
+            y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
+            anomaly = y == 1
+            if axis == 1:
+                X[:, anomaly] = -X[:, anomaly]
+            else:
+                X[anomaly, :] = -X[anomaly, :]
+        else:
+            raise ValueError(
+                f"{return_y} value for return_y is not supported, see the docstring "
+                f"for valid options."
+            )
+
+        return X, y
+    return X
 
 
 def make_example_pandas_series(
     n_timepoints: int = 12,
     index_type=None,
-    random_state: Union[int, None] = None,
-) -> pd.Series:
+    random_state: Optional[int] = None,
+    return_y: Optional[str] = None,
+) -> Union[pd.Series, tuple[pd.Series, np.ndarray]]:
     """Randomly generate pandas Series X.
 
     Generates data in 'pd.Series' format.
@@ -120,11 +176,21 @@ def make_example_pandas_series(
         If None, uses default integer index.
     random_state : int or None, default=None
         Seed for random number generation.
+    return_y : str or None, default=None
+        If not None, returns an array of relevant labels alongside the generated data.
+        Valid options are None and "anomaly".
+
+    Raises
+    ------
+    ValueError
+        If `return_y` is not None and not one of the valid options.
 
     Returns
     -------
     X : pd.Series
         Randomly generated 1D data.
+    y : np.ndarray, optional
+        If `return_y` is not None, returns an array of relevant labels.
 
     Examples
     --------
@@ -144,16 +210,31 @@ def make_example_pandas_series(
     """
     rng = np.random.RandomState(random_state)
     index = _make_index(n_timepoints, index_type)
-    return pd.Series(rng.uniform(size=(n_timepoints,)), index=index)
+    X = pd.Series(rng.uniform(size=(n_timepoints,)), index=index)
+
+    if return_y is not None:
+        if return_y == "anomaly" or return_y == "anomaly_detection":
+            y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
+            anomaly = y == 1
+            X[anomaly] = -X[anomaly]
+        else:
+            raise ValueError(
+                f"{return_y} value for return_y is not supported, see the docstring "
+                f"for valid options."
+            )
+
+        return X, y
+    return X
 
 
 def make_example_dataframe_series(
     n_timepoints: int = 12,
     n_channels: int = 1,
     index_type=None,
-    random_state: Union[int, None] = None,
+    random_state: Optional[int] = None,
     axis: int = 1,
-) -> pd.DataFrame:
+    return_y: Optional[str] = None,
+) -> Union[pd.DataFrame, tuple[pd.DataFrame, np.ndarray]]:
     """Randomly generate pandas DataFrame X.
 
     Generates data in 'pd.DataFrame' format.
@@ -172,11 +253,21 @@ def make_example_dataframe_series(
     axis : int, default=1
         The axis to for the series timepoints. If 1, returns the shape
         (n_channels, n_timepoints). If 0, returns the shape (n_timepoints, n_channels).
+    return_y : str or None, default=None
+        If not None, returns an array of relevant labels alongside the generated data.
+        Valid options are None and "anomaly".
 
     Returns
     -------
     X : pd.DataFrame
         Randomly generated 2D data.
+    y : np.ndarray, optional
+        If `return_y` is not None, returns an array of relevant labels.
+
+    Raises
+    ------
+    ValueError
+        If `return_y` is not None and not one of the valid options.
 
     Examples
     --------
@@ -199,19 +290,36 @@ def make_example_dataframe_series(
     rng = np.random.RandomState(random_state)
     index = _make_index(n_timepoints, index_type)
     if axis == 1:
-        return pd.DataFrame(
+        X = pd.DataFrame(
             rng.uniform(size=(n_channels, n_timepoints)),
             index=np.arange(n_channels),
             columns=index,
         )
     elif axis == 0:
-        return pd.DataFrame(
+        X = pd.DataFrame(
             rng.uniform(size=(n_timepoints, n_channels)),
             columns=np.arange(n_channels),
             index=index,
         )
     else:
         raise ValueError(f"axis: {axis} is not supported, please use 0 or 1.")
+
+    if return_y is not None:
+        if return_y == "anomaly" or return_y == "anomaly_detection":
+            y = make_anomaly_detection_labels(n_timepoints, random_state=random_state)
+            anomaly = y == 1
+            if axis == 1:
+                X[:, anomaly] = -X[:, anomaly]
+            else:
+                X[anomaly, :] = -X[anomaly, :]
+        else:
+            raise ValueError(
+                f"{return_y} value for return_y is not supported, see the docstring "
+                f"for valid options."
+            )
+
+        return X, y
+    return X
 
 
 def _make_index(n_timepoints, index_type=None):

--- a/aeon/testing/data_generation/tests/test_labels.py
+++ b/aeon/testing/data_generation/tests/test_labels.py
@@ -1,0 +1,22 @@
+"""Tests for label generation functions."""
+
+import numpy as np
+
+from aeon.testing.data_generation import make_anomaly_detection_labels
+
+
+def test_make_anomaly_detection_labels():
+    """Test anomaly detection label generation."""
+    labels = make_anomaly_detection_labels(50)
+
+    assert isinstance(labels, np.ndarray)
+    assert labels.shape == (50,)
+    assert np.all(np.isin(labels, [0, 1]))
+    assert np.sum(labels) == 1
+
+    labels2 = make_anomaly_detection_labels(100, anomaly_rate=0.2)
+
+    assert isinstance(labels2, np.ndarray)
+    assert labels2.shape == (100,)
+    assert np.all(np.isin(labels2, [0, 1]))
+    assert np.sum(labels2) == 20

--- a/aeon/testing/data_generation/tests/test_series.py
+++ b/aeon/testing/data_generation/tests/test_series.py
@@ -27,6 +27,18 @@ def test_make_example_1d_numpy(n_timepoints):
     assert X.shape == (n_timepoints,)
     assert is_single_series(X)
 
+    X, y = make_example_1d_numpy(n_timepoints=n_timepoints, return_y="anomaly")
+
+    assert isinstance(X, np.ndarray)
+    assert X.shape == (n_timepoints,)
+    assert is_single_series(X)
+    assert isinstance(y, np.ndarray)
+    assert y.shape == (n_timepoints,)
+    assert np.all(np.isin(y, [0, 1]))
+
+    with pytest.raises(ValueError, match="value for return_y is not supported"):
+        make_example_1d_numpy(n_timepoints=n_timepoints, return_y="invalid")
+
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 @pytest.mark.parametrize("n_channels", N_CHANNELS)
@@ -48,6 +60,25 @@ def test_make_example_2d_numpy_series(n_timepoints, n_channels):
     assert X.shape == (n_channels, n_timepoints)
     assert is_single_series(X)
 
+    (
+        X,
+        y,
+    ) = make_example_2d_numpy_series(
+        n_timepoints=n_timepoints, n_channels=n_channels, axis=1, return_y="anomaly"
+    )
+
+    assert isinstance(X, np.ndarray)
+    assert X.shape == (n_channels, n_timepoints)
+    assert is_single_series(X)
+    assert isinstance(y, np.ndarray)
+    assert y.shape == (n_timepoints,)
+    assert np.all(np.isin(y, [0, 1]))
+
+    with pytest.raises(ValueError, match="value for return_y is not supported"):
+        make_example_2d_numpy_series(
+            n_timepoints=n_timepoints, n_channels=n_channels, axis=1, return_y="invalid"
+        )
+
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
 def test_make_example_pandas_series(n_timepoints):
@@ -57,6 +88,18 @@ def test_make_example_pandas_series(n_timepoints):
     assert isinstance(X, pd.Series)
     assert X.shape == (n_timepoints,)
     assert is_single_series(X)
+
+    X, y = make_example_pandas_series(n_timepoints=n_timepoints, return_y="anomaly")
+
+    assert isinstance(X, pd.Series)
+    assert X.shape == (n_timepoints,)
+    assert is_single_series(X)
+    assert isinstance(y, np.ndarray)
+    assert y.shape == (n_timepoints,)
+    assert np.all(np.isin(y, [0, 1]))
+
+    with pytest.raises(ValueError, match="value for return_y is not supported"):
+        make_example_pandas_series(n_timepoints=n_timepoints, return_y="invalid")
 
 
 @pytest.mark.parametrize("n_timepoints", N_TIMEPOINTS)
@@ -78,3 +121,22 @@ def test_make_example_dataframe_series(n_timepoints, n_channels):
     assert isinstance(X, pd.DataFrame)
     assert X.shape == (n_channels, n_timepoints)
     assert is_single_series(X)
+
+    (
+        X,
+        y,
+    ) = make_example_dataframe_series(
+        n_timepoints=n_timepoints, n_channels=n_channels, axis=1, return_y="anomaly"
+    )
+
+    assert isinstance(X, pd.DataFrame)
+    assert X.shape == (n_channels, n_timepoints)
+    assert is_single_series(X)
+    assert isinstance(y, np.ndarray)
+    assert y.shape == (n_timepoints,)
+    assert np.all(np.isin(y, [0, 1]))
+
+    with pytest.raises(ValueError, match="value for return_y is not supported"):
+        make_example_dataframe_series(
+            n_timepoints=n_timepoints, n_channels=n_channels, axis=1, return_y="invalid"
+        )

--- a/aeon/testing/testing_data.py
+++ b/aeon/testing/testing_data.py
@@ -14,17 +14,20 @@ from aeon.segmentation import BaseSegmenter
 from aeon.similarity_search.collection import BaseCollectionSimilaritySearch
 from aeon.similarity_search.series import BaseSeriesSimilaritySearch
 from aeon.testing.data_generation import (
+    make_example_1d_numpy,
     make_example_2d_dataframe_collection,
     make_example_2d_numpy_collection,
     make_example_2d_numpy_series,
     make_example_3d_numpy,
     make_example_3d_numpy_list,
     make_example_dataframe_list,
+    make_example_dataframe_series,
     make_example_multi_index_dataframe,
+    make_example_pandas_series,
 )
 from aeon.transformations.collection import BaseCollectionTransformer
 from aeon.transformations.series import BaseSeriesTransformer
-from aeon.utils.conversion import convert_collection
+from aeon.utils.conversion import convert_collection, convert_series
 
 data_rng = np.random.RandomState(42)
 
@@ -642,48 +645,248 @@ MISSING_VALUES_REGRESSION = {
 
 # Series testing data
 
-X_series = make_example_2d_numpy_series(
-    n_timepoints=40,
-    n_channels=1,
-    axis=1,
-    random_state=data_rng.randint(np.iinfo(np.int32).max),
-)
-X_series2 = X_series[:, 20:40]
-X_series = X_series[:, :20]
-UNIVARIATE_SERIES_NONE = {"train": (X_series, None), "test": (X_series2, None)}
-
-X_series_mv = make_example_2d_numpy_series(
-    n_timepoints=40,
-    n_channels=2,
-    axis=1,
-    random_state=data_rng.randint(np.iinfo(np.int32).max),
-)
-X_series_mv2 = X_series_mv[:, 20:40]
-X_series_mv = X_series_mv[:, :20]
-MULTIVARIATE_SERIES_NONE = {
-    "train": (X_series_mv, None),
-    "test": (X_series_mv2, None),
+UNIVARIATE_SERIES = {
+    "pd.Series": {
+        "train": (
+            make_example_pandas_series(
+                n_timepoints=20,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+        "test": (
+            make_example_pandas_series(
+                n_timepoints=20,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+    },
+    "pd.DataFrame": {
+        "train": (
+            make_example_dataframe_series(
+                n_channels=1,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+        "test": (
+            make_example_dataframe_series(
+                n_channels=1,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+    },
+    "np.ndarray": {
+        "train": (
+            make_example_1d_numpy(
+                n_timepoints=20,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+        "test": (
+            make_example_1d_numpy(
+                n_timepoints=20,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+    },
 }
 
-X_series_mi = make_example_2d_numpy_series(
-    n_timepoints=40,
+UNIVARIATE_SERIES_ANOMALY = {
+    "pd.Series": {
+        "train": make_example_pandas_series(
+            n_timepoints=20,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+        "test": make_example_pandas_series(
+            n_timepoints=20,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+    },
+    "pd.DataFrame": {
+        "train": make_example_dataframe_series(
+            n_channels=1,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+        "test": make_example_dataframe_series(
+            n_channels=1,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+    },
+    "np.ndarray": {
+        "train": make_example_1d_numpy(
+            n_timepoints=20,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+        "test": make_example_1d_numpy(
+            n_timepoints=20,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+    },
+}
+
+MULTIVARIATE_SERIES = {
+    "pd.DataFrame": {
+        "train": (
+            make_example_dataframe_series(
+                n_channels=2,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+        "test": (
+            make_example_dataframe_series(
+                n_channels=2,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+    },
+    "np.ndarray": {
+        "train": (
+            make_example_2d_numpy_series(
+                n_channels=2,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+        "test": (
+            make_example_2d_numpy_series(
+                n_channels=2,
+                n_timepoints=20,
+                axis=1,
+                random_state=data_rng.randint(np.iinfo(np.int32).max),
+            ),
+            None,
+        ),
+    },
+}
+
+MULTIVARIATE_SERIES_ANOMALY = {
+    "pd.DataFrame": {
+        "train": make_example_dataframe_series(
+            n_channels=2,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+        "test": make_example_dataframe_series(
+            n_channels=2,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+    },
+    "np.ndarray": {
+        "train": make_example_2d_numpy_series(
+            n_channels=2,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+        "test": make_example_2d_numpy_series(
+            n_channels=2,
+            n_timepoints=20,
+            axis=1,
+            random_state=data_rng.randint(np.iinfo(np.int32).max),
+            return_y="anomaly",
+        ),
+    },
+}
+
+X_series_missing_train = make_example_2d_numpy_series(
     n_channels=1,
+    n_timepoints=20,
     axis=1,
     random_state=data_rng.randint(np.iinfo(np.int32).max),
 )
-X_series_mi2 = X_series_mi[:, 20:40]
-X_series_mi2[:, data_rng.choice(20, 1)] = np.nan
-X_series_mi = X_series_mi[:, :20]
-X_series_mi[:, data_rng.choice(20, 2)] = np.nan
-MISSING_VALUES_SERIES_NONE = {
-    "train": (X_series_mi, None),
-    "test": (X_series_mi2, None),
+X_series_missing_test = make_example_2d_numpy_series(
+    n_channels=1,
+    n_timepoints=20,
+    axis=1,
+    random_state=data_rng.randint(np.iinfo(np.int32).max),
+)
+X_series_missing_train[:, data_rng.choice(20, 1)] = np.nan
+X_series_missing_test[:, data_rng.choice(20, 2)] = np.nan
+
+MISSING_VALUES_SERIES = {
+    "pd.DataFrame": {
+        "train": (convert_series(X_series_missing_train, "pd.DataFrame"), None),
+        "test": (convert_series(X_series_missing_test, "pd.DataFrame"), None),
+    },
+    "np.ndarray": {
+        "train": (X_series_missing_train, None),
+        "test": (X_series_missing_test, None),
+    },
+}
+
+X_anomaly_missing_train, y_anomaly_missing_train = make_example_2d_numpy_series(
+    n_channels=1,
+    n_timepoints=20,
+    axis=1,
+    random_state=data_rng.randint(np.iinfo(np.int32).max),
+    return_y="anomaly",
+)
+X_anomaly_missing_test, y_anomaly_missing_test = make_example_2d_numpy_series(
+    n_channels=1,
+    n_timepoints=20,
+    axis=1,
+    random_state=data_rng.randint(np.iinfo(np.int32).max),
+    return_y="anomaly",
+)
+X_anomaly_missing_train[:, data_rng.choice(20, 1)] = np.nan
+X_anomaly_missing_test[:, data_rng.choice(20, 2)] = np.nan
+
+MISSING_VALUES_SERIES_ANOMALY = {
+    "pd.DataFrame": {
+        "train": (
+            convert_series(X_anomaly_missing_train, "pd.DataFrame"),
+            y_anomaly_missing_train,
+        ),
+        "test": (
+            convert_series(X_anomaly_missing_test, "pd.DataFrame"),
+            y_anomaly_missing_test,
+        ),
+    },
+    "np.ndarray": {
+        "train": (X_anomaly_missing_train, y_anomaly_missing_train),
+        "test": (X_anomaly_missing_test, y_anomaly_missing_test),
+    },
 }
 
 # All testing data
 
 FULL_TEST_DATA_DICT = {}
+
 # Collection
+
 FULL_TEST_DATA_DICT.update(
     {
         f"EqualLengthUnivariate-Classification-{k}": v
@@ -743,9 +946,31 @@ FULL_TEST_DATA_DICT.update(
 )
 
 # Series
-FULL_TEST_DATA_DICT.update({"UnivariateSeries-None": UNIVARIATE_SERIES_NONE})
-FULL_TEST_DATA_DICT.update({"MultivariateSeries-None": MULTIVARIATE_SERIES_NONE})
-FULL_TEST_DATA_DICT.update({"MissingValues-None": MISSING_VALUES_SERIES_NONE})
+
+FULL_TEST_DATA_DICT.update(
+    {f"UnivariateSeries-None-{k}": v for k, v in UNIVARIATE_SERIES.items()}
+)
+FULL_TEST_DATA_DICT.update(
+    {f"UnivariateSeries-Anomaly-{k}": v for k, v in UNIVARIATE_SERIES_ANOMALY.items()}
+)
+FULL_TEST_DATA_DICT.update(
+    {f"MultivariateSeries-None-{k}": v for k, v in MULTIVARIATE_SERIES.items()}
+)
+FULL_TEST_DATA_DICT.update(
+    {
+        f"MultivariateSeries-Anomaly-{k}": v
+        for k, v in MULTIVARIATE_SERIES_ANOMALY.items()
+    }
+)
+FULL_TEST_DATA_DICT.update(
+    {f"MissingValuesSeries-None-{k}": v for k, v in MISSING_VALUES_SERIES.items()}
+)
+FULL_TEST_DATA_DICT.update(
+    {
+        f"MissingValuesSeries-Anomaly-{k}": v
+        for k, v in MISSING_VALUES_SERIES_ANOMALY.items()
+    }
+)
 
 
 def _get_datatypes_for_estimator(estimator):
@@ -775,6 +1000,8 @@ def _get_datatypes_for_estimator(estimator):
     if not isinstance(inner_types, list):
         inner_types = [inner_types]
 
+    found_missing_type = False
+
     if isinstance(estimator, BaseCollectionEstimator):
         for inner_type in inner_types:
             if univariate:
@@ -797,15 +1024,34 @@ def _get_datatypes_for_estimator(estimator):
                     if s in FULL_TEST_DATA_DICT:
                         datatypes.append(s)
 
-        if missing_values:
+            if missing_values:
+                s = f"MissingValues-{task}-{inner_type}"
+                if s in FULL_TEST_DATA_DICT:
+                    datatypes.append(s)
+                found_missing_type = True
+
+        if missing_values and not found_missing_type:
             datatypes.append(f"MissingValues-{task}-numpy3D")
     elif isinstance(estimator, BaseSeriesEstimator):
-        if univariate:
-            datatypes.append(f"UnivariateSeries-{task}")
-        if multivariate:
-            datatypes.append(f"MultivariateSeries-{task}")
-        if missing_values:
-            datatypes.append(f"MissingValues-{task}")
+        for inner_type in inner_types:
+            if univariate:
+                s = f"UnivariateSeries-{task}-{inner_type}"
+                if s in FULL_TEST_DATA_DICT:
+                    datatypes.append(s)
+
+            if multivariate:
+                s = f"MultivariateSeries-{task}-{inner_type}"
+                if s in FULL_TEST_DATA_DICT:
+                    datatypes.append(s)
+
+            if missing_values:
+                s = f"MissingValuesSeries-{task}-{inner_type}"
+                if s in FULL_TEST_DATA_DICT:
+                    datatypes.append(s)
+                found_missing_type = True
+
+        if missing_values and not found_missing_type:
+            datatypes.append(f"MissingValues-{task}-np.ndarray")
     else:
         raise ValueError(f"Unknown estimator type: {type(estimator)}")
 
@@ -856,7 +1102,7 @@ def _get_task_for_estimator(estimator):
     data_label : str
         Task string for the estimator used in forming a key from FULL_TEST_DATA_DICT.
     """
-    # collection data with class labels
+    # collection data with 0/1 class labels
     if (
         isinstance(estimator, BaseClassifier)
         or isinstance(estimator, BaseEarlyClassifier)
@@ -871,13 +1117,15 @@ def _get_task_for_estimator(estimator):
         data_label = "Regression"
     # series data with no secondary input
     elif (
-        isinstance(estimator, BaseSeriesAnomalyDetector)
-        or isinstance(estimator, BaseSegmenter)
+        isinstance(estimator, BaseSegmenter)
         or isinstance(estimator, BaseSeriesTransformer)
         or isinstance(estimator, BaseForecaster)
         or isinstance(estimator, BaseSeriesSimilaritySearch)
     ):
         data_label = "None"
+    # series data with 0/1 anomaly labels
+    elif isinstance(estimator, BaseSeriesAnomalyDetector):
+        data_label = "Anomaly"
     else:
         raise ValueError(f"Unknown estimator type: {type(estimator)}")
 

--- a/aeon/testing/testing_data.py
+++ b/aeon/testing/testing_data.py
@@ -14,7 +14,6 @@ from aeon.segmentation import BaseSegmenter
 from aeon.similarity_search.collection import BaseCollectionSimilaritySearch
 from aeon.similarity_search.series import BaseSeriesSimilaritySearch
 from aeon.testing.data_generation import (
-    make_example_1d_numpy,
     make_example_2d_dataframe_collection,
     make_example_2d_numpy_collection,
     make_example_2d_numpy_series,
@@ -684,14 +683,16 @@ UNIVARIATE_SERIES = {
     },
     "np.ndarray": {
         "train": (
-            make_example_1d_numpy(
+            make_example_2d_numpy_series(
+                n_channels=1,
                 n_timepoints=20,
                 random_state=data_rng.randint(np.iinfo(np.int32).max),
             ),
             None,
         ),
         "test": (
-            make_example_1d_numpy(
+            make_example_2d_numpy_series(
+                n_channels=1,
                 n_timepoints=20,
                 random_state=data_rng.randint(np.iinfo(np.int32).max),
             ),
@@ -730,12 +731,14 @@ UNIVARIATE_SERIES_ANOMALY = {
         ),
     },
     "np.ndarray": {
-        "train": make_example_1d_numpy(
+        "train": make_example_2d_numpy_series(
+            n_channels=1,
             n_timepoints=20,
             random_state=data_rng.randint(np.iinfo(np.int32).max),
             return_y="anomaly",
         ),
-        "test": make_example_1d_numpy(
+        "test": make_example_2d_numpy_series(
+            n_channels=1,
             n_timepoints=20,
             random_state=data_rng.randint(np.iinfo(np.int32).max),
             return_y="anomaly",

--- a/aeon/testing/tests/test_testing_data.py
+++ b/aeon/testing/tests/test_testing_data.py
@@ -15,8 +15,10 @@ from aeon.testing.testing_data import (
     UNEQUAL_LENGTH_MULTIVARIATE_REGRESSION,
     UNEQUAL_LENGTH_UNIVARIATE_CLASSIFICATION,
     UNEQUAL_LENGTH_UNIVARIATE_REGRESSION,
+    UNIVARIATE_SERIES,
+    UNIVARIATE_SERIES_ANOMALY,
 )
-from aeon.utils.data_types import COLLECTIONS_DATA_TYPES
+from aeon.utils.data_types import COLLECTIONS_DATA_TYPES, SERIES_DATA_TYPES
 from aeon.utils.validation import (
     has_missing,
     is_collection,
@@ -31,6 +33,10 @@ def test_datatype_exists():
     for data in COLLECTIONS_DATA_TYPES:
         assert data in EQUAL_LENGTH_UNIVARIATE_CLASSIFICATION
         assert data in EQUAL_LENGTH_UNIVARIATE_REGRESSION
+
+    for data in SERIES_DATA_TYPES:
+        assert data in UNIVARIATE_SERIES
+        assert data in UNIVARIATE_SERIES_ANOMALY
 
 
 def test_testing_data_dict():


### PR DESCRIPTION
The current testing data for series estimators is rather shallow as around the time of the rework most series modules were much more experimental. Now that more work is going in to these modules i.e. anomaly detection and forecasting this PR expands the testing data available in the general testing and formats it more like the collection sets. For now the options are no labels and anomaly labels, but it is easy to expand this.