### PR TITLE
[MNT] Remove `ruptures` install to fix CI

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -174,7 +174,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Clear disik space
+      - name: Clear disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           dotnet: false

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Clear disik space
+      - name: Clear disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           dotnet: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Clear disik space
+      - name: Clear disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           dotnet: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ keywords = [
 classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
@@ -64,7 +63,7 @@ all_extras = [
     "pycatch22>=0.4.5",
     "pyod>=1.1.3",
     "pydot>=2.0.0",
-    "ruptures>=1.1.9",
+    # "ruptures>=1.1.9",     # Causing CI fails, temporarily removed
     "seaborn>=0.11.0",
     "sparse",
     "statsmodels>=0.12.1",


### PR DESCRIPTION
Annoying error crashing CI, not on our end pretty sure. Don't see any issues or releases on their repository though. Possibly caused by a pip or setuptools update or a new version for one of these on CI?

Python 3.13 for all OS crashing as well as all MacOS runners.