### PR TITLE
[BUG] use len(X) instead of X.shape[0] for list input in ShapeletTransformClassifier (fixes #3447)

### DIFF
--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -273,8 +273,7 @@ class ShapeletTransformClassifier(BaseClassifier):
         ):
             if self.verbose:
                 print(  # noqa: T201
-                    "Fitting estimator and generating train set estimates "
-                    "(RotF OOB)..."
+                    "Fitting estimator and generating train set estimates (RotF OOB)..."
                 )
 
             proba = self._estimator.fit_predict_proba(X_t, y)

--- a/aeon/classification/shapelet_based/_stc.py
+++ b/aeon/classification/shapelet_based/_stc.py
@@ -246,9 +246,9 @@ class ShapeletTransformClassifier(BaseClassifier):
         if callable(m):
             proba = self._estimator.predict_proba(X_t)
         else:
-            proba = np.zeros((X.shape[0], self.n_classes_))
+            proba = np.zeros((len(X), self.n_classes_))
             preds = self._estimator.predict(X_t)
-            for i in range(0, X.shape[0]):
+            for i in range(0, len(X)):
                 proba[i, np.where(self.classes_ == preds[i])] = 1
 
         if self.verbose:

--- a/aeon/classification/shapelet_based/tests/test_stc.py
+++ b/aeon/classification/shapelet_based/tests/test_stc.py
@@ -16,9 +16,9 @@ def test_predict_proba():
     stc = ShapeletTransformClassifier(estimator=SVC(probability=False))
     stc.fit(X, y)
     probas = stc._predict_proba(X)
-    assert np.all((probas == 0.0) | (probas == 1.0)), (
-        "Array contains values other than 0 and 1"
-    )
+    assert np.all(
+        (probas == 0.0) | (probas == 1.0)
+    ), "Array contains values other than 0 and 1"
     with pytest.raises(ValueError, match="Estimator must have a predict_proba method"):
         stc._fit_predict_proba(X, y)
     stc = ShapeletTransformClassifier(estimator=RandomForestClassifier(n_estimators=10))
@@ -31,6 +31,7 @@ def test_predict_proba_unequal_length_list():
     """Test predict_proba on unequal-length list input (gh#3447)."""
     import numpy as np
     from sklearn.svm import LinearSVC
+
     from aeon.classification.shapelet_based import ShapeletTransformClassifier
 
     X = [np.random.RandomState(i).rand(1, 8 + i) for i in range(6)]

--- a/aeon/classification/shapelet_based/tests/test_stc.py
+++ b/aeon/classification/shapelet_based/tests/test_stc.py
@@ -16,9 +16,9 @@ def test_predict_proba():
     stc = ShapeletTransformClassifier(estimator=SVC(probability=False))
     stc.fit(X, y)
     probas = stc._predict_proba(X)
-    assert np.all(
-        (probas == 0.0) | (probas == 1.0)
-    ), "Array contains values other than 0 and 1"
+    assert np.all((probas == 0.0) | (probas == 1.0)), (
+        "Array contains values other than 0 and 1"
+    )
     with pytest.raises(ValueError, match="Estimator must have a predict_proba method"):
         stc._fit_predict_proba(X, y)
     stc = ShapeletTransformClassifier(estimator=RandomForestClassifier(n_estimators=10))

--- a/aeon/classification/shapelet_based/tests/test_stc.py
+++ b/aeon/classification/shapelet_based/tests/test_stc.py
@@ -25,3 +25,18 @@ def test_predict_proba():
     y = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
     with pytest.raises(ValueError, match="All classes must have at least 2 values"):
         stc._fit_predict_proba(X, y)
+
+
+def test_predict_proba_unequal_length_list():
+    """Test predict_proba on unequal-length list input (gh#3447)."""
+    import numpy as np
+    from sklearn.svm import LinearSVC
+    from aeon.classification.shapelet_based import ShapeletTransformClassifier
+
+    X = [np.random.RandomState(i).rand(1, 8 + i) for i in range(6)]
+    y = np.array([0, 1, 0, 1, 0, 1])
+
+    clf = ShapeletTransformClassifier(estimator=LinearSVC(), random_state=0)
+    clf.fit(X, y)
+    proba = clf.predict_proba(X[:2])
+    assert proba.shape == (2, clf.n_classes_)


### PR DESCRIPTION
## Description
`ShapeletTransformClassifier.predict_proba` crashed with `AttributeError: 'list' object has no attribute 'shape'` when:
- X is a list of unequal-length series
- The underlying estimator lacks a `predict_proba` method (falling back to the `predict`-based code path)

## Root Cause
The fallback code path in `_predict_proba` used `X.shape[0]`, which is invalid for Python lists.

## Fix
Replace both `X.shape[0]` occurrences with `len(X)`, matching the same fix applied for Catch22Classifier and TSFreshClassifier in #3446.

Closes #3447

This pull request includes code written with the assistance of AI under my direction.