### PR TITLE
[BUG] Add load_regression encoding parameter

### DIFF
--- a/aeon/datasets/_data_loaders.py
+++ b/aeon/datasets/_data_loaders.py
@@ -234,7 +234,7 @@ def load_from_ts_file(
     replace_missing_vals_with="NaN",
     return_meta_data=False,
     return_type="auto",
-    encoding="utf-8"
+    encoding="utf-8",
 ):
     """Load time series .ts file into X and (optionally) y.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3086

#### What does this implement/fix? Explain your changes.

Add `encoding="utf-8"` parameter to `load_from_ts_file`.
```python
def load_from_ts_file(
    full_file_path_and_name,
    replace_missing_vals_with="NaN",
    return_meta_data=False,
    return_type="auto",
    encoding="utf-8"
):
```

This makes no changes for 99% of usages, but when a .ts file is not UTF-8 encoded, user can specify its encoding.
Example of fixed situation :
```python
import aeon.datasets
x, y = aeon.datasets.load_from_ts_file('K:/Monash_UEA_UCR_Regression_Archive/BIDMC32SpO2/BIDMC32SpO2_TRAIN.ts', encoding='cp1252')
```

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

No.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
