### PR TITLE
[BUG] ClassifierChannelEnsemble with remainder crashes

### DIFF
--- a/aeon/base/_estimators/compose/collection_channel_ensemble.py
+++ b/aeon/base/_estimators/compose/collection_channel_ensemble.py
@@ -222,7 +222,7 @@ class BaseCollectionChannelEnsemble(ComposableEstimatorMixin, BaseCollectionEsti
         if self.remainder is not None:
             current_channels = []
             all_channels = np.arange(n_channels)
-            for channels in self._channels:
+            for channels in self.channels_:
                 if isinstance(channels, int):
                     channels = [channels]
                 current_channels.extend(all_channels[channels])

--- a/aeon/classification/compose/tests/test_compose.py
+++ b/aeon/classification/compose/tests/test_compose.py
@@ -1,0 +1,27 @@
+"""Tests for classification compose estimators."""
+
+import numpy as np
+
+from aeon.classification import DummyClassifier
+from aeon.classification.compose import ClassifierChannelEnsemble
+
+
+def test_classifier_channel_ensemble_with_remainder():
+    """Test ClassifierChannelEnsemble fits remaining channels with remainder."""
+    X = np.random.RandomState(0).rand(10, 3, 5)
+    y = np.array([0, 1] * 5)
+
+    clf = ClassifierChannelEnsemble(
+        classifiers=[("first", DummyClassifier())],
+        channels=[0],
+        remainder=DummyClassifier(),
+    )
+
+    clf.fit(X, y)
+
+    assert len(clf.ensemble_) == 2
+    assert clf.ensemble_[1][0] == "Remainder"
+    assert clf.channels_[1] == [1, 2]
+
+    preds = clf.predict(X)
+    assert preds.shape == (10,)


### PR DESCRIPTION
 Solved#3428
ClassifierChannelEnsemble with remainder crashes


#### Reference Issues/PRs
Fixes #3428 

#### What does this implement/fix? Explain your changes.

Fixed an issue in `ClassifierChannelEnsemble` where fitting with a `remainder` estimator failed because the implementation attempted to access an undefined `_channels` attribute. The fix uses the validated channel information instead, allowing the remaining unspecified channels to be correctly assigned to the remainder estimator.

#### Does your contribution introduce a new dependency? If yes, which one?

Nope

#### Any other comments?

This is my first contribution to the community, so I’m trying to tackle this relatively simple issue to familiarise myself with the workflow.

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
