### PR TITLE
[BUG] Support callable weights in KNeighborsTimeSeriesClassifier

### DIFF
--- a/aeon/classification/distance_based/_time_series_neighbors.py
+++ b/aeon/classification/distance_based/_time_series_neighbors.py
@@ -33,9 +33,14 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
     n_neighbors : int, default = 1
         Set ``k`` for knn.
     weights : str or callable, default = 'uniform'
-        Mechanism for weighting a vote one of: ``'uniform'``, ``'distance'``,
-        or a callable
-        function.
+        Mechanism for weighting a vote, one of:
+
+        - ``'uniform'`` : all points in each neighbourhood are weighted equally.
+        - ``'distance'`` : weight points by the inverse of their distance, so that
+          closer neighbours have greater influence.
+        - a callable : a user-defined function which accepts an array of distances
+          to the neighbours and returns an array of the same shape containing the
+          weights.
     distance : str or callable, default ='dtw'
         Distance measure between time series.
         Distance metric to compute similarity between time series. A ``list`` of valid
@@ -99,10 +104,10 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         if self._distance_params is None:
             self._distance_params = {}
 
-        if weights not in WEIGHTS_SUPPORTED:
+        if not callable(weights) and weights not in WEIGHTS_SUPPORTED:
             raise ValueError(
                 f"Unrecognised kNN weights: {weights}. "
-                f"Allowed values are: {WEIGHTS_SUPPORTED}. "
+                f"Allowed values are: {WEIGHTS_SUPPORTED}, or a callable. "
             )
         self.weights = weights
 
@@ -150,7 +155,9 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             neigh_dist = neigh_dist[0]
             neigh_ind = neigh_ind[0]
 
-            if self.weights == "distance":
+            if callable(self.weights):
+                weights = self.weights(neigh_dist)
+            elif self.weights == "distance":
                 weights = 1 / (neigh_dist + np.finfo(float).eps)
             elif self.weights == "uniform":
                 weights = np.repeat(1.0, len(neigh_ind))

--- a/aeon/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/aeon/classification/distance_based/tests/test_time_series_neighbors.py
@@ -153,3 +153,37 @@ def test_knn_kneighbors(distance_key):
     # Each point should not be its own neighbor (diagonal should be excluded)
     for i in range(len(X_train)):
         assert i not in train_ind[i]
+
+
+def test_predict_callable_weights():
+    """A callable ``weights`` is accepted and used to weight the vote.
+
+    Regression test for issue #3426: the constructor documented ``callable``
+    weights but rejected them.
+    """
+    X_train = np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16]).reshape(7, 1, 1)
+    y_train = np.array([0, 1, 1, 1, 1, 1, 1])
+    X_test = np.zeros((1, 1, 1))
+
+    def nearest_only(distances):
+        # Put all weight on the single closest neighbour.
+        w = np.zeros_like(distances)
+        w[np.argmin(distances)] = 1.0
+        return w
+
+    knn = KNeighborsTimeSeriesClassifier(
+        distance="euclidean", n_neighbors=7, weights=nearest_only
+    )
+    knn.fit(X_train, y_train)
+
+    probabilities = knn.predict_proba(X_test)
+    # Only the closest neighbour (class 0) carries weight, so class 0 wins;
+    # uniform weighting over the 7 neighbours would instead predict class 1.
+    np.testing.assert_array_equal(knn.predict(X_test), np.array([0]))
+    np.testing.assert_allclose(probabilities.sum(axis=1), 1.0)
+
+
+def test_invalid_weights_string_raises():
+    """An unrecognised ``weights`` string is still rejected."""
+    with pytest.raises(ValueError, match="Unrecognised kNN weights"):
+        KNeighborsTimeSeriesClassifier(weights="not_a_weighting")


### PR DESCRIPTION
Fixes #3426.

## Why

`KNeighborsTimeSeriesClassifier` documents and type-annotates `weights` as `str | Callable`, and the class docstring says it accepts a callable. But the constructor validated against `WEIGHTS_SUPPORTED = ["uniform", "distance"]`, so any callable raised `ValueError: Unrecognised kNN weights: ...`. `_predict_proba` had the same gap — it only branched on the two strings and raised otherwise. So callable weighting was documented but impossible to use.

This restores the documented behaviour and brings it in line with sklearn's `KNeighborsClassifier`, where `weights` may be a callable that receives an array of distances and returns an array of weights.

## What changed

- Constructor: accept `weights` if it is `callable(...)`, otherwise keep the existing string validation (unknown strings are still rejected).
- `_predict_proba`: when `weights` is callable, weight each neighbour's vote by `self.weights(neigh_dist)` (the array of distances to that query's neighbours), mirroring sklearn. The `'uniform'` / `'distance'` paths are unchanged.
- Docstring: spell out the three `weights` options, including the callable contract.

## Review notes

The callable receives the 1-D array of neighbour distances for a single query (as sklearn does) and must return weights of the same shape; no normalisation or sign checks are imposed, matching sklearn.

## Testing

Added two tests in `test_time_series_neighbors.py`:
- `test_predict_callable_weights` — a callable that puts all weight on the closest neighbour flips the prediction relative to uniform weighting, proving the callable is actually applied (fails before this change at construction time).
- `test_invalid_weights_string_raises` — an unknown weight string is still rejected.

The full `test_time_series_neighbors.py` suite passes (25 tests); `ruff check` and `ruff format` are clean.

---
This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
