### PR TITLE
[BUG] Remove test exclusion for RDST #2290

### DIFF
--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -55,7 +55,6 @@ EXCLUDED_TESTS = {
     "ClaSPSegmenter": ["check_non_state_changing_method"],
     "HMMSegmenter": ["check_non_state_changing_method"],
     # Unknown issue not producing the same results
-    "RDSTRegressor": ["check_regressor_against_expected_results"],
     "RISTRegressor": ["check_regressor_against_expected_results"],
     # Requires y to be passed in inverse_transform,
     # but this is not currently enabled/supported


### PR DESCRIPTION
fixes #2290 if it works

tried to reproduce locally as follows, ran with default and `os.environ["NUMBA_DISABLE_JIT"] = "1"` get same answer. 

```python
"""Reproduce https://github.com/aeon-toolkit/aeon/issues/2290."""

import sys
from copy import deepcopy
from pathlib import Path

import numpy as np
from sklearn.ensemble._base import _set_random_states

sys.path.insert(0, str(Path(__file__).parents[2]))

from aeon.regression.shapelet_based import RDSTRegressor
from aeon.testing.expected_results._write_estimator_results import (
    X_c3m_test,
    X_c3m_train,
    y_c3m_train,
)
from aeon.testing.expected_results.expected_regressor_results import (
    univariate_expected_results,
)

regressor = RDSTRegressor._create_test_instance(
    parameter_set="results_comparison",
    return_first=True,
)
_set_random_states(regressor, 42)

regressor.fit(deepcopy(X_c3m_train), deepcopy(y_c3m_train))
actual = regressor.predict(deepcopy(X_c3m_test))
expected = np.asarray(univariate_expected_results["RDSTRegressor"])

print("Actual:  ", np.round(actual, 4).tolist())
print("Expected:", expected.tolist())

if np.allclose(actual, expected, rtol=0, atol=0.005):
    print("ISSUE NOT REPRODUCED: predictions match to 2 decimal places")
else:
    print("ISSUE PRESENT: predictions differ at 2 decimal places")
    print("Difference:", np.round(actual - expected, 4).tolist())
```