### PR TITLE
[DOC] Fix typo in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,7 +28,7 @@ yourself to an issue for such algorithms.
 When using code from another package or writing code inspired from another implementation,
 please mention this in your PR. At the very least credit must be given where
 applicable. If the package has a different license, using the code as is may not be
-acceptable. Using others code without credit will like result in your PR being closed.
+acceptable. Using others code without credit will likely result in your PR being closed.
 
 In the following we will give a brief overview of how to contribute to `aeon`. Making
 contributions to open-source projects takes a bit of proactivity and can be daunting at


### PR DESCRIPTION
#### Reference Issues/PRs
<!-- None - this is a simple typo fix -->

#### What does this implement/fix? Explain your changes.

This PR fixes a typo in the contributing guide where "like" should be "likely" in the sentence about code credit requirements.

**Before:** "Using others code without credit will like result in your PR being closed."

**After:** "Using others code without credit will likely result in your PR being closed."

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

This is my first contribution to aeon. I noticed the typo while reading the contributing guide and wanted to help improve the documentation.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.