### PR TITLE
[BUG] remap CLARA init indices from full-dataset to sample coordinates (fixes #3423)

### DIFF
--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -167,18 +167,39 @@ class TimeSeriesCLARA(BaseClusterer):
         for _ in range(self.n_sampling_iters):
 
             if n_samples < n_cases:
-                sample_idxs = self._random_state.choice(
-                    np.arange(n_cases),
-                    size=n_samples,
-                    replace=False,
-                )
-
+                n_init_indices = len(self.init) if isinstance(self.init, np.ndarray) else 0
+                if n_init_indices > 0:
+                    init_indices = self.init
+                    n_random = n_samples - n_init_indices
+                    remaining = np.setdiff1d(np.arange(n_cases), init_indices)
+                    if n_random > 0:
+                        random_sample = self._random_state.choice(
+                            remaining, size=n_random, replace=False
+                        )
+                        sample_idxs = np.concatenate([init_indices, random_sample])
+                    else:
+                        sample_idxs = init_indices
+                    self._random_state.shuffle(sample_idxs)
+                else:
+                    sample_idxs = self._random_state.choice(
+                        np.arange(n_cases),
+                        size=n_samples,
+                        replace=False,
+                    )
             else:
                 sample_idxs = np.arange(n_cases)
 
+            # Remap init indices from full-dataset space to sample space
+            if isinstance(self.init, np.ndarray):
+                sample_init = np.array(
+                    [np.where(sample_idxs == i)[0][0] for i in self.init]
+                )
+            else:
+                sample_init = self.init
+
             pam = TimeSeriesKMedoids(
                 n_clusters=self.n_clusters,
-                init=self.init,
+                init=sample_init,
                 distance=self.distance,
                 n_init=self.n_init,
                 max_iter=self.max_iter,

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.random import RandomState
 from sklearn.utils import check_random_state
 
+from aeon.clustering._cluster_initialisation import resolve_center_initialiser
 from aeon.clustering._k_medoids import TimeSeriesKMedoids
 from aeon.clustering.base import BaseClusterer
 from aeon.distances import pairwise_distance
@@ -39,7 +40,9 @@ class TimeSeriesCLARA(BaseClusterer):
         from one another. First is the fastest method and simply chooses the
         first k time series as centroids.
         If an np.ndarray is provided it must be of shape (n_clusters,) and contain
-        the indices of the time series to use as centroids.
+        the indices of the time series to use as centroids.  The values are
+        interpreted as indices into the full dataset; when CLARA subsamples,
+        they are automatically remapped to sample-local coordinates.
     distance : str or Callable, default='msm'
         Distance method to compute similarity between time series. A list of valid
         strings for metrics can be found in the documentation for
@@ -161,17 +164,29 @@ class TimeSeriesCLARA(BaseClusterer):
         else:
             n_samples = self.n_samples
 
+        # Validate ndarray init once, before the sampling loop, using the same
+        # validation path as TimeSeriesKMedoids (out-of-range, non-integer, shape).
+        if isinstance(self.init, np.ndarray):
+            self._init = resolve_center_initialiser(
+                init=self.init,
+                X=X,
+                n_clusters=self.n_clusters,
+                random_state=self._random_state,
+                use_indexes=True,
+            )
+        else:
+            self._init = self.init
+
         best_inertia = np.inf
         best_pam = None
         best_labels = None
         for _ in range(self.n_sampling_iters):
-
             if n_samples < n_cases:
                 n_init_indices = (
-                    len(self.init) if isinstance(self.init, np.ndarray) else 0
+                    len(self._init) if isinstance(self._init, np.ndarray) else 0
                 )
                 if n_init_indices > 0:
-                    init_indices = self.init
+                    init_indices = self._init
                     n_random = n_samples - n_init_indices
                     remaining = np.setdiff1d(np.arange(n_cases), init_indices)
                     if n_random > 0:
@@ -192,12 +207,12 @@ class TimeSeriesCLARA(BaseClusterer):
                 sample_idxs = np.arange(n_cases)
 
             # Remap init indices from full-dataset space to sample space
-            if isinstance(self.init, np.ndarray):
+            if isinstance(self._init, np.ndarray):
                 sample_init = np.array(
-                    [np.where(sample_idxs == i)[0][0] for i in self.init]
+                    [np.where(sample_idxs == i)[0][0] for i in self._init]
                 )
             else:
-                sample_init = self.init
+                sample_init = self._init
 
             pam = TimeSeriesKMedoids(
                 n_clusters=self.n_clusters,

--- a/aeon/clustering/_clara.py
+++ b/aeon/clustering/_clara.py
@@ -167,7 +167,9 @@ class TimeSeriesCLARA(BaseClusterer):
         for _ in range(self.n_sampling_iters):
 
             if n_samples < n_cases:
-                n_init_indices = len(self.init) if isinstance(self.init, np.ndarray) else 0
+                n_init_indices = (
+                    len(self.init) if isinstance(self.init, np.ndarray) else 0
+                )
                 if n_init_indices > 0:
                     init_indices = self.init
                     n_random = n_samples - n_init_indices

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -1,6 +1,7 @@
 """Tests for time series k-medoids."""
 
 import numpy as np
+import pytest
 from sklearn import metrics
 
 from aeon.clustering._clara import TimeSeriesCLARA
@@ -139,3 +140,30 @@ def test_clara_init_indices_remapped():
     assert clara.labels_ is not None
     assert len(clara.labels_) == 20
     assert clara.cluster_centers_ is not None
+
+
+@pytest.mark.parametrize(
+    "init, match",
+    [
+        (np.array([-1, 0]), "Values must be in the range"),
+        (np.array([0, 30]), "Values must be in the range"),
+        (np.array([0.5, 1.0]), "Expected an array of integers"),
+    ],
+)
+def test_clara_init_ndarray_validation(init, match):
+    """Test CLARA raises ValueError for invalid ndarray init values."""
+    X = np.arange(40).reshape(20, 2, 1).astype(float)
+
+    clara = TimeSeriesCLARA(
+        n_clusters=2,
+        init=init,
+        n_samples=5,
+        n_sampling_iters=1,
+        n_init=1,
+        max_iter=1,
+        distance="euclidean",
+        random_state=1,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        clara.fit(X)

--- a/aeon/clustering/tests/test_clara.py
+++ b/aeon/clustering/tests/test_clara.py
@@ -115,3 +115,27 @@ def test_clara_samples_from_all_cases():
     clara.fit(X)
 
     assert np.max(clara.cluster_centers_) >= clara.n_samples
+
+
+def test_clara_init_indices_remapped():
+    """Test CLARA correctly remaps init indices when subsampling (issue #3423)."""
+    X = np.arange(40).reshape(20, 2, 1).astype(float)
+
+    # Use indices that would be out of bounds in a small sample
+    clara = TimeSeriesCLARA(
+        n_clusters=2,
+        init=np.array([5, 15]),
+        n_samples=4,
+        n_sampling_iters=1,
+        n_init=1,
+        max_iter=2,
+        distance="euclidean",
+        random_state=1,
+    )
+
+    clara.fit(X)
+
+    # Check that it fitted successfully and produced labels
+    assert clara.labels_ is not None
+    assert len(clara.labels_) == 20
+    assert clara.cluster_centers_ is not None


### PR DESCRIPTION
When `TimeSeriesCLARA` receives `init` as an ndarray of indices and
`n_samples < n_cases`, the indices were passed directly to
`TimeSeriesKMedoids`, which validates them against the sampled subset
`X[sample_idxs]`.  If `init` contained any index ≥ `n_samples`, the
init-validity check in PAM raised a `ValueError`.

**Fix**: when `init` is an array, reserve those indices in the sample so
they are always present, then remap them to sample-relative positions
before passing to PAM.  When `init` is a string (random, first, etc.)
the sampling behaviour is unchanged.

Closes #3423.

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.