### PR TITLE
[DOC] Fix save_to_ts_file API reference (#3391)

### DIFF
--- a/docs/api_reference/datasets.md
+++ b/docs/api_reference/datasets.md
@@ -27,8 +27,7 @@ used by `aeon`.
     load_rehab_pile_regression_datasets
     load_monster_dataset
     load_monster_dataset_names
-    write_to_ts_file
-    write_to_arff_file
+    save_to_ts_file
     load_airline
     load_arrow_head
     load_gunpoint


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #3391

### What does this implement/fix? Explain your changes.

The `Datasets` API reference page (`docs/api_reference/datasets.md`)listed two functions that do not exist in `aeon.datasets`:

- `write_to_ts_file`
- `write_to_arff_file`

(neither is defined in `aeon/datasets/_data_writers.py` or exported via `aeon/datasets/__init__.py`).

The real exported writer is `save_to_ts_file`, which was missing from the API reference. This PR replaces the two phantom entries with the correct `save_to_ts_file` so it appears in the rendered API docs.

### Any other comments?

Minimal doc-only change — no runtime code touched.