### PR TITLE
[BUG] Fix multirocket bug variables not updated in loop

### DIFF
--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -868,6 +868,9 @@ def _transform_multi(
 
                 feature_index_start = feature_index_end
 
+                combination_index += 1
+                n_channels_start = n_channels_end
+
     return features
 
 


### PR DESCRIPTION
Update variables `combination_index` and `n_channels_start` in loop for first order difference.

#### Reference Issues/PRs

Fixes #2967

#### What does this implement/fix? Explain your changes.

Ensures variables `combination_index` and `n_channels_start` are updated in loop for function _transform_multi for the first order difference.

### PR checklist

##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.