### PR TITLE
[DOC] Fix clustering documentation typos

### DIFF
--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -38,8 +38,8 @@ class TimeSeriesCLARA(BaseClusterer):
         accurate than random. It works by choosing centroids that are distant
         from one another. First is the fastest method and simply chooses the
         first k time series as centroids.
-        If a np.ndarray provided it must be of shape (n_clusters,) and contain
-        the indexes of the time series to use as centroids.
+        If an np.ndarray is provided it must be of shape (n_clusters,) and contain
+        the indices of the time series to use as centroids.
     distance : str or Callable, default='msm'
         Distance method to compute similarity between time series. A list of valid
         strings for metrics can be found in the documentation for
@@ -48,10 +48,10 @@ class TimeSeriesCLARA(BaseClusterer):
     n_samples : int, default=None,
         Number of samples to sample from the dataset. If None, then
         min(n_cases, 40 + 2 * n_clusters) is used.
-    n_sampling_iters : int, default=5,
+    n_sampling_iters : int, default=10
         Number of different subsets of samples to try. The best subset cluster centers
         are used.
-    n_init : int, default=5
+    n_init : int, default=1
         Number of times the PAM algorithm will be run with different
         centroid seeds. The final result will be the best output of n_init
         consecutive runs in terms of inertia.
@@ -78,8 +78,8 @@ class TimeSeriesCLARA(BaseClusterer):
     ----------
     cluster_centers_ : np.ndarray, of shape (n_cases, n_channels, n_timepoints)
         A collection of time series instances that represent the cluster centers.
-    labels_ : np.ndarray (1d array of shape (n_case,))
-        Labels that is the index each time series belongs to.
+    labels_ : np.ndarray (1d array of shape (n_cases,))
+        Labels indicating the cluster index assigned to each time series.
     inertia_ : float
         Sum of squared distances of samples to their closest cluster center, weighted by
         the sample weights if provided.

--- a/aeon/clustering/_clarans.py
+++ b/aeon/clustering/_clarans.py
@@ -16,8 +16,8 @@ from aeon.clustering._k_medoids import TimeSeriesKMedoids
 class TimeSeriesCLARANS(TimeSeriesKMedoids):
     """Time series CLARANS implementation.
 
-    CLARA based raNdomised Search (CLARANS) [1] adapts the swap operation of PAM to
-    use a more greedy approach. This is done by only performing the first swap which
+    Clustering Large Applications based upon RANdomized Search (CLARANS) [1]
+    adapts the swap operation of PAM to use a more greedy approach. This is done by only performing the first swap which
     results in a reduction in total deviation before continuing evaluation. It limits
     the number of attempts known as max neighbours to randomly select and check if
     total deviation is reduced. This random selection gives CLARANS an advantage when
@@ -40,8 +40,8 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
         accurate than random. It works by choosing centroids that are distant
         from one another. First is the fastest method and simply chooses the
         first k time series as centroids.
-        If a np.ndarray provided it must be of shape (n_clusters,) and contain
-        the indexes of the time series to use as centroids.
+        If an np.ndarray is provided it must be of shape (n_clusters,) and contain
+        the indices of the time series to use as centroids.
     distance : str or Callable, default='msm'
         Distance method to compute similarity between time series. A list of valid
         strings for measures can be found in the documentation for
@@ -50,10 +50,10 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
     max_neighbours : int, default=None,
         The maximum number of neighbouring solutions that the algorithm will explore
         for each set of medoids. A neighbouring solution is obtained by replacing
-        one of the medoids with a non-medoid and seeing if total cost reduces. If
+        one of the medoids with a non-medoid and seeing if total cost is reduced. If
         not specified max_neighbours is set to 1.25% of the total number of possible
         swaps (as suggested in the original paper).
-    n_init : int, default=5
+    n_init : int, default=10
         Number of times the PAM algorithm will be run with different
         centroid seeds. The final result will be the best output of n_init
         consecutive runs in terms of inertia.
@@ -68,8 +68,8 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
     ----------
     cluster_centers_ : np.ndarray, of shape (n_cases, n_channels, n_timepoints)
         A collection of time series instances that represent the cluster centers.
-    labels_ : np.ndarray (1d array of shape (n_case,))
-        Labels that is the index each time series belongs to.
+    labels_ : np.ndarray (1d array of shape (n_cases,))
+        Labels indicating the cluster index assigned to each time series.
     inertia_ : float
         Sum of squared distances of samples to their closest cluster center, weighted by
         the sample weights if provided.

--- a/aeon/clustering/_clarans.py
+++ b/aeon/clustering/_clarans.py
@@ -17,7 +17,8 @@ class TimeSeriesCLARANS(TimeSeriesKMedoids):
     """Time series CLARANS implementation.
 
     Clustering Large Applications based upon RANdomized Search (CLARANS) [1]
-    adapts the swap operation of PAM to use a more greedy approach. This is done by only performing the first swap which
+    adapts the swap operation of PAM to use a more greedy approach. This is done
+    by only performing the first swap which
     results in a reduction in total deviation before continuing evaluation. It limits
     the number of attempts known as max neighbours to randomly select and check if
     total deviation is reduced. This random selection gives CLARANS an advantage when

--- a/aeon/clustering/_elastic_som.py
+++ b/aeon/clustering/_elastic_som.py
@@ -59,18 +59,18 @@ class ElasticSOM(BaseClusterer):
     init : str or np.ndarray, default='random'
         Random is the default and simply chooses k time series at random as
         centroids. It is fast but sometimes yields sub-optimal clustering.
-        Kmeans++ [2] and is slower but often more
+        K-means++ [2] is slower but often more
         accurate than random. It works by choosing centroids that are distant
         from one another.
         First is the fastest method and simply chooses the first k time series as
         centroids.
-        If a np.ndarray provided it must be of shape (n_clusters, n_channels,
+        If an np.ndarray is provided it must be of shape (n_clusters, n_channels,
         n_timepoints)
         and contains the time series to use as centroids.
     sigma : float, default=1.0
         Spread of the neighborhood function.
     learning_rate : float, default=0.5
-        Initial learning rate. For a given iterations the learning rate is:
+        Initial learning rate. For a given iteration the learning rate is:
         learning_rate = learning_rate / (1 + iterations / max_iter)
     decay_function : Union[Callable, str], default='asymptotic_decay'
         Decay function to use for the learning rate. Valid strings are:
@@ -118,9 +118,9 @@ class ElasticSOM(BaseClusterer):
         be used. See aeon.clustering.elastic_som.VALID_ELASTIC_SOM_METRICS for a list of
         distances that have an elastic alignment path.
         The alignment path function takes the form
-        Callable[[np.ndarray, np.ndarray, dict], where the dict is the kwargs for the
-        distance function. See documentation of aeon.distances for example alignment
-        path functions. The alignment path function must return a a full alignment path
+        Callable[[np.ndarray, np.ndarray, dict], tuple[list, float]], where the dict
+        contains the kwargs for the distance function. See documentation of aeon.distances for example alignment
+        path functions. The alignment path function must return a full alignment path
         with no gaps.
     verbose : bool, default=False
         Verbosity mode.
@@ -128,11 +128,11 @@ class ElasticSOM(BaseClusterer):
     Attributes
     ----------
     cluster_centers_ : 3d np.ndarray
-        Array of shape (n_clusters, n_channels, n_timepoints))
+        Array of shape (n_clusters, n_channels, n_timepoints)
         Time series that represent each of the cluster centers.
     labels_ : 1d np.ndarray
-        1d array of shape (n_case,)
-        Labels that is the index each time series belongs to.
+        1d array of shape (n_cases,)
+        Labels indicating the cluster index assigned to each time series.
 
     References
     ----------

--- a/aeon/clustering/_elastic_som.py
+++ b/aeon/clustering/_elastic_som.py
@@ -119,8 +119,9 @@ class ElasticSOM(BaseClusterer):
         distances that have an elastic alignment path.
         The alignment path function takes the form
         Callable[[np.ndarray, np.ndarray, dict], tuple[list, float]], where the dict
-        contains the kwargs for the distance function. See documentation of aeon.distances for example alignment
-        path functions. The alignment path function must return a full alignment path
+        contains the kwargs for the distance function. See documentation of
+        aeon.distances for example alignment path functions. The alignment path
+        function must return a full alignment path
         with no gaps.
     verbose : bool, default=False
         Verbosity mode.

--- a/aeon/clustering/_k_means.py
+++ b/aeon/clustering/_k_means.py
@@ -41,7 +41,7 @@ class TimeSeriesKMeans(BaseClusterer):
     particular MSM/TWE [1]_). K-means for time series can further be improved by using
     an elastic averaging method. The most common one is dynamic barycenter averaging
     [3]_ however, in recent years alternates using other elastic distances such as
-    ShapeDBA [4]_ (Shape DTW DBA) and MBA (Msm DBA) [5]_ have shown signicant
+    ShapeDBA [4]_ (Shape DTW DBA) and MBA (MSM DBA) [5]_ have shown significant
     performance benefits.
 
     Parameters
@@ -51,12 +51,12 @@ class TimeSeriesKMeans(BaseClusterer):
     init : str or np.ndarray, default='random'
         Random is the default and simply chooses k time series at random as
         centroids. It is fast but sometimes yields sub-optimal clustering.
-        Kmeans++ [2] and is slower but often more
+        K-means++ [2] is slower but often more
         accurate than random. It works by choosing centroids that are distant
         from one another.
         First is the fastest method and simply chooses the first k time series as
         centroids.
-        If a np.ndarray provided it must be of shape (n_clusters, n_channels,
+        If an np.ndarray is provided it must be of shape (n_clusters, n_channels,
         n_timepoints)
         and contains the time series to use as centroids.
     distance : str or Callable, default='msm'
@@ -114,11 +114,11 @@ class TimeSeriesKMeans(BaseClusterer):
     Attributes
     ----------
     cluster_centers_ : 3d np.ndarray
-        Array of shape (n_clusters, n_channels, n_timepoints))
+        Array of shape (n_clusters, n_channels, n_timepoints)
         Time series that represent each of the cluster centers.
     labels_ : 1d np.ndarray
-        1d array of shape (n_case,)
-        Labels that is the index each time series belongs to.
+        1d array of shape (n_cases,)
+        Labels indicating the cluster index assigned to each time series.
     inertia_ : float
         Sum of distances of samples to their closest cluster center, weighted by
         the sample weights if provided.

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -33,7 +33,8 @@ class TimeSeriesKMedoids(BaseClusterer):
     Where n is the number of time series and k is the number of clusters. There have
     been a number of algorithms published to solve the problem. The most common is the
     PAM (Partition Around Medoids)[3]_ algorithm and is the default method used in this
-    implementation. However, an adaptation of Lloyd's method classically used for k-means
+    implementation. However, an adaptation of Lloyd's method classically used for
+    k-means
     is also available by specifying method='alternate'. Alternate is faster but less
     accurate than PAM. For a full review of variations of k-medoids for time series
     see [5]_.

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -33,7 +33,7 @@ class TimeSeriesKMedoids(BaseClusterer):
     Where n is the number of time series and k is the number of clusters. There have
     been a number of algorithms published to solve the problem. The most common is the
     PAM (Partition Around Medoids)[3]_ algorithm and is the default method used in this
-    implementation. However, an adaptation of lloyds method classically used for k-means
+    implementation. However, an adaptation of Lloyd's method classically used for k-means
     is also available by specifying method='alternate'. Alternate is faster but less
     accurate than PAM. For a full review of variations of k-medoids for time series
     see [5]_.
@@ -56,11 +56,11 @@ class TimeSeriesKMedoids(BaseClusterer):
         from one another. First is the fastest method and simply chooses the
         first k time series as centroids. Build [1] greedily selects the k medoids
         by first selecting the medoid that minimizes the sum of distances
-        to all other points(this point is the most centrally located) and then
+        to all other points (this point is the most centrally located) and then
         iteratively selects the next k-1 medoids that maximizes the decrease in sum
         of distances of all other points to their respective medoids selected so far.
-        If a np.ndarray provided it must be of shape (n_clusters,) and contain
-        the indexes of the time series to use as centroids.
+        If an np.ndarray is provided it must be of shape (n_clusters,) and contain
+        the indices of the time series to use as centroids.
     distance : str or Callable, default='msm'
         Distance method to compute similarity between time series. A list of valid
         strings for measures can be found in the documentation for
@@ -69,7 +69,7 @@ class TimeSeriesKMedoids(BaseClusterer):
     method : str, default='pam'
         Method for computing k-medoids. Any of the following are valid:
         ['alternate', 'pam'].
-        Alternate applies lloyds method to k-medoids and is faster but less accurate
+        Alternate applies Lloyd's method to k-medoids and is faster but less accurate
         than PAM.
         PAM is implemented using the fastpam1 algorithm which gives the same output
         as PAM but is faster.
@@ -100,8 +100,8 @@ class TimeSeriesKMedoids(BaseClusterer):
     ----------
     cluster_centers_ : np.ndarray, of shape (n_cases, n_channels, n_timepoints)
         A collection of time series instances that represent the cluster centers.
-    labels_ : np.ndarray (1d array of shape (n_case,))
-        Labels that is the index each time series belongs to.
+    labels_ : np.ndarray (1d array of shape (n_cases,))
+        Labels indicating the cluster index assigned to each time series.
     inertia_ : float
         Sum of squared distances of samples to their closest cluster center, weighted by
         the sample weights if provided.
@@ -110,7 +110,7 @@ class TimeSeriesKMedoids(BaseClusterer):
 
     References
     ----------
-    .. [1] Kaufmann, Leonard & Rousseeuw, Peter. (1987). Clustering by Means of Medoids.
+    .. [1] Kaufman, Leonard & Rousseeuw, Peter. (1987). Clustering by Means of Medoids.
     Data Analysis based on the L1-Norm and Related Methods. 405-416.
 
     .. [2] Holder, Christopher & Middlehurst, Matthew & Bagnall, Anthony. (2022).

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -34,7 +34,8 @@ class TimeSeriesKMedoids(BaseClusterer):
     been a number of algorithms published to solve the problem. The most common is the
     PAM (Partition Around Medoids)[3]_ algorithm and is the default method used in this
     implementation. However, an adaptation of Lloyd's method classically used
-    for k-means is also available by specifying method='alternate'. Alternate is faster but less
+    for k-means is also available by specifying method='alternate'. Alternate is
+    faster but less
     accurate than PAM. For a full review of variations of k-medoids for time series
     see [5]_.
 

--- a/aeon/clustering/_k_medoids.py
+++ b/aeon/clustering/_k_medoids.py
@@ -33,9 +33,8 @@ class TimeSeriesKMedoids(BaseClusterer):
     Where n is the number of time series and k is the number of clusters. There have
     been a number of algorithms published to solve the problem. The most common is the
     PAM (Partition Around Medoids)[3]_ algorithm and is the default method used in this
-    implementation. However, an adaptation of Lloyd's method classically used for
-    k-means
-    is also available by specifying method='alternate'. Alternate is faster but less
+    implementation. However, an adaptation of Lloyd's method classically used
+    for k-means is also available by specifying method='alternate'. Alternate is faster but less
     accurate than PAM. For a full review of variations of k-medoids for time series
     see [5]_.
 

--- a/aeon/clustering/_k_shape.py
+++ b/aeon/clustering/_k_shape.py
@@ -34,7 +34,7 @@ class KShape(BaseClusterer):
 
     K-Shape is a k-means based clustering algorithm that employs Shape-Based
     Distance (SBD) for assignment and shape extraction via leading eigenvector
-    of a centred covariance-like matrix for centroid forming. This implementation is
+    of a centred covariance-like matrix for forming centroids. This implementation is
     based on the implementation from TheDatumOrg/kshape-python (MIT License)
     adapted to use aeon SBD distance and to be compliant with aeon BaseClusterer API.
 

--- a/aeon/clustering/_kasba.py
+++ b/aeon/clustering/_kasba.py
@@ -33,12 +33,12 @@ class KASBA(BaseClusterer):
         The number of clusters to form as well as the number of centroids to generate.
     distance : str or callable, default='msm'
         The distance metric to use. If a string, must be one of the following:
-        'msm', 'twe'. The distance measure use MUST be a metric.
+        'msm', 'twe'. The distance measure used MUST be a metric.
     ba_subset_size : float, default=0.5
         The proportion of the data to use in the barycenter average step. For the first
         iteration all the data will be used however, on subsequent iterations a subset
         of the data will be used. This will be a % of the data passed (e.g. 0.5 = 50%).
-        If there are less than 10 data points, all the available data will be used
+        If there are fewer than 10 data points, all the available data will be used
         every iteration.
     initial_step_size : float, default=0.05
         The initial step size for the stochastic gradient descent in the
@@ -72,11 +72,11 @@ class KASBA(BaseClusterer):
     Attributes
     ----------
     cluster_centers_ : 3d np.ndarray
-        Array of shape (n_clusters, n_channels, n_timepoints))
+        Array of shape (n_clusters, n_channels, n_timepoints)
         Time series that represent each of the cluster centers.
     labels_ : 1d np.ndarray
-        1d array of shape (n_case,)
-        Labels that is the index each time series belongs to.
+        1d array of shape (n_cases,)
+        Labels indicating the cluster index assigned to each time series.
     inertia_ : float
         Sum of squared distances of samples to their closest cluster center.
     n_iter_ : int
@@ -96,7 +96,7 @@ class KASBA(BaseClusterer):
     >>> import numpy as np
     >>> from aeon.clustering import KASBA
     >>> X = np.random.random(size=(10,2,20))
-    >>> clst= KASBA(distance="msm",n_clusters=2)
+    >>> clst = KASBA(distance="msm", n_clusters=2)
     >>> clst.fit(X)
     KASBA(n_clusters=2)
     >>> preds = clst.predict(X)

--- a/aeon/clustering/_kernel_k_means.py
+++ b/aeon/clustering/_kernel_k_means.py
@@ -125,7 +125,7 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         If set to 'auto', it is computed based on a sampling of the training
         set
         (cf :ref:`tslearn.metrics.sigma_gak <fun-tslearn.metrics.sigma_gak>`).
-        If no specific value is set for ``sigma``, its default to 1.
+        If no specific value is set for ``sigma``, it defaults to 1.
     max_iter: int, default=300
         Maximum number of iterations of the k-means algorithm for a single
         run.
@@ -139,7 +139,7 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         The number of jobs to run in parallel for GAK cross-similarity matrix
         computations.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See scikit-learns'
+        ``-1`` means using all processors. See scikit-learn's
         `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
         for more details.
     random_state: int or np.random.RandomState instance or None, default=None
@@ -151,8 +151,8 @@ class TimeSeriesKernelKMeans(BaseClusterer):
         The kernel resolved during ``fit``. This is identical to ``kernel``
         unless ``kernel="kdtw"``, in which case it is the callable used
         internally to compute the KDTW similarity.
-    labels_: np.ndarray (1d array of shape (n_case,))
-        Labels that is the index each time series belongs to.
+    labels_: np.ndarray (1d array of shape (n_cases,))
+        Labels indicating the cluster index assigned to each time series.
     inertia_: float
         Sum of squared distances of samples to their closest cluster center, weighted by
         the sample weights if provided.

--- a/aeon/clustering/base.py
+++ b/aeon/clustering/base.py
@@ -77,8 +77,8 @@ class BaseClusterer(ClusterMixin, BaseCollectionEstimator):
         Returns
         -------
         np.array
-            shape ``(n_cases)`, index of the cluster each time series in X.
-            belongs to.
+            shape ``(n_cases,)``, index of the cluster to which each time series in X
+            belongs.
         """
         self._check_is_fitted()
         X = self._preprocess_collection(X, store_metadata=False)
@@ -127,8 +127,8 @@ class BaseClusterer(ClusterMixin, BaseCollectionEstimator):
         ----------
         X : np.ndarray (2d or 3d array of shape (n_cases, n_timepoints) or shape
             (n_cases, n_channels, n_timepoints)).
-            Time series instances to train clusterer and then have indexes each belong
-            to return.
+            Time series instances used to train the clusterer and return their assigned
+            cluster indices.
         y: ignored, exists for API consistency reasons.
 
         Returns


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3421.

#### What does this implement/fix? Explain your changes.

This fixes a focused set of typos, grammar issues, shape text, and documented default-value mismatches in clustering estimator docstrings. The default values changed here match the current estimator signatures for `TimeSeriesCLARA` and `TimeSeriesCLARANS`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Validation was not run because this documentation-only change was prepared through the GitHub API without a local checkout.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors, or will use the @all-contributors bot after merge.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV].

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.