### PR TITLE
[BUG] Fix forecasting regression test: make _LastFeatureRegressor sklearn-clone-compatible

### DIFF
--- a/aeon/forecasting/tests/test_regressor.py
+++ b/aeon/forecasting/tests/test_regressor.py
@@ -2,14 +2,22 @@
 
 import numpy as np
 import pytest
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression
 
 from aeon.forecasting import RegressionForecaster
 from aeon.regression import DummyRegressor
 
 
-class _LastFeatureRegressor:
-    """Test regressor that predicts from the final feature column."""
+class _LastFeatureRegressor(BaseEstimator):
+    """Test regressor that predicts from the final feature column.
+
+    Inherits :class:`sklearn.base.BaseEstimator` so that it satisfies
+    sklearn's ``clone()`` contract (introduced into
+    ``RegressionForecaster._fit`` by PR #3464 to prevent regressor
+    mutation). ``BaseEstimator`` provides default ``get_params`` /
+    ``set_params`` that are correct for this parameter-free class.
+    """
 
     def fit(self, X, y):
         """Fit no state and return self."""


### PR DESCRIPTION
Body:

  Three tests in aeon/forecasting/tests/test_regressor.py broke on main after #3464:

  - test_regression_forecaster_predict_uses_target_time_exog
  - test_regression_forecaster_iterative_forecast_with_exog
  - test_regression_forecaster_iterative_forecast_uses_changed_future_exog

  All three failed with:

  ▎ TypeError: Cannot clone object … it does not seem to be a scikit-learn estimator as it does not implement a 'get_params' method.

  Why it broke

  Two recent PRs are individually correct but didn't notice each other:

  - #3454 (iterative_forecast refactor) introduced a small test stub _LastFeatureRegressor with just fit and predict so the three new exog-routing tests could assert deterministic predict-from-features
  behaviour.
  - #3464 then fixed a real bug in RegressionForecaster._fit by cloning the user's regressor (self.regressor_ = _clone_estimator(self.regressor)) to prevent in-place mutation. _clone_estimator delegates to
  sklearn's clone(), which requires get_params on the estimator.

  The stub had no get_params, so clone() now rejects it and the three tests fail. The fix in #3464 is correct and stays as is — the test stub just needs to comply with the new (correct) contract.

  Fix

  Make _LastFeatureRegressor inherit from sklearn.base.BaseEstimator. That provides default get_params / set_params which are correct for this parameter-free class, and satisfies clone(). No production code
   changes.

```python
  class _LastFeatureRegressor(BaseEstimator):
      def fit(self, X, y):
          return self
      def predict(self, X):
          return X[:, -1]
```
  Tests
```python
  python -m pytest aeon/forecasting/tests/test_regressor.py -v — 8/8 pass (the three previously broken + the five that were already green).
```