### PR TITLE
[BUG] Return TDE and HC2 to expected results test skip

### DIFF
--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -60,6 +60,9 @@ EXCLUDED_TESTS = {
     # Requires y to be passed in inverse_transform,
     # but this is not currently enabled/supported
     "DifferenceTransformer": ["check_transform_inverse_transform_equivalent"],
+    # broken by 0.63.0 numba update, see #3307 attempt to fix
+    "HIVECOTEV2": ["check_classifier_against_expected_results"],
+    "TemporalDictionaryEnsemble": ["check_classifier_against_expected_results"],
 }
 
 # Exclude specific tests for estimators here only when numba is disabled


### PR DESCRIPTION
this reverts two out of three exclusion removals from #3307, because they seem to be failing still on a new PR, which is confusing given #3307 passed all tests, but there you go, some numba thing probably. 

this is failing
https://github.com/aeon-toolkit/aeon/pull/3321

<img width="633" height="386" alt="image" src="https://github.com/user-attachments/assets/ea4d9c33-83ed-472d-a11b-a3b55f5e9a9c" />

<img width="602" height="570" alt="image" src="https://github.com/user-attachments/assets/456cef16-c68a-4c5e-82bd-497cc6315d21" />
