### PR TITLE
[BUG] Validate uniqueness of custom medoid initialisation indices

### DIFF
--- a/aeon/clustering/_cluster_initialisation.py
+++ b/aeon/clustering/_cluster_initialisation.py
@@ -398,6 +398,12 @@ def resolve_center_initialiser(
                     f"The value provided for init: {init} is invalid. "
                     f"Values must be in the range [0, {X.shape[0]})."
                 )
+            if len(np.unique(init)) != n_clusters:
+                raise ValueError(
+                    f"The value provided for init: {init} is invalid. "
+                    f"Expected {n_clusters} unique indices, got "
+                    f"{len(np.unique(init))}."
+                )
             return init
         else:
             if init.ndim == 1:

--- a/aeon/clustering/tests/test_k_medoids.py
+++ b/aeon/clustering/tests/test_k_medoids.py
@@ -244,3 +244,12 @@ def test_medoids_init_invalid():
             random_state=1,
         )
         kmedoids.fit(X_train)
+
+    # Test duplicate indices
+    with pytest.raises(ValueError, match="unique indices"):
+        kmedoids = TimeSeriesKMedoids(
+            n_clusters=num_clusters,
+            init=np.array([0, 1, 1]),
+            random_state=1,
+        )
+        kmedoids.fit(X_train)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3425.

#### What does this implement/fix? Explain your changes.

Custom medoid initialisation accepted duplicate indices: `init=np.array([0, 0])` with `n_clusters=2` was accepted even though it defines only one distinct medoid. Downstream this yields fewer effective clusters than requested — with PAM, duplicate medoids are returned as duplicate centres; with the `alternate` method, a duplicate initial medoid leaves a cluster empty and then raises an `IndexError` when computing that cluster's new medoid.

`resolve_center_initialiser` already validates the custom index array's length, dimensionality, dtype and range when `use_indexes=True`, but not uniqueness. This adds a uniqueness check in that shared resolver, so it applies consistently to every index-based clusterer (`TimeSeriesKMedoids`, `TimeSeriesCLARA`, `TimeSeriesCLARANS`). A custom init with duplicate indices now raises a clear `ValueError` (`Expected N unique indices, got M`) instead of silently degrading.

A duplicate-index case was added to the existing `test_medoids_init_invalid`.

#### Verification

- Reproduced on the released `aeon`: `init=[0, 0]` was accepted and produced a single effective cluster.
- After the fix: duplicate indices raise `ValueError` for both `pam` and `alternate`; valid unique indices and string inits (`"random"`, `"first"`, etc.) are unaffected.
- `test_cluster_initialisation.py` + `test_k_medoids.py` pass (50 tests); `ruff check` and `ruff format` clean.
