### PR TITLE
[BUG] MSM cost matrix initialisation bug fix.

### DIFF
--- a/aeon/distances/elastic/_msm.py
+++ b/aeon/distances/elastic/_msm.py
@@ -272,7 +272,7 @@ def _independent_cost_matrix(
 
     for i in range(1, y_size):
         if bounding_matrix[0, i]:
-            cost = _cost_independent(y[i], y[i - 1], x[0], c)
+            cost = _cost_independent(y[i], x[0], y[i - 1], c)
             cost_matrix[0][i] = cost_matrix[0][i - 1] + cost
 
     for i in range(1, x_size):
@@ -302,7 +302,7 @@ def _msm_dependent_cost_matrix(
             cost_matrix[i][0] = cost_matrix[i - 1][0] + cost
     for i in range(1, y_size):
         if bounding_matrix[0, i]:
-            cost = _cost_dependent(y[:, i], y[:, i - 1], x[:, 0], c)
+            cost = _cost_dependent(y[:, i], x[:, 0], y[:, i - 1], c)
             cost_matrix[0][i] = cost_matrix[0][i - 1] + cost
 
     for i in range(1, x_size):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->
Our MSM cost matrix initialisation passed the values in the wrong order to the cost function. This is aeons MSM cost matrix initilisation:

```python3
    for i in range(1, x_size):
        if bounding_matrix[i, 0]:
            cost = _cost_independent(x[i], x[i - 1], y[0], c)
            cost_matrix[i][0] = cost_matrix[i - 1][0] + cost

    for i in range(1, y_size):
        if bounding_matrix[0, i]:
            cost = _cost_independent(y[i], y[i - 1], x[0], c)  # <------ This line is wrong
            cost_matrix[0][i] = cost_matrix[0][i - 1] + cost
```

In the original paper is show that it should be _cost_independent(y[i], x[0], y[i - 1], c). 

See:
<img width="439" height="170" alt="Screenshot 2025-08-07 at 16 20 16" src="https://github.com/user-attachments/assets/bb842388-9c50-4850-8466-85a2ae7966ca" />

Source: https://ieeexplore.ieee.org/document/6189346

This PR fixes this minor bug.


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?

This should never really impact any results (I haven't changed any tests that check for expected results) just a minor edge case thing to fix for consitency.

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [x] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [x] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
