### PR TITLE
[ENH] Deprecate MatrixProfile collection transformer and MPDist

### DIFF
--- a/aeon/distances/_mpdist.py
+++ b/aeon/distances/_mpdist.py
@@ -3,6 +3,7 @@
 from typing import Optional, Union
 
 import numpy as np
+from deprecated.sphinx import deprecated
 from numba import njit
 from numba.typed import List as NumbaList
 
@@ -10,6 +11,14 @@ from aeon.utils.conversion._convert_collection import _convert_collection_to_num
 from aeon.utils.validation.collection import _is_numpy_list_multivariate
 
 
+# TODO: remove in v1.5.0
+@deprecated(
+    version="1.3.0",
+    reason="mp_distance will be removed in v1.5.0. We recommend using the stumpy "
+    "version instead, see "
+    "https://stumpy.readthedocs.io/en/latest/api.html#stumpy.mpdist.",
+    category=FutureWarning,
+)
 def mp_distance(x: np.ndarray, y: np.ndarray, m: int = 0) -> float:
     r"""Matrix Profile Distance.
 
@@ -283,6 +292,12 @@ def _stomp_ab(
     return mp, ip
 
 
+# TODO: remove in v1.5.0
+@deprecated(
+    version="1.3.0",
+    reason="mp_pairwise_distance will be removed in v1.5.0.",
+    category=FutureWarning,
+)
 def mp_pairwise_distance(
     X: Union[np.ndarray, list[np.ndarray]],
     y: Optional[Union[np.ndarray, list[np.ndarray]]] = None,

--- a/aeon/transformations/collection/__init__.py
+++ b/aeon/transformations/collection/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "MinMaxScaler",
     "Normalizer",
     "PeriodogramTransformer",
+    "SeriesToCollectionBroadcaster",
     "SlopeTransformer",
     "SimpleImputer",
     "Tabularizer",
@@ -21,6 +22,7 @@ __all__ = [
 
 from aeon.transformations.collection._acf import AutocorrelationFunctionTransformer
 from aeon.transformations.collection._ar_coefficient import ARCoefficientTransformer
+from aeon.transformations.collection._broadcaster import SeriesToCollectionBroadcaster
 from aeon.transformations.collection._downsample import DownsampleTransformer
 from aeon.transformations.collection._dwt import DWTTransformer
 from aeon.transformations.collection._hog1d import HOG1DTransformer

--- a/aeon/transformations/collection/_matrix_profile.py
+++ b/aeon/transformations/collection/_matrix_profile.py
@@ -3,6 +3,7 @@
 __maintainer__ = []
 
 import numpy as np
+from deprecated.sphinx import deprecated
 
 from aeon.transformations.collection.base import BaseCollectionTransformer
 
@@ -192,6 +193,13 @@ def _stomp_self(ts, m):
     return mp
 
 
+# TODO: remove in v1.5.0
+@deprecated(
+    version="1.3.0",
+    reason="MatrixProfile will be removed in v1.5.0. Instead, use the "
+    "MatrixProfileSeriesTransformer and the SeriesToCollectionBroadcaster.",
+    category=FutureWarning,
+)
 class MatrixProfile(BaseCollectionTransformer):
     """Return the matrix profile and index profile for each time series of a dataset.
 

--- a/aeon/transformations/series/_matrix_profile.py
+++ b/aeon/transformations/series/_matrix_profile.py
@@ -1,11 +1,20 @@
 """Implements matrix profile transformation."""
 
-__maintainer__ = []
+__maintainer__ = ["TonyBagnall"]
 __all__ = ["MatrixProfileSeriesTransformer"]
+
+from deprecated.sphinx import deprecated
 
 from aeon.transformations.series.base import BaseSeriesTransformer
 
 
+# TODO: remove in v1.5.0
+@deprecated(
+    version="1.3.0",
+    reason="MatrixProfileSeriesTransformer will be renamed MatrixProfileTransformer in "
+    "v1.5.0.",
+    category=FutureWarning,
+)
 class MatrixProfileSeriesTransformer(BaseSeriesTransformer):
     """Calculate the matrix profile of a time series.
 


### PR DESCRIPTION
resolves #833 

after discussion, we have decided to remove our bespoke implementations of matrix profile to rely instead on those in the stumpy package, which are better maintained and more comprehensive than ours. This involves

deprecate MatrixProfile in collections
deprecate MPDist in distances
rename MatrixProfileSeriesTransformer -> MatrixProfileTransformer 

we could call it just MatrixProfile, but most others have the suffix. 