### PR TITLE
[MNT] change precommit yml

### DIFF
--- a/.github/utilities/pr_open_commenter.py
+++ b/.github/utilities/pr_open_commenter.py
@@ -95,21 +95,20 @@ pr.create_issue_comment(f"""
 
 The [Checks](https://github.com/aeon-toolkit/aeon/pull/{pr_number}/checks) tab will show the status of our automated tests. You can click on individual test runs in the tab or "Details" in the panel below to see more information if there is a failure.
 
-If our `pre-commit` code quality check fails, any trivial fixes will automatically be pushed to your PR unless it is a draft.
+If our `pre-commit` code quality check fails, please run `pre-commit` locally and push the fixes to your PR branch.
 
 Don't hesitate to ask questions on the `aeon` [Discord](https://discord.gg/D6rzqHGKRJ) channel if you have any.
 
 <details><summary>PR CI actions</summary>
 <p>
 
-These checkboxes will add labels to enable/disable CI functionality for this PR. This may not take effect immediately, and a new commit may be required to run the new configuration.
+These checkboxes will add labels to enable or disable CI functionality for this PR. This may not take effect immediately, and a new commit may be required to run the new configuration.
 
 - [ ] Run `pre-commit` checks for all files
 - [ ] Run `mypy` typecheck tests
 - [ ] Run all `pytest` tests and configurations
 - [ ] Run all notebook example tests
 - [ ] Run numba-disabled `codecov` tests
-- [ ] Stop automatic `pre-commit` fixes (always disabled for drafts)
 - [ ] Disable numba cache loading
 - [ ] Regenerate expected results for testing
 - [ ] Push an empty commit to re-run CI checks

--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -11,8 +11,6 @@ on:
       - reopened
       - labeled
       - unlabeled
-      - ready_for_review
-      - converted_to_draft
 
 permissions:
   contents: read
@@ -38,7 +36,7 @@ jobs:
 
       - name: Get changed files
         if: ${{ github.event_name == 'pull_request' }}
-        uses: tj-actions/changed-files@v47.0.5
+        uses: tj-actions/changed-files@2f7246cb26e8bb6709b6cbfc1fec7febfe82e96a  # v47.0.5
         id: changed-files
 
       - name: List changed files

--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -4,10 +4,21 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -15,19 +26,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Create app token
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_APP_ID }}
-          private-key: ${{ secrets.PR_APP_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v6
@@ -35,49 +37,43 @@ jobs:
           python-version: "3.12"
 
       - name: Get changed files
+        if: ${{ github.event_name == 'pull_request' }}
         uses: tj-actions/changed-files@v47.0.5
         id: changed-files
 
       - name: List changed files
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}'
 
-      # only check the full repository if PR and correctly labelled
-      - if: ${{ github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
-        name: Full pre-commit
+      # Check the full repository on pushes to main
+      - name: Full pre-commit
+        if: ${{ github.event_name == 'push' }}
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-      - if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
-        name: Local pre-commit
+
+      # Check the full repository on PRs that are explicitly labelled
+      - name: Full pre-commit on labelled PR
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
+
+      # Otherwise only check changed files on PRs
+      - name: Local pre-commit
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pre-commit') }}
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
-
-      # push fixes if pre-commit fails and PR is eligible
-      - if: ${{ failure() && github.event_name == 'pull_request_target' && !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'stop pre-commit fixes') }}
-        name: Push pre-commit fixes
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: Automatic `pre-commit` fixes
-          commit_user_name: aeon-actions-bot[bot]
 
   codespell-annotations:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Create app token
-        uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_APP_ID }}
-          private-key: ${{ secrets.PR_APP_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@v1


### PR DESCRIPTION
---

This PR hardens the pre-commit workflow for fork PRs.

#### Changes
- switched `pull_request_target` to `pull_request`
- added `labeled` and `unlabeled` to PR event types so toggling the `full pre-commit` label re-triggers the workflow
- removed GitHub App token generation
- removed privileged checkout of PR head code
- removed auto-commit / auto-push of pre-commit fixes
- added `persist-credentials: false` to checkout
- set workflow permissions to read-only (`contents: read`)
- pinned `tj-actions/changed-files` to a commit SHA (with tag comment) instead of a moving tag
- retained `push` on `main`
- retained the `full pre-commit` label path
- retained full-check vs changed-files behaviour
- added concurrency cancellation for superseded runs

#### Rationale
The old workflow executed fork-controlled code via `pre-commit` in a privileged `pull_request_target` context. This change moves PR execution back into the unprivileged PR context and removes the token exposure path. Pinning third-party actions to commit SHAs rather than tags is defence-in-depth against supply-chain attacks of the kind seen in the March 2025 `tj-actions/changed-files` incident.

#### Note
Auto-fixing and pushing changes back to PR branches is intentionally no longer supported in this workflow. Contributors must run pre-commit locally, or we can enable `pre-commit.ci` in a follow-up to restore auto-fix behaviour safely. I have also removed the comments in pr_open_commentator.yml. We can add this feature back in lately if anyone wants it