### PR TITLE
[BUG] Fix TimeSeriesCLARA sampling

### DIFF
--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -165,13 +165,17 @@ class TimeSeriesCLARA(BaseClusterer):
         best_pam = None
         best_labels = None
         for _ in range(self.n_sampling_iters):
-            sample_idxs = np.arange(n_samples)
+
             if n_samples < n_cases:
                 sample_idxs = self._random_state.choice(
-                    sample_idxs,
+                    np.arange(n_cases),
                     size=n_samples,
                     replace=False,
                 )
+
+            else:
+                sample_idxs = np.arange(n_cases)
+
             pam = TimeSeriesKMedoids(
                 n_clusters=self.n_clusters,
                 init=self.init,

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -34,18 +34,18 @@ def test_clara_uni():
     proba = clara.predict_proba(X_test)
     assert np.array_equal(
         test_medoids_result,
-        [1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1],
     )
     assert np.array_equal(
         train_medoids_result,
-        [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1],
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0],
     )
     assert test_score == 0.5210526315789473
     assert train_score == 0.5578947368421052
-    assert np.isclose(clara.inertia_, 78.79839208236065)
-    assert clara.n_iter_ == 2
+    assert np.isclose(clara.inertia_, 74.72628097332178)
+    assert clara.n_iter_ == 3
     assert np.array_equal(
-        clara.labels_, [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1]
+        clara.labels_, [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0]
     )
     assert isinstance(clara.cluster_centers_, np.ndarray)
     for val in proba:
@@ -79,19 +79,39 @@ def test_clara_multi():
     proba = clara.predict_proba(X_test)
     assert np.array_equal(
         test_medoids_result,
-        [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     )
     assert np.array_equal(
         train_medoids_result,
-        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1],
     )
     assert test_score == 0.4789473684210526
     assert train_score == 0.5578947368421052
-    assert np.isclose(clara.inertia_, 1900.6752544011563)
+    assert np.isclose(clara.inertia_, 1675.1873875545991)
     assert clara.n_iter_ == 3
     assert np.array_equal(
-        clara.labels_, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1]
+        clara.labels_, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1]
     )
     assert isinstance(clara.cluster_centers_, np.ndarray)
     for val in proba:
         assert np.count_nonzero(val == 1.0) == 1
+
+
+def test_clara_samples_from_all_cases():
+    """Test CLARA samples from all cases, not only the first n_samples."""
+    X = np.arange(20).reshape(20, 1, 1).astype(float)
+
+    clara = TimeSeriesCLARA(
+        n_clusters=10,
+        init="first",
+        n_samples=10,
+        n_sampling_iters=1,
+        n_init=1,
+        max_iter=1,
+        distance="euclidean",
+        random_state=1,
+    )
+
+    clara.fit(X)
+
+    assert np.max(clara.cluster_centers_) >= clara.n_samples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Fixes #3420 


#### What does this implement/fix? Explain your changes.

This fixes the sampling logic in `TimeSeriesCLARA`.

Previously, when `n_samples < n_cases`, candidate sample indices were drawn from `np.arange(n_samples)`, meaning CLARA could only sample from the first `n_samples` cases.

This change updates the sampling logic so indices are drawn from `np.arange(n_cases)` instead, allowing samples to be selected from the full dataset.

The previous expected outputs in the CLARA tests were based on the buggy sampling behaviour. Since the corrected implementation samples from the full set of cases, the deterministic outputs for those tests changed and have been updated accordingly.

A regression test has also been added to verify that CLARA can sample cases beyond the first `n_samples`.


#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

I ran:

```bash
python -m pytest aeon/clustering/tests/test_clara.py -vv
```
and the tests passed.

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are
not applicable. To check a box, replace the space inside the square brackets with an
'x' i.e. [x].
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.



<!--
Thanks for contributing!
-->
