### PR TITLE
DOC: fix typo in custom_alignment_path docstring

### DIFF
--- a/aeon/clustering/_elastic_som.py
+++ b/aeon/clustering/_elastic_som.py
@@ -115,8 +115,8 @@ class ElasticSOM(BaseClusterer):
         be used. See aeon.clustering.elastic_som.VALID_ELASTIC_SOM_METRICS for a list of
         distances that have an elastic alignment path.
         The alignment path function takes the form
-        Callable[[np.ndarray, np.ndarray, dict], whee the dict is the kwargs for the
-        distance function. See documentation of aeon.distances documentation for
+        Callable[[np.ndarray, np.ndarray, dict], where the dict is the kwargs for the
+        distance function. See documentation of aeon.distances for
         example alignment path functions. The alignment path function must return a
         a full alignment path with no gaps.
     verbose : bool, default=False


### PR DESCRIPTION
This PR fixes a small typo and removes duplicated wording in the
`custom_alignment_path` parameter docstring.

Specifically:
- Corrects `whee` → `where`
- Removes repeated use of the word `documentation`

This improves clarity without changing any functionality.

Closes #3230
