### PR TITLE
[ENH] Add axis to base forecaster

### DIFF
--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -226,7 +226,8 @@ class BaseForecaster(BaseSeriesEstimator):
         once.
 
         y : np.ndarray
-            The time series to make forecasts about.
+            The time series to make forecasts about.  Must be of shape
+            ``(n_channels, n_timepoints)`` if a multivariate time series.
         prediction_horizon : int
             The number of future time steps to forecast.
 


### PR DESCRIPTION
Fixes #2999 

adds an axis to fit and predict, default to 1 as elsewhere, and requires forecast, direct_forecast and iterative_forecast to be passed series with axis = 1
