### PR TITLE
[BUG] Enforce at least one of each class for  dummy classifier test

### DIFF
--- a/aeon/classification/tests/test_dummy.py
+++ b/aeon/classification/tests/test_dummy.py
@@ -12,7 +12,7 @@ from aeon.classification import DummyClassifier
 def test_dummy_classifier_strategies(strategy):
     """Test DummyClassifier strategies."""
     X = np.ones(shape=(10, 10))
-    y_train = np.random.choice([0, 1], size=10)
+    y_train = np.array([0, 1] + np.random.choice([0, 1], size=8).tolist())
 
     dummy = DummyClassifier(strategy=strategy, constant=1)
     dummy.fit(X, y_train)


### PR DESCRIPTION
occasional fail for test_dummy caused by random generation of one class data, mitigated be enforcing one of each class

<img width="822" height="193" alt="image" src="https://github.com/user-attachments/assets/9f3961d4-5b8f-401b-b14f-ae79e1e2c661" />


