### PR TITLE
[BUG] Ensure parent directory exists before writing info.json in RehabPile loader

### DIFF
--- a/aeon/datasets/rehabpile_loader.py
+++ b/aeon/datasets/rehabpile_loader.py
@@ -303,6 +303,7 @@ def load_rehab_pile_dataset(
             meta_url = f"{REHABPILE_ROOT_URL}{collection}/{subfolder}/info.json"
             try:
                 with urlopen(meta_url, timeout=60) as response:
+                    meta_path.parent.mkdir(parents=True, exist_ok=True)
                     with open(meta_path, "wb") as out_file:
                         out_file.write(response.read())
             except (HTTPError, URLError, TimeoutError) as e:


### PR DESCRIPTION
The RehabPile loader was attempting to write info.json to a directory that might not exist yet, causing FileNotFoundError in flaky tests.

This fix ensures the parent directory is created before file write by adding  before opening the file for writing.

Fixes #3318

**Changes:**
- Added directory creation before writing info.json
- No changes to logic or functionality, only adds safety check

**Testing:**
- This is a simple defensive fix that ensures the directory exists before file operations
- The issue describes flaky CI failures, this should resolve those