### PR TITLE
[ENH] Fix binary IG calculation to respect identical split values

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -696,12 +696,15 @@ def _calc_binary_ig(orderline, c1, c2):
     c2_count = 0
 
     # evaluate each split point
-    for split in range(len(orderline)):
+    for split in range(len(orderline) - 1):
         next_class = orderline[split][1]  # +1 if this class, -1 if other
         if next_class > 0:
             c1_count += 1
         else:
             c2_count += 1
+
+        if orderline[split][0] == orderline[split + 1][0]:
+            continue
 
         left_prop = (split + 1) / total_all
         ent_left = _binary_entropy(c1_count, c2_count)

--- a/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
@@ -1,0 +1,25 @@
+"""Tests for shapelet transform functions."""
+
+__maintainer__ = []
+
+from aeon.transformations.collection.shapelet_based._shapelet_transform import (
+    _calc_binary_ig,
+)
+
+
+def test_calc_binary_ig_identical_splits():
+    """Test binary IG calculation correctly handles identical split values.
+
+    Regression test for Issue #1322. Ensures that split points are not
+    evaluated between identical distance values, which previously resulted
+    in incorrect Information Gain calculation.
+    """
+    orderline = [(2, -1), (2, -1), (2, 1), (3, 1), (3, 1)]
+
+    # Class 1 has 3 items, Class -1 has 2 items
+    c1, c2 = 3, 2
+
+    ig = _calc_binary_ig(orderline, c1, c2)
+
+    # The expected IG is approx 0.42.
+    assert 0.41 < ig < 0.43


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1322

#### What does this implement/fix? Explain your changes.
This PR fixes a logic error in `ShapeletTransform` where the binary Information Gain (IG) calculation was incorrectly evaluating split points between identical distance values.

**Problem:**
The `_calc_binary_ig` function iterated through every index in the sorted orderline to test split points. It failed to check if the current distance was equal to the next distance (`orderline[i].distance == orderline[i+1].distance`). This caused the algorithm to calculate splits *inside* groups of identical values, which is mathematically invalid and resulted in inflated IG scores (e.g., returning ~0.97 instead of ~0.42 for the reproduction case).

**Solution:**
Added a check to strictly skip invalid split points where the distance values are identical.
```python
if orderline[split][0] == orderline[split+1][0]:
    continue