### PR TITLE
[BUG] add raise of softdep not working when we install all extras

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -206,7 +206,9 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical
+        run: >
+          python -m pytest -n logical
+          --fail-soft-dependency-skips
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run tests
         run: >
           python -m pytest -n logical
-          --fail-soft-dependency-skips
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run tests
         run: >
           python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -106,7 +106,7 @@ jobs:
         # run the full test suit if a PR has the 'full pytest actions' label
         run: >
           python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
           --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -106,7 +106,7 @@ jobs:
         # run the full test suit if a PR has the 'full pytest actions' label
         run: >
           python -m pytest -n logical
-          --fail-soft-dependency-skips
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
           --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -104,7 +104,10 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
+        run: >
+          python -m pytest -n logical
+          --fail-soft-dependency-skips
+          --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:
     runs-on: ubuntu-24.04

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,20 @@ least once, but not necessarily on each operating system / python version combin
 
 __maintainer__ = ["MatthewMiddlehurst"]
 
+import pytest
+
+
+def _is_soft_dependency_skip(report):
+    if not report.skipped:
+        return False
+
+    skip_reason = (
+        report.longrepr[2]
+        if isinstance(report.longrepr, tuple)
+        else str(report.longrepr)
+    )
+    return "soft dependency" in skip_reason.lower()
+
 
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
@@ -35,6 +49,32 @@ def pytest_addoption(parser):
             "version."
         ),
     )
+    parser.addoption(
+        "--fail-soft-dependency-skips",
+        action="store_true",
+        default=False,
+        help=(
+            "Fail tests skipped by soft dependency checks. Use only in environments "
+            "where soft dependencies are installed."
+        ),
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Turn soft dependency skips into failures when requested."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if item.config.getoption(
+        "--fail-soft-dependency-skips"
+    ) and _is_soft_dependency_skip(report):
+        report.outcome = "failed"
+        report.longrepr = (
+            "Test skipped because a soft dependency check failed while "
+            "--fail-soft-dependency-skips is enabled. "
+            f"Original skip reason: {report.longrepr}"
+        )
 
 
 def pytest_configure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,12 @@ import pytest
 
 
 def _is_soft_dependency_skip(report):
+    """
+    When a test function is skipped, this inspect the skip reason to pickup
+    the soft dependency term, and return true if found.
+    """
     if not report.skipped:
+        # The test was not skipped, so we return false
         return False
 
     skip_reason = (
@@ -22,6 +27,7 @@ def _is_soft_dependency_skip(report):
         if isinstance(report.longrepr, tuple)
         else str(report.longrepr)
     )
+    # If the test was skipped, check for the term in reason.
     return "soft dependency" in skip_reason.lower()
 
 
@@ -65,7 +71,7 @@ def pytest_runtest_makereport(item, call):
     """Turn soft dependency skips into failures when requested."""
     outcome = yield
     report = outcome.get_result()
-
+    # When the flag is on, and test was a softdep skip, flag it as failed.
     if item.config.getoption(
         "--fail-soft-dependency-skips"
     ) and _is_soft_dependency_skip(report):


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #3406 

#### What does this implement/fix? Explain your changes.

While running tests in CI on environment where we install all_extras, we didn't raise when softdep checks failed, as they had severity=None in the test files. Added a flag to make these test raise. 

One issue is that it's kind of the point of the softdeps checks, as some of these are OS dependent. But the linked issue showed that it can hide real failures. So with this PR we basically say, we trust one OS (here ubuntu) to be able to take all softdeps.

This is more of a quickfix. Maybe a better future solution would be to label those test under different pytest marks (e.g. @pytest.mark.softdepschecks with additional marks for specific OS) that would only run on these CI environment using all_extras.

This PR CI should fail due to the "hugging-face" softdep check.
