### PR TITLE
[BUG] Fix broken fit_predict in anomaly detection & add tests

### DIFF
--- a/aeon/anomaly_detection/collection/base.py
+++ b/aeon/anomaly_detection/collection/base.py
@@ -201,14 +201,14 @@ class BaseCollectionAnomalyDetector(BaseCollectionEstimator, BaseAnomalyDetector
         # reset estimator at the start of fit
         self.reset()
 
-        X = self._preprocess_series(X, axis, store_metadata=True)
+        X = self._preprocess_collection(X)
 
         if self.get_tag("fit_is_empty"):
             self.is_fitted = True
             return self._predict(X)
 
         if y is not None:
-            y = self._check_y(y)
+            y = self._check_y(y, self.metadata_["n_cases"])
 
         pred = self._fit_predict(X, y)
 

--- a/aeon/testing/estimator_checking/_yield_collection_anomaly_detection_checks.py
+++ b/aeon/testing/estimator_checking/_yield_collection_anomaly_detection_checks.py
@@ -79,3 +79,12 @@ def check_collection_anomaly_detector_output(estimator, datatype):
         ), "y_pred must contain only 0s, 1s, True, or False"
     else:
         raise ValueError(f"Unknown anomaly output type: {out_type}")
+
+    # Test fit_predict method
+    estimator_fp = _clone_estimator(estimator)
+    y_pred_fp = estimator_fp.fit_predict(
+        FULL_TEST_DATA_DICT[datatype]["train"][0],
+        FULL_TEST_DATA_DICT[datatype]["train"][1],
+    )
+    assert isinstance(y_pred_fp, np.ndarray)
+    assert len(y_pred_fp) == get_n_cases(FULL_TEST_DATA_DICT[datatype]["train"][0])


### PR DESCRIPTION
### Reference Issues/PRs
Fixes #3208 

### What does this implement/fix? Explain your changes.
This PR fixes two critical bugs in `BaseCollectionAnomalyDetector.fit_predict()` and updates the centralized test suite to prevent future regressions.

1. Critical Bug Fixes in BaseCollectionAnomalyDetector: Prior to this PR, the fit_predict() method was completely non-functional.

**Fix 1:** Changed `self._preprocess_series(X)` to` self._preprocess_collection(X)`. The adapter previously crashed with AttributeError because it tried to call a series-specific method.

**Fix 2:** Updated `self._check_y(y)` to `self._check_y(y, self.metadata_["n_cases"])`. The previous call was missing the required n_cases argument, causing crashes when labels were provided.

**Cleanup:** Removed the unused axis parameter from` fit_predict` (collection data does not require axis specification).

2. Testing Infrastructure Update:

Updated `aeon/testing/estimator_checking/_yield_collection_anomaly_detection_checks.py` to explicitly test `fit_predict` for all Collection Anomaly Detectors.

Note: Previously, fit_predict was missed in the centralized checks for this module, which allowed these bugs to persist. This change ensures strictly enforced coverage for all current and future estimators.

### Does your contribution introduce a new dependency? If yes, which one? 
No.

### Any other comments?
Refactored the PR to align with architectural guidance of removing the initial custom test suite in favor of patching aeon.testing directly.

### PR checklist
**For all contributions** 
[x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you after the PR has been merged.

[x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

**For new estimators and functions** 
[ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).

[ ] (OPTIONAL) I've added myself as a maintainer at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

**For developers with write access** 
[ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.