### PR TITLE
[MNT] Restrict tslearn version range in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ all_extras = [
     "keras>=3.6.0; python_version < '3.13'",
     "torch>=1.13.1",
     "tsfresh>=0.20.0",
-    "tslearn>=0.5.2",
+    "tslearn>=0.5.2,<0.7.0",
 ]
 dl = [
     "tensorflow>=2.14; python_version < '3.13'",


### PR DESCRIPTION
tslearn did a change on kshape, making our "Expected results" in the test of kshape false, putting an uperbound until we fix the test

see Issue #3108