### PR TITLE
[ENH] Implement TS-QUAD configuration option in ElasticEnsemble

### DIFF
--- a/aeon/classification/distance_based/_elastic_ensemble.py
+++ b/aeon/classification/distance_based/_elastic_ensemble.py
@@ -528,13 +528,6 @@ class ElasticEnsemble(BaseClassifier):
                 "majority_vote": True,
                 "distance_measures": ["dtw", "ddtw", "wdtw"],
             }
-        elif parameter_set == "ts-quad":
-            return {
-                "proportion_of_param_options": 0.01,
-                "proportion_train_for_test": 0.1,
-                "majority_vote": True,
-                "distance_measures": "ts-quad",
-            }
         else:
             return {
                 "proportion_of_param_options": 0.01,

--- a/aeon/classification/distance_based/tests/test_elastic_ensemble.py
+++ b/aeon/classification/distance_based/tests/test_elastic_ensemble.py
@@ -103,4 +103,7 @@ def test_ts_quad_distance_measures():
     )
     ee.fit(X, y)
     actual_distances = list(ee.get_metric_params())
+    preds = ee.predict(X)
     assert len(actual_distances) == 4
+    assert isinstance(preds, np.ndarray)
+    assert len(preds) == len(X)

--- a/docs/changelogs/v1.3.md
+++ b/docs/changelogs/v1.3.md
@@ -35,7 +35,6 @@ September 2025
 
 ### Enhancements
 
-- [ENH] Implement TS-QUAD as a distance parameter for `ElasticEnsemble` ({pr}`3126`) {user}`Nithurshen`
 - [ENH] Improvements to ST transformer and classifier ({pr}`2968`) {user}`MatthewMiddlehurst`
 - [ENH] KNN n_jobs and updated kneighbours method ({pr}`2578`) {user}`chrisholder`
 - [ENH] Refactor signature code ({pr}`2943`) {user}`TonyBagnall`


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #2855 

#### What does this implement/fix? Explain your changes.

This PR implements the **TS-QUAD** (Time Series QUARtet of Distance-based Classifiers) configuration as a new option within the existing `ElasticEnsemble` (EE) classifier.

**Key Changes:**
1.  **TS-QUAD Configuration**: Adds the `distance_measures="ts-quad"` option to `ElasticEnsemble`.
2. **Testing**: Adds a dedicated unit test (`test_ts_quad_distance_measures`) to verify the correct configuration of the four distances.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Any other comments?

No

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
