### PR TITLE
[ENH] Zenodo keys

### DIFF
--- a/aeon/datasets/tsc_datasets.py
+++ b/aeon/datasets/tsc_datasets.py
@@ -1116,7 +1116,6 @@ tsc_zenodo = {
     "UWaveGestureLibraryX": 11198374,
     "UWaveGestureLibraryY": 11198382,
     "UWaveGestureLibraryZ": 11198384,
-    "Unequal": 18300287,
     "VisualSpeech": 15366803,
     "WISDM": 18500261,
     "WISDM2": 18500263,


### PR DESCRIPTION
fix an old key for SpokenArabDigits and corrects the names of a couple of Monster datasets