### PR TITLE
[MNT] Replace deprecated np.int_ with np.intp in resampling.py

### DIFF
--- a/aeon/benchmarking/resampling.py
+++ b/aeon/benchmarking/resampling.py
@@ -108,7 +108,7 @@ def resample_data_indices(y_train, y_test, random_state=None):
     """
     # shuffle data indices
     rng = check_random_state(random_state)
-    indices = np.arange(len(y_train) + len(y_test), dtype=int)
+    indices = np.arange(len(y_train) + len(y_test), dtype=np.intp)
     rng.shuffle(indices)
 
     train_indices = indices[: len(y_train)]
@@ -230,8 +230,8 @@ def stratified_resample_data_indices(y_train, y_test, random_state=None):
     # ensure same classes exist in both train and test
     assert list(unique_train) == list(unique_test)
 
-    train_indices = np.zeros(0, dtype=int)
-    test_indices = np.zeros(0, dtype=int)
+    train_indices = np.zeros(0, dtype=np.intp)
+    test_indices = np.zeros(0, dtype=np.intp)
 
     # for each class
     for label_index in range(len(unique_train)):


### PR DESCRIPTION
[MNT] Replace deprecated np.int_ with np.intp in resampling.py

#### Reference Issues/PRs

Fixes #3201

#### What does this implement/fix? Explain your changes

Replaces the deprecated `np.int_` with `np.intp` in `aeon/benchmarking/resampling.py` to ensure compatibility with the latest NumPy versions.  

#### Does your contribution introduce a new dependency? If yes, which one?

No.  

#### Any other comments

None.  

### PR checklist

##### For all contributions
- [x] The PR title starts with [MNT] indicating a maintenance-related change.  
- [x] No new dependencies introduced.  
