### PR TITLE
[ENH] Add type hints to get_unchanged_and_required_params_as_str

### DIFF
--- a/aeon/utils/repr.py
+++ b/aeon/utils/repr.py
@@ -1,6 +1,7 @@
 """Utilities for class __repr__ presentation."""
 
 import inspect
+from typing import Any
 
 from aeon.testing.utils.deep_equals import deep_equals
 
@@ -10,7 +11,7 @@ __all__ = [
 ]
 
 
-def get_unchanged_and_required_params_as_str(obj):
+def get_unchanged_and_required_params_as_str(obj: Any) -> str:
     """
     Get object parameters as a comma delimited string.
 


### PR DESCRIPTION
#### Reference Issues/PRs
No existing issue - improving type hints coverage.

#### What does this implement/fix?

Adds type hints to `get_unchanged_and_required_params_as_str()` function:
- `obj: Any` for the parameter
- `-> str` for the return type

Improves IDE support and enables static type checking.

#### Does your contribution introduce a new dependency?
No.

#### Any other comments?
Part of adding type hints throughout the codebase for better tooling support.