### PR TITLE
[ENH] Fix k-nn predict for k>1

### DIFF
--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -182,13 +182,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         y : array of shape (n_cases)
             Class labels for each data sample.
         """
-        self._check_is_fitted()
-
-        neigh_ind = self._kneighbors(
-            X, n_neighbors=1, return_distance=False, query_is_train=False
-        )
-        indexes = neigh_ind[:, 0]
-        return self.classes_[self.y_[indexes]]
+        return self.classes_[np.argmax(self._predict_proba(X), axis=1)]
 
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         """Find the K-neighbors of a point.

--- a/aeon/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/aeon/classification/distance_based/tests/test_time_series_neighbors.py
@@ -40,6 +40,25 @@ expected_correct_window = {
 }
 
 
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
+def test_predict_uses_all_neighbors(weights):
+    """Test predict uses the configured neighbor count and weighting."""
+    X_train = np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16]).reshape(7, 1, 1)
+    y_train = np.array([0, 1, 1, 1, 1, 1, 1])
+    X_test = np.zeros((1, 1, 1))
+
+    knn = KNeighborsTimeSeriesClassifier(
+        distance="euclidean", n_neighbors=7, weights=weights
+    )
+    knn.fit(X_train, y_train)
+
+    probabilities = knn.predict_proba(X_test)
+    expected = knn.classes_[np.argmax(probabilities, axis=1)]
+
+    np.testing.assert_array_equal(knn.predict(X_test), expected)
+    np.testing.assert_array_equal(expected, np.array([1]))
+
+
 @pytest.mark.parametrize("distance_key", distance_functions)
 def test_knn_on_unit_test(distance_key):
     """Test function for elastic knn, to be reinstated soon."""


### PR DESCRIPTION
a bug was introduced last year where predict in KNN always hard coded to the default on k = 1. Not exactly sure why it happened, but this fixes it and adds a regression test