### PR TITLE
[MNT] Add test to check that soft dependency skipping is working as intended

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -177,7 +177,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --check-soft-dependency-skips
+        run: python -m pytest --check-soft-dependency-skips
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -206,7 +206,9 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical
+        run: >
+          python -m pytest -n logical
+          --fail-soft-dependency-skips
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run tests
         run: >
           python -m pytest -n logical
-          --fail-soft-dependency-skips
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -156,7 +156,7 @@ jobs:
           # Save cache with the current date (ENV set in numba_cache action)
           key: numba-test-no-soft-deps-${{ runner.os }}-3.12-${{ env.CURRENT_DATE }}
 
-  test_soft_dep_skips:
+  test-soft-dep-skips:
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run tests
         run: >
           python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -177,7 +177,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --fail-soft-dependency-skips
+        run: python -m pytest -n logical --check-soft-dependency-skips
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -156,6 +156,29 @@ jobs:
           # Save cache with the current date (ENV set in numba_cache action)
           key: numba-test-no-soft-deps-${{ runner.os }}-3.12-${{ env.CURRENT_DATE }}
 
+  test_soft_dep_skips:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
+        with:
+          additional_extras: "dev,unstable_extras"
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: python -m pytest -n logical --fail-soft-dependency-skips
+
   pytest:
     runs-on: ${{ matrix.os }}
 
@@ -206,9 +229,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: >
-          python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
+        run: python -m pytest -n logical
 
       - name: Save new cache
         uses: actions/cache/save@v5

--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -177,7 +177,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --check-soft-dependency-skips
+        run: python -m pytest --check-soft-dependency-skips -q
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -69,7 +69,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --fail-soft-dependency-skips
+        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --check-soft-dependency-skips
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -69,7 +69,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --prtesting --fail-soft-dependency-skips
+        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --fail-soft-dependency-skips
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run tests
         run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
-  test_soft_dep_skips:
+  test-soft-dep-skips:
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install aeon and dependencies
         uses: ./.github/actions/cpu_all_extras
         with:
-          additional_extras: "dev"
+          additional_extras: "dev,unstable_extras"
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -106,7 +106,7 @@ jobs:
         # run the full test suit if a PR has the 'full pytest actions' label
         run: >
           python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
           --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -106,7 +106,7 @@ jobs:
         # run the full test suit if a PR has the 'full pytest actions' label
         run: >
           python -m pytest -n logical
-          --fail-soft-dependency-skips
+          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.12' && '--fail-soft-dependency-skips' || '' }}
           --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -48,6 +48,29 @@ jobs:
       - name: Run tests
         run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
+  test_soft_dep_skips:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install aeon and dependencies
+        uses: ./.github/actions/cpu_all_extras
+        with:
+          additional_extras: "dev,unstable_extras"
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Run tests
+        run: python -m pytest -n logical --prtesting --fail-soft-dependency-skips
+
   pytest:
     runs-on: ${{ matrix.os }}
 
@@ -104,10 +127,7 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: >
-          python -m pytest -n logical
-          ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' && '--fail-soft-dependency-skips' || '' }}
-          --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
+        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Install aeon and dependencies
         uses: ./.github/actions/cpu_all_extras
         with:
-          additional_extras: "dev,unstable_extras"
+          additional_extras: "dev"
 
       - name: Show dependencies
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --check-soft-dependency-skips
+        run: python -m pytest --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --check-soft-dependency-skips -q
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -104,7 +104,10 @@ jobs:
 
       - name: Run tests
         # run the full test suit if a PR has the 'full pytest actions' label
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
+        run: >
+          python -m pytest -n logical
+          --fail-soft-dependency-skips
+          --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }}
 
   doctests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_pytest.yml
+++ b/.github/workflows/pr_pytest.yml
@@ -69,7 +69,7 @@ jobs:
         run: python -m pip list
 
       - name: Run tests
