### PR TITLE
[BUG] Reject array init for TimeSeriesCLARA

### DIFF
--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -29,7 +29,7 @@ class TimeSeriesCLARA(BaseClusterer):
     n_clusters : int, default=8
         The number of clusters to form as well as the number of
         centroids to generate.
-    init : str or np.ndarray, default='random'
+    init : str, default='random'
         Method for initialising cluster centers. Any of the following are valid:
         ['kmedoids++', 'random', 'first'].
         Random is the default as it is very fast and it was found in [2] to
@@ -38,8 +38,6 @@ class TimeSeriesCLARA(BaseClusterer):
         accurate than random. It works by choosing centroids that are distant
         from one another. First is the fastest method and simply chooses the
         first k time series as centroids.
-        If an np.ndarray is provided it must be of shape (n_clusters,) and contain
-        the indices of the time series to use as centroids.
     distance : str or Callable, default='msm'
         Distance method to compute similarity between time series. A list of valid
         strings for metrics can be found in the documentation for
@@ -154,6 +152,13 @@ class TimeSeriesCLARA(BaseClusterer):
         return self._kmedoids_instance.predict(X)
 
     def _fit(self, X: np.ndarray, y=None):
+        if isinstance(self.init, np.ndarray):
+            raise ValueError(
+                "Array initialisation is not supported for TimeSeriesCLARA "
+                "because CLARA fits PAM on sampled subsets. Use a string "
+                "initialisation method instead."
+            )
+
         self._random_state = check_random_state(self.random_state)
         n_cases = X.shape[0]
         if self.n_samples is None:

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -115,7 +115,7 @@ class TimeSeriesCLARA(BaseClusterer):
     def __init__(
         self,
         n_clusters: int = 8,
-        init: str | np.ndarray = "random",
+        init: str = "random",
         distance: str | Callable = "msm",
         n_samples: int | None = None,
         n_sampling_iters: int = 10,
@@ -152,9 +152,9 @@ class TimeSeriesCLARA(BaseClusterer):
         return self._kmedoids_instance.predict(X)
 
     def _fit(self, X: np.ndarray, y=None):
-        if isinstance(self.init, np.ndarray):
+        if not isinstance(self.init, str):
             raise ValueError(
-                "Array initialisation is not supported for TimeSeriesCLARA "
+                "Non-string initialisation is not supported for TimeSeriesCLARA "
                 "because CLARA fits PAM on sampled subsets. Use a string "
                 "initialisation method instead."
             )

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -1,6 +1,7 @@
 """Tests for time series k-medoids."""
 
 import numpy as np
+import pytest
 from sklearn import metrics
 
 from aeon.clustering._clara import TimeSeriesCLARA
@@ -95,3 +96,20 @@ def test_clara_multi():
     assert isinstance(clara.cluster_centers_, np.ndarray)
     for val in proba:
         assert np.count_nonzero(val == 1.0) == 1
+
+
+def test_clara_rejects_array_init():
+    """Test CLARA rejects array initialisation."""
+    X = np.random.RandomState(0).random(size=(10, 1, 8))
+
+    clara = TimeSeriesCLARA(
+        n_clusters=2,
+        init=np.array([6, 7]),
+        n_samples=4,
+        n_sampling_iters=1,
+        distance="euclidean",
+        random_state=0,
+    )
+
+    with pytest.raises(ValueError, match="Array initialisation is not supported"):
+        clara.fit(X)

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -98,20 +98,21 @@ def test_clara_multi():
         assert np.count_nonzero(val == 1.0) == 1
 
 
-def test_clara_rejects_array_init():
-    """Test CLARA rejects array initialisation."""
+@pytest.mark.parametrize("init", [np.array([6, 7]), [6, 7]])
+def test_clara_rejects_non_string_init(init):
+    """Test CLARA rejects non-string initialisation."""
     X = np.random.RandomState(0).random(size=(10, 1, 8))
 
     clara = TimeSeriesCLARA(
         n_clusters=2,
-        init=np.array([6, 7]),
+        init=init,
         n_samples=4,
         n_sampling_iters=1,
         distance="euclidean",
         random_state=0,
     )
 
-    with pytest.raises(ValueError, match="Array initialisation is not supported"):
+    with pytest.raises(ValueError, match="Non-string initialisation is not supported"):
         clara.fit(X)
 
 


### PR DESCRIPTION
## Summary
- Reject ndarray initialisation in TimeSeriesCLARA with a clear ValueError before fitting sampled PAM subsets.
- Update the init docstring to match the supported CLARA initialisation methods.
- Add a regression test for the invalid full-dataset init-index case from #3423.

## Validation
- python -m py_compile aeon/clustering/_clara.py aeon/clustering/tests/test_clara.py
- Could not run pytest locally because this Python environment is missing pytest/sklearn.

Closes #3423.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.