### PR TITLE
[DOC] Add save_to_ts_file to datasets API reference

### DIFF
--- a/docs/api_reference/datasets.md
+++ b/docs/api_reference/datasets.md
@@ -27,7 +27,7 @@ used by `aeon`.
     load_rehab_pile_regression_datasets
     load_monster_dataset
     load_monster_dataset_names
-    write_to_ts_file
+    save_to_ts_file
     write_to_arff_file
     load_airline
     load_arrow_head


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3391.

#### What does this implement/fix? Explain your changes.

The datasets API reference on https://www.aeon-toolkit.org/en/stable/api_reference/datasets.html did not list \`save_to_ts_file\`. The autosummary in \`docs/api_reference/datasets.md\` still referenced \`write_to_ts_file\`, which is no longer exported from \`aeon.datasets\` (it was replaced by \`save_to_ts_file\` in #3042).

Replaced that entry with \`save_to_ts_file\` so the current writer shows up in the generated API docs.

#### Does your contribution introduce a new dependency?

No.

#### Any other comments?

\`write_to_arff_file\` on the next line also appears to be removed from \`aeon.datasets\` (no longer in \`__all__\` or exported). It is left unchanged here to keep this PR focused on the issue; happy to open a follow-up if you'd like it tidied in the same sweep.