### PR TITLE
[BUG] Fix `TimeSeriesKernelKMeans` mutating `kernel` when `kernel="kdtw"`

### DIFF
--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -147,6 +147,10 @@ class TimeSeriesKernelKMeans(BaseClusterer):
 
     Attributes
     ----------
+    kernel_ : string or callable
+        The kernel resolved during ``fit``. This is identical to ``kernel``
+        unless ``kernel="kdtw"``, in which case it is the callable used
+        internally to compute the KDTW similarity.
     labels_: np.ndarray (1d array of shape (n_case,))
         Labels that is the index each time series belongs to.
     inertia_: float
@@ -235,6 +239,7 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         if self.verbose is True:
             verbose = 1
 
+        self.kernel_ = self.kernel
         if self.kernel == "kdtw":
             n_channels = X.shape[1]
 
@@ -247,11 +252,11 @@ class TimeSeriesKernelKMeans(BaseClusterer):
                     y = y.reshape(T, n_channels)
                 return _kdtw(x, y, sigma=sigma, epsilon=epsilon)
 
-            self.kernel = kdtw_kernel
+            self.kernel_ = kdtw_kernel
 
         self._tslearn_kernel_k_means = TsLearnKernelKMeans(
             n_clusters=self.n_clusters,
-            kernel=self.kernel,
+            kernel=self.kernel_,
             max_iter=self.max_iter,
             tol=self.tol,
             n_init=self.n_init,

--- a/aeon/clustering/tests/test_kernel_k_means.py
+++ b/aeon/clustering/tests/test_kernel_k_means.py
@@ -70,6 +70,35 @@ def test_kernel_k_means_kdtw():
         assert np.count_nonzero(val == 1.0) == 1
 
 
+@pytest.mark.skipif(
+    not _check_estimator_deps(TimeSeriesKernelKMeans, severity="none"),
+    reason="skip test if required soft dependencies not available",
+)
+def test_kernel_k_means_kdtw_does_not_mutate_kernel():
+    """KDTW fit must not overwrite the ``kernel`` parameter.
+
+    Regression test for issue #3422: the resolved callable should be stored
+    in the fitted ``kernel_`` attribute, leaving the ``kernel`` parameter (and
+    therefore ``get_params``) unchanged so that repeated fits behave the same.
+    """
+    kernel_kmeans_kdtw = TimeSeriesKernelKMeans(
+        kernel="kdtw",
+        random_state=1,
+        n_clusters=3,
+    )
+
+    kernel_kmeans_kdtw.fit(X_train[0:max_train])
+
+    assert kernel_kmeans_kdtw.kernel == "kdtw"
+    assert kernel_kmeans_kdtw.get_params()["kernel"] == "kdtw"
+    assert callable(kernel_kmeans_kdtw.kernel_)
+
+    # a second fit must still take the KDTW code path and yield the same labels
+    first_labels = kernel_kmeans_kdtw.labels_.copy()
+    kernel_kmeans_kdtw.fit(X_train[0:max_train])
+    assert np.array_equal(kernel_kmeans_kdtw.labels_, first_labels)
+
+
 def test_kdtw_kernel_univariate():
     """Test kdtw kernel for univariate time series."""
     # expected value created with the original (Matlab) code from:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3422

#### What does this implement/fix? Explain your changes.

When `kernel="kdtw"`, `TimeSeriesKernelKMeans._fit` resolved the `"kdtw"`
string into a local callable and assigned it back to `self.kernel`, mutating
the public parameter. This had two consequences:

- `get_params()` returned a function object instead of the original `"kdtw"`
  string, breaking scikit-learn parameter consistency (clone, repr, etc.).
- A second call to `fit` no longer entered the KDTW branch, because the
  `self.kernel == "kdtw"` check no longer held.

This PR stores the resolved callable in a fitted `self.kernel_` attribute and
passes that to the underlying `tslearn` estimator, leaving the `kernel`
parameter untouched. This follows the scikit-learn convention that `__init__`
parameters are never modified during `fit`, and that derived state lives in a
trailing-underscore attribute.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

- `kernel_` is documented in the class `Attributes` section.
- Added `test_kernel_k_means_kdtw_does_not_mutate_kernel`, which asserts that
  `kernel` / `get_params()["kernel"]` stay `"kdtw"`, that `kernel_` is the
  resolved callable, and that a repeated `fit` produces identical labels.
- All existing kernel k-means tests and the pre-commit hooks pass.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
- [x] I've added a unit test reproducing the issue and guarding the fix.