-        run: python -m pytest -n logical --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --check-soft-dependency-skips
+        run: python -m pytest --prtesting ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full pytest actions') }} --check-soft-dependency-skips
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/aeon/datasets/tests/test_monster_loader.py
+++ b/aeon/datasets/tests/test_monster_loader.py
@@ -12,7 +12,7 @@ from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("huggingface-hub", severity="none"),
+    not _check_soft_dependencies("huggingface_hub", severity="none"),
     reason="required soft dependency huggingface-hub not available",
 )
 @pytest.mark.xfail(raises=CONNECTION_ERRORS)
@@ -25,7 +25,7 @@ def test_monster_dataset_names():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("huggingface-hub", severity="none"),
+    not _check_soft_dependencies("huggingface_hub", severity="none"),
     reason="required soft dependency huggingface-hub not available",
 )
 @pytest.mark.xfail(raises=CONNECTION_ERRORS)

--- a/aeon/testing/estimator_checking/_estimator_checking.py
+++ b/aeon/testing/estimator_checking/_estimator_checking.py
@@ -88,7 +88,7 @@ def parametrize_with_checks(
         ):
             # wrap check to skip if necessary (missing dependencies, on an exclude list
             # etc.)
-            checks.append(_check_if_xfail(est, check, has_dependencies))
+            checks.append(_check_if_skip_pytest(est, check, has_dependencies))
 
     # return a pytest parametrize decorator with custom ids
     return pytest.mark.parametrize(
@@ -204,7 +204,7 @@ def check_estimator(
         has_dependencies=True,
     ):
         # wrap check to skip if necessary (on an exclude list etc.)
-        checks.append(_check_if_skip(estimator, check, True))
+        checks.append(_check_if_skip_wrapper(estimator, check, True))
 
     # process run/exclude lists to filter checks
     if not isinstance(checks_to_run, (list, tuple)) and checks_to_run is not None:
@@ -275,18 +275,18 @@ def check_estimator(
     return results
 
 
-def _check_if_xfail(estimator, check, has_dependencies):
-    """Check if a check should be xfailed."""
+def _check_if_skip_pytest(estimator, check, has_dependencies):
+    """Check if a check should be skipped in a pytest setting."""
     import pytest
 
     skip, reason, _ = _should_be_skipped(estimator, check, has_dependencies)
     if skip:
-        return pytest.param(check, marks=pytest.mark.xfail(reason=reason))
+        return pytest.param(check, marks=pytest.mark.skip(reason=reason))
 
     return check
 
 
-def _check_if_skip(estimator, check, has_dependencies):
+def _check_if_skip_wrapper(estimator, check, has_dependencies):
     """Check if a check should be skipped by raising a SkipTest exception."""
     skip, reason, check_name = _should_be_skipped(estimator, check, has_dependencies)
     if skip:
@@ -312,7 +312,12 @@ def _should_be_skipped(estimator, check, has_dependencies):
 
     # check estimator dependencies
     if not has_dependencies and "softdep" not in check_name:
-        return True, "Incompatible dependencies or Python version", check_name
+        return (
+            True,
+            "Incompatible dependencies or Python version. Check may require "
+            "a soft dependency.",
+            check_name,
+        )
 
     # check aeon exclude lists
     if est_name in EXCLUDE_ESTIMATORS:

--- a/aeon/testing/estimator_checking/_estimator_checking.py
+++ b/aeon/testing/estimator_checking/_estimator_checking.py
@@ -279,9 +279,17 @@ def _check_if_skip_pytest(estimator, check, has_dependencies):
     """Check if a check should be skipped in a pytest setting."""
     import pytest
 
-    skip, reason, _ = _should_be_skipped(estimator, check, has_dependencies)
+    skip, reason, check_name = _should_be_skipped(estimator, check, has_dependencies)
     if skip:
-        return pytest.param(check, marks=pytest.mark.skip(reason=reason))
+        est_name = (
+            estimator.__name__ if isclass(estimator) else estimator.__class__.__name__
+        )
+        return pytest.param(
+            check,
+            marks=pytest.mark.skip(
+                reason=f"Skipping test {check_name} for {est_name}: {reason}"
+            ),
+        )
 
     return check
 
@@ -298,7 +306,7 @@ def _check_if_skip_wrapper(estimator, check, has_dependencies):
                 if isclass(estimator)
                 else estimator.__class__.__name__
             )
-            raise SkipTest(f"Skipping {check_name} for {est_name}: {reason}")
+            raise SkipTest(f"Skipping test {check_name} for {est_name}: {reason}")
 
         return wrapped
     return check

--- a/conftest.py
+++ b/conftest.py
@@ -13,24 +13,6 @@ __maintainer__ = ["MatthewMiddlehurst"]
 import pytest
 
 
-def _is_soft_dependency_skip(report):
-    """
-    When a test function is skipped, this inspect the skip reason to pickup
-    the soft dependency term, and return true if found.
-    """
-    if not report.skipped:
-        # The test was not skipped, so we return false
-        return False
-
-    skip_reason = (
-        report.longrepr[2]
-        if isinstance(report.longrepr, tuple)
-        else str(report.longrepr)
-    )
-    # If the test was skipped, check for the term in reason.
-    return "soft dependency" in skip_reason.lower()
-
-
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
     parser.addoption(
@@ -56,31 +38,14 @@ def pytest_addoption(parser):
         ),
     )
     parser.addoption(
-        "--fail-soft-dependency-skips",
+        "--check-soft-dependency-skips",
         action="store_true",
         default=False,
         help=(
-            "Fail tests skipped by soft dependency checks. Use only in environments "
-            "where soft dependencies are installed."
+            "Fail tests skipped by soft dependency checks. Skips all other tests. "
+            "Use only in environments where soft dependencies are installed."
         ),
     )
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Turn soft dependency skips into failures when requested."""
-    outcome = yield
-    report = outcome.get_result()
-    # When the flag is on, and test was a softdep skip, flag it as failed.
-    if item.config.getoption(
-        "--fail-soft-dependency-skips"
-    ) and _is_soft_dependency_skip(report):
-        report.outcome = "failed"
-        report.longrepr = (
-            "Test skipped because a soft dependency check failed while "
-            "--fail-soft-dependency-skips is enabled. "
-            f"Original skip reason: {report.longrepr}"
-        )
 
 
 def pytest_configure(config):
@@ -126,3 +91,58 @@ def pytest_configure(config):
         from aeon.testing import testing_config
 
         testing_config.PR_TESTING = True
+
+    if config.getoption("--check-soft-dependency-skips"):
+        config.pluginmanager.register(
+            _CheckSoftDependencySkips(),
+            name="check-soft-dependency-skips",
+        )
+
+
+class _CheckSoftDependencySkips:
+    _SOFT_DEPENDENCY_TERMS = (
+        "soft dependency",
+        "soft dependencies",
+        "soft-dependency",
+        "soft-dependencies",
+        "softdep",
+        "softdeps",
+    )
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_runtest_setup(self, item):
+        pytest.skip(
+            "Skipping test. --check-soft-dependency-skips only audits test"
+            " skipping without running tests."
+        )
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        outcome = yield
+        report = outcome.get_result()
+
+        if self._is_soft_dependency_skip(report):
+            skip_reason = self._get_skip_reason(report)
+            report.outcome = "failed"
+            report.longrepr = (
+                "Test skipped because a soft dependency check failed while "
+                "--check-soft-dependency-skips is enabled. "
+                f"Original skip reason: {skip_reason}"
+            )
+
+    @staticmethod
+    def _get_skip_reason(report):
+        """Extract the skip reason across pytest longrepr formats."""
+        if isinstance(report.longrepr, tuple) and len(report.longrepr) >= 3:
+            return str(report.longrepr[2])
+
+        return str(report.longrepr)
+
+    @classmethod
+    def _is_soft_dependency_skip(cls, report):
+        """Check if a soft dependency related test is skipped."""
+        if not report.skipped:
+            return False
+
+        reason = cls._get_skip_reason(report).lower()
+        return any(term in reason for term in cls._SOFT_DEPENDENCY_TERMS)

--- a/conftest.py
+++ b/conftest.py
@@ -105,8 +105,6 @@ class _CheckSoftDependencySkips:
         "soft dependencies",
         "soft-dependency",
         "soft-dependencies",
-        "softdep",
-        "softdeps",
     )
 
     @pytest.hookimpl(trylast=True)

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,20 @@ least once, but not necessarily on each operating system / python version combin
 
 __maintainer__ = ["MatthewMiddlehurst"]
 
+import pytest
+
+
+def _is_soft_dependency_skip(report):
+    if not report.skipped:
+        return False
+
+    skip_reason = (
+        report.longrepr[2]
+        if isinstance(report.longrepr, tuple)
+        else str(report.longrepr)
+    )
+    return "soft dependency" in skip_reason.lower()
+
 
 def pytest_addoption(parser):
     """Pytest command line parser options adder."""
@@ -35,6 +49,32 @@ def pytest_addoption(parser):
             "version."
         ),
     )
+    parser.addoption(
+        "--fail-soft-dependency-skips",
+        action="store_true",
+        default=False,
+        help=(
+            "Fail tests skipped by soft dependency checks. Use only in environments "
+            "where soft dependencies are installed."
+        ),
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Turn soft dependency skips into failures when requested."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if item.config.getoption(
+        "--fail-soft-dependency-skips"
+    ) and _is_soft_dependency_skip(report):
+        report.outcome = "failed"
+        report.longrepr = (
+            "Test skipped because a soft dependency check failed while "
+            "--fail-soft-dependency-skips is enabled. "
+            f"Original skip reason: {report.longrepr}"
+        )
 
 
 def pytest_configure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,12 @@ import pytest
 
 
 def _is_soft_dependency_skip(report):
+    """
+    When a test function is skipped, this inspect the skip reason to pickup
+    the soft dependency term, and return true if found.
+    """
     if not report.skipped:
+        # The test was not skipped, so we return false
         return False
 
     skip_reason = (
@@ -22,6 +27,7 @@ def _is_soft_dependency_skip(report):
         if isinstance(report.longrepr, tuple)
         else str(report.longrepr)
     )
+    # If the test was skipped, check for the term in reason.
     return "soft dependency" in skip_reason.lower()
 
 
@@ -65,7 +71,7 @@ def pytest_runtest_makereport(item, call):
     """Turn soft dependency skips into failures when requested."""
     outcome = yield
     report = outcome.get_result()
-
+    # When the flag is on, and test was a softdep skip, flag it as failed.
     if item.config.getoption(
         "--fail-soft-dependency-skips"
     ) and _is_soft_dependency_skip(report):

--- a/conftest.py
+++ b/conftest.py
@@ -111,10 +111,7 @@ class _CheckSoftDependencySkips:
 
     @pytest.hookimpl(trylast=True)
     def pytest_runtest_setup(self, item):
-        pytest.skip(
-            "Skipping test. --check-soft-dependency-skips only audits test"
-            " skipping without running tests."
-        )
+        pytest.skip("Tests are not run in current testing setup.")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,8 +187,9 @@ addopts = [
     "--dist=worksteal",
     "--reruns=3",
     "--reruns-delay=3",
-    "--rerun-except=(?<!Permission)Error",
-    "--rerun-except=Exception",
+    "--rerun-except=^(?!PermissionError:).*Error:",
+    "--rerun-except=Exception:",
+    "--rerun-except=Skipping test",
 ]
 filterwarnings = [
     "ignore::UserWarning",


### PR DESCRIPTION
See also #3406 #3409 #3410

Adds a test run that simply checks no tests are skipped containing the reason "soft dependency" or similar when all dependencies are installed.

Skips all actual tests after the initial pytest check for skipping.

pytest checks generated by out testing system no longer xfail (still runs but expected to fail) but skips (does not run at all). I honestly thought we were already skipping and we have never run into and unexpected pass I believe.

Only wraps tests if the pytest flag is set.