### PR TITLE
[DOC] Fix classification docstring typos

### DIFF
--- a/aeon/classification/deep_learning/_disjoint_cnn.py
+++ b/aeon/classification/deep_learning/_disjoint_cnn.py
@@ -15,7 +15,7 @@ from aeon.networks import DisjointCNNNetwork
 
 
 class DisjointCNNClassifier(BaseDeepClassifier):
-    """Disjoint Convolutional Neural Netowkr classifier.
+    """Disjoint Convolutional Neural Network classifier.
 
     Adapted from the implementation used in [1]_.
 

--- a/aeon/classification/deep_learning/_inception_time.py
+++ b/aeon/classification/deep_learning/_inception_time.py
@@ -61,7 +61,7 @@ class InceptionTimeClassifier(BaseClassifier):
         module, if not a list,
         the same is used in all inception modules
     padding : str or list of str, default = "same",
-        the type of padding used for convoltuon for each
+        the type of padding used for convolution for each
         inception module, if not a list,
         the same is used in all inception modules
     activation : str or list of str, default = "relu",
@@ -463,7 +463,7 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
             the dilation rate of convolutions in each inception module, if not a list,
             the same is used in all inception modules
         padding : str or list of str, default = "same",
-            the type of padding used for convoltuon for each
+            the type of padding used for convolution for each
             inception module, if not a list,
             the same is used in all inception modules
         activation : str or list of str, default = "relu",
@@ -477,7 +477,7 @@ class IndividualInceptionClassifier(BaseDeepClassifier):
         use_residual : bool, default = True,
             condition whether or not to use residual connections all over Inception
         use_bottleneck : bool, default = True,
-            confition whether or not to use bottlenecks all over Inception
+            condition whether or not to use bottlenecks all over Inception
         bottleneck_size : int, default = 32,
             the bottleneck size in case use_bottleneck = True
         use_custom_filters : bool, default = False,

--- a/aeon/classification/deep_learning/_resnet.py
+++ b/aeon/classification/deep_learning/_resnet.py
@@ -116,7 +116,7 @@ class ResNetClassifier(BaseDeepClassifier):
     >>> from aeon.classification.deep_learning import ResNetClassifier
     >>> from aeon.datasets import load_unit_test
     >>> X_train, y_train = load_unit_test(split="train")
-    >>> clf = ResNetClassifier(n_epochs=20, bacth_size=4) # doctest: +SKIP
+    >>> clf = ResNetClassifier(n_epochs=20, batch_size=4) # doctest: +SKIP
     >>> clf.fit(X_train, Y_train) # doctest: +SKIP
     ResNetClassifier(...)
     """

--- a/aeon/classification/dictionary_based/_boss.py
+++ b/aeon/classification/dictionary_based/_boss.py
@@ -59,7 +59,7 @@ class BOSSEnsemble(BaseClassifier):
     min_window : int, default=10
         Minimum window size.
     feature_selection : str, default: "none"
-        Sets the feature selections strategy to be usedfrom  {"chi2", "none",
+        Sets the feature selections strategy to be used from {"chi2", "none",
         "random"}. Chi2 reduces the number of words significantly and is thus much
         faster (preferred). Random also reduces the number significantly. None
         applies not feature selection and yields large bag of words, e.g. much memory
@@ -68,7 +68,7 @@ class BOSSEnsemble(BaseClassifier):
         Number of possible letters (values) for each word.
     use_boss_distance : bool, default=True
         The Boss-distance is an asymmetric distance measure. It provides higher
-        accuracy, yet is signifaicantly slower to compute.
+        accuracy, yet is significantly slower to compute.
     n_jobs : int, default=1
         The number of jobs to run in parallel for both `fit` and `predict`.
         ``-1`` means using all processors.
@@ -471,7 +471,7 @@ class IndividualBOSS(BaseClassifier):
         can shorten the time to calculate dictionaries using a shorter
         `word_length` (since the last "n" letters can be removed).
     feature_selection : str, default: "none"
-        Sets the feature selections strategy to be usedfrom  {"chi2", "none",
+        Sets the feature selections strategy to be used from {"chi2", "none",
         "random"}. Chi2 reduces the number of words significantly and is thus much
         faster (preferred). Random also reduces the number significantly. None
         applies not feature selection and yields large bag of words, e.g. much memory
@@ -480,7 +480,7 @@ class IndividualBOSS(BaseClassifier):
         Number of possible letters (values) for each word.
     use_boss_distance : bool, default=True
          The Boss-distance is an asymmetric distance measure. It provides higher
-         accuracy, yet is signifaicantly slower to compute.
+         accuracy, yet is significantly slower to compute.
     n_jobs : int, default=1
          The number of jobs to run in parallel for both `fit` and `predict`.
          ``-1`` means using all processors.

--- a/aeon/classification/dictionary_based/_cboss.py
+++ b/aeon/classification/dictionary_based/_cboss.py
@@ -69,7 +69,7 @@ class ContractableBOSS(BaseClassifier):
         Sets the feature selections strategy to be used. One of {"chi2", "none",
         "random"}. "chi2" reduces the number of words significantly and is thus much
         faster (preferred). Random also reduces the number significantly. None
-        applies not feature selectiona and yields large bag of words, e.g. much
+        applies no feature selection and yields large bag of words, e.g. much
         memory may be needed.
     random_state : int, RandomState instance or None, default=None
         If `int`, random_state is the seed used by the random number generator;

--- a/aeon/classification/dictionary_based/_muse.py
+++ b/aeon/classification/dictionary_based/_muse.py
@@ -36,7 +36,7 @@ class MUSE(BaseClassifier):
 
     There are these primary parameters:
              chi2-threshold: used for feature selection to select best words
-             binning_strategy: the binning strategy used to disctrtize into SFA words.
+             binning_strategy: the binning strategy used to discretize into SFA words.
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ class MUSE(BaseClassifier):
         Sets the feature selections strategy to be used, one of
         {"chi2", "none", "random"}. "chi2" reduces the number of words significantly
         and is thus much faster (preferred). Random also reduces the number
-        significantly. None applies not feature selectiona and yields large
+        significantly. None applies no feature selection and yields large
         bag of words, e.g. much memory may be needed.
     p_threshold : int, default=0.05
         Used when feature selection is applied based on the chi-squared test.
@@ -104,7 +104,7 @@ class MUSE(BaseClassifier):
     See Also
     --------
     WEASEL
-        MUSE is the multivariare version of WEASEL.
+        MUSE is the multivariate version of WEASEL.
 
     References
     ----------

--- a/aeon/classification/dictionary_based/_weasel.py
+++ b/aeon/classification/dictionary_based/_weasel.py
@@ -74,7 +74,7 @@ class WEASEL(BaseClassifier):
         Number of possible letters (values) for each word.
     feature_selection : str, default: "chi2"
         Sets the feature selections strategy to be used. One of {"chi2", "none",
-        "random"}.  Large amounts of memory may beneeded depending on the setting of
+        "random"}.  Large amounts of memory may be needed depending on the setting of
         bigrams (true is more) or alpha (larger is more).
         'chi2' reduces the number of words, keeping those above the 'p_threshold'.
         'random' reduces the number to at most 'max_feature_count',

--- a/aeon/classification/dictionary_based/_weasel_v2.py
+++ b/aeon/classification/dictionary_based/_weasel_v2.py
@@ -40,7 +40,7 @@ class WEASEL_V2(BaseClassifier):
     for different window lengths and learns a logistic regression classifier
     on this bag.
 
-    WEASEL 2.0 has three key parameters that are automcatically set based on the
+    WEASEL 2.0 has three key parameters that are automatically set based on the
     length of the time series:
     (1) Minimal window length: Typically defaulted to 4
     (2) Maximal window length: Typically chosen from
@@ -258,7 +258,7 @@ class WEASEL_V2(BaseClassifier):
 class WEASELTransformerV2:
     """The Word Extraction for Time Series Classifier v2.0 Transformation.
 
-    WEASEL 2.0 has three key parameters that are automcatically set based on the
+    WEASEL 2.0 has three key parameters that are automatically set based on the
     length of the time series:
     (1) Minimal window length: Typically defaulted to 4
     (2) Maximal window length: Typically chosen from

--- a/aeon/classification/early_classification/_probability_threshold.py
+++ b/aeon/classification/early_classification/_probability_threshold.py
@@ -31,7 +31,7 @@ class ProbabilityThresholdEarlyClassifier(BaseEarlyClassifier):
         Build n classifiers, where n is the number of classification_points.
         While a prediction is still deemed unsafe:
             Make a prediction using the series length at classification point i.
-            Decide whether the predcition is safe or not using decide_prediction_safety.
+            Decide whether the prediction is safe or not using decide_prediction_safety.
 
     Parameters
     ----------
@@ -419,7 +419,7 @@ class ProbabilityThresholdEarlyClassifier(BaseEarlyClassifier):
         return preds, out[1]
 
     def compute_harmonic_mean(self, state_info, y) -> tuple[float, float, float]:
-        """Calculate harmonic mean from a state info matrix and array of class labeles.
+        """Calculate harmonic mean from a state info matrix and array of class labels.
 
         Parameters
         ----------

--- a/aeon/classification/early_classification/_teaser.py
+++ b/aeon/classification/early_classification/_teaser.py
@@ -38,7 +38,7 @@ class TEASER(BaseEarlyClassifier):
 
         While a prediction is still deemed unsafe:
             Make a prediction using the series length at classification point i.
-            Decide whether the predcition is safe or not using decide_prediction_safety.
+            Decide whether the prediction is safe or not using decide_prediction_safety.
 
     Parameters
     ----------
@@ -582,7 +582,7 @@ class TEASER(BaseEarlyClassifier):
         return preds, out[1]
 
     def compute_harmonic_mean(self, state_info, y) -> tuple[float, float, float]:
-        """Calculate harmonic mean from a state info matrix and array of class labeles.
+        """Calculate harmonic mean from a state info matrix and array of class labels.
 
         Parameters
         ----------

--- a/aeon/classification/feature_based/_catch22.py
+++ b/aeon/classification/feature_based/_catch22.py
@@ -46,7 +46,7 @@ class Catch22Classifier(BaseClassifier):
     outlier_norm : bool, optional, default=False
         If True, each time series is normalized during the computation of the two
         outlier Catch22 features, which can take a while to process for large values
-        as it depends on the max value in the timseries. Note that this parameter
+        as it depends on the max value in the time series. Note that this parameter
         did not exist in the original publication/implementation as they used time
         series that were already normalized.
     replace_nans : bool, default=True

--- a/aeon/classification/feature_based/_tdmvdc.py
+++ b/aeon/classification/feature_based/_tdmvdc.py
@@ -282,7 +282,7 @@ class TDMVDCClassifier(BaseClassifier):
 
         Parameters
         ----------
-        testYList : 2D np.ndarray of shape = [n_classifierss, n_cases]
+        testYList : 2D np.ndarray of shape = [n_classifiers, n_cases]
         """
         uniqueY = np.unique(testYList)  # Holds the label for each class
         n_classes = len(uniqueY)  # Number of classes

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -46,7 +46,7 @@ class RDSTClassifier(BaseClassifier):
         sensitivity or invariance. A value of 1 would mean that all shapelets will use
         a z-normalized distance.
     threshold_percentiles : array, default=None
-        The two perceniles used to select the threshold used to compute the Shapelet
+        The two percentiles used to select the threshold used to compute the Shapelet
         Occurrence feature. If None, the 5th and the 10th percentiles (i.e. [5,10])
         will be used.
     alpha_similarity : float, default=0.5

--- a/aeon/classification/shapelet_based/_sast.py
+++ b/aeon/classification/shapelet_based/_sast.py
@@ -20,7 +20,7 @@ from aeon.utils.validation import check_n_jobs
 
 
 class SASTClassifier(BaseClassifier):
-    """Classification pipeline using SAST [1]_ transformer and an sklean classifier.
+    """Classification pipeline using SAST [1]_ transformer and a sklearn classifier.
 
     Parameters
     ----------
@@ -28,7 +28,7 @@ class SASTClassifier(BaseClassifier):
         an array containing the lengths of the subsequences to be generated.
         If None, will be inferred during fit as np.arange(3, X.shape[1])
     stride : int, default = 1
-        the stride used when generating subsquences
+        the stride used when generating subsequences
     nb_inst_per_class : int default = 1
         the number of reference time series to select per class
     random_state : int, default = None


### PR DESCRIPTION
## Description

Fixes typos in classification module docstrings and examples, including spelling corrections in deep learning, dictionary-based, early classification, feature-based, and shapelet-based classifiers.

## Related Issues

Resolves #3431

## AI Assistance

This PR was authored with assistance from AI.