### PR TITLE
[ENH] Enable temporal importance curves for DrCIFClassifier by supporting BaseDecisionTree

### DIFF
--- a/aeon/base/_estimators/interval_based/base_interval_forest.py
+++ b/aeon/base/_estimators/interval_based/base_interval_forest.py
@@ -362,8 +362,7 @@ class BaseIntervalForest(ABC):
                 self._base_estimator = DecisionTreeRegressor(criterion="absolute_error")
             else:
                 raise ValueError(
-                    f"{self} must be a scikit-learn compatible classifier or "
-                    "regressor."
+                    f"{self} must be a scikit-learn compatible classifier or regressor."
                 )
         # base_estimator must be an sklearn estimator
         elif not isinstance(self.base_estimator, BaseEstimator):
@@ -1194,8 +1193,7 @@ class BaseIntervalForest(ABC):
                     )
                     * impurity_right
                 )
-            else:
-                continue
+
             split_features = []
 
             for n, rep in enumerate(self.intervals_[i]):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #3140 

#### What does this implement/fix? Explain your changes.

<!--
A clear and concise description of what you have implemented.
-->

This Pull Request fixes a `ValueError` in `DrCIFClassifier.temporal_importance_curves()` that occurred because DrCIF defaults to using `sklearn.tree.DecisionTreeClassifier`, which is a subclass of `BaseDecisionTree`, but the base function only explicitly supported `aeon.classification.sklearn.ContinuousIntervalTree`.

The fix involves modifying `BaseIntervalForest.temporal_importance_curves` to:

1.  **Update the base estimator check** to explicitly allow `sklearn.tree.BaseDecisionTree`.
2.  **Implement the Information Gain (Gains) calculation** for `BaseDecisionTree` by inspecting its internal structure (`tree_.tree_`). The gain is calculated as the normalized reduction in impurity for each split node.
3.  Ensure the final function output is explicitly converted to **lists** for API consistency, resolving a subsequent test failure related to `zip()` returning tuples.

This restores the desirable feature of generating temporal importance curves for `DrCIFClassifier` when using its default settings.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

No

#### Any other comments?

<!--
Any other information that is important to this PR or helpful for reviewers.
-->

A new test case, `test_drcif_temporal_importance_curves`, was added to confirm the fix and ensure future compatibility.

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [X] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
