### PR TITLE
[BUG] clone regressor in RegressionForecaster to prevent mutation (fixes #3448)

### DIFF
--- a/aeon/forecasting/_regression.py
+++ b/aeon/forecasting/_regression.py
@@ -8,6 +8,7 @@ to form ``X`` and trains to predict the next ``horizon`` points ahead.
 import numpy as np
 from sklearn.linear_model import LinearRegression
 
+from aeon.base._base import _clone_estimator
 from aeon.forecasting.base import (
     BaseForecaster,
     DirectForecastingMixin,
@@ -75,7 +76,7 @@ class RegressionForecaster(
         if self.regressor is None:
             self.regressor_ = LinearRegression()
         else:
-            self.regressor_ = self.regressor
+            self.regressor_ = _clone_estimator(self.regressor)
         self._n_exog = 0
         # Combine y and exog for windowing
         if exog is not None:

--- a/aeon/forecasting/tests/test_regressor.py
+++ b/aeon/forecasting/tests/test_regressor.py
@@ -118,6 +118,7 @@ def test_regressor_cloned_not_mutated():
     """Test RegressionForecaster clones the regressor instead of mutating it."""
     import numpy as np
     from sklearn.linear_model import Ridge
+
     from aeon.forecasting._regression import RegressionForecaster
 
     reg = Ridge()

--- a/aeon/forecasting/tests/test_regressor.py
+++ b/aeon/forecasting/tests/test_regressor.py
@@ -112,3 +112,26 @@ def test_regression_forecaster_with_exog_errors():
         f.predict(y)
     with pytest.raises(ValueError, match="must be greater than or equal to 1"):
         f.direct_forecast(y, prediction_horizon=0)
+
+
+def test_regressor_cloned_not_mutated():
+    """Test RegressionForecaster clones the regressor instead of mutating it."""
+    import numpy as np
+    from sklearn.linear_model import Ridge
+    from aeon.forecasting._regression import RegressionForecaster
+
+    reg = Ridge()
+    y1 = np.arange(20.0)
+    y2 = np.arange(20.0)[::-1]
+
+    f1 = RegressionForecaster(window=5, regressor=reg)
+    f2 = RegressionForecaster(window=5, regressor=reg)
+
+    f1.fit(y1)
+    f2.fit(y2)
+
+    # Original regressor should not be the fitted regressor_
+    assert reg is not f1.regressor_
+    assert reg is not f2.regressor_
+    # Two forecasters with same regressor should get independent clones
+    assert f1.regressor_ is not f2.regressor_


### PR DESCRIPTION
## Description
RegressionForecaster._fit stored the user's regressor object directly in `regressor_` instead of cloning it first. This caused:
1. The original regressor to become fitted as a side-effect of fitting the forecaster
2. Two forecasters constructed with the same regressor to share fitted state

## Fix
Import `_clone_estimator` from `aeon.base._base` and clone the supplied regressor before fitting, matching the convention used elsewhere in the codebase (e.g. forecasting/base.py, classifiers).

Closes #3448

This pull request includes code written with the assistance of AI under my direction.