### PR TITLE
DOC: add Raises section to BaseSegmenter._check_y

### DIFF
--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -174,10 +174,11 @@ class BaseSegmenter(BaseSeriesEstimator):
         """Check y specific to segmentation.
 
         y must be a univariate series
-               Raises
-       ------
-       ValueError
-           If ``y`` is not one of 
+
+        Raises
+        ------
+        ValueError
+           If ``y`` is not one of
            ``VALID_SERIES_INPUT_TYPES``, is not univariate,
            or does not contain numeric values.
 


### PR DESCRIPTION
This PR adds a `Raises` section to the `_check_y` method docstring in `aeon/segmentation/base.py`.

The section documents the `ValueError` raised when:
- `y` is not one of `VALID_SERIES_INPUT_TYPES`
- `y` is not univariate
- `y` does not contain numeric values

This addresses part of #1766.
