### PR TITLE
[BUG] use actual shapelet transform in LearningShapeletClassifier (fixes #3380)

### DIFF
--- a/aeon/classification/shapelet_based/_ls.py
+++ b/aeon/classification/shapelet_based/_ls.py
@@ -147,7 +147,7 @@ class LearningShapeletClassifier(BaseClassifier):
         X_t = _X_transformed_tslearn(X)
         self.clf_.fit(X_t, y)
         if self.save_transformed_data:
-            self.transformed_data_ = X_t
+            self.transformed_data_ = self.clf_.transform(X_t)
 
         return self
 
@@ -181,7 +181,8 @@ class LearningShapeletClassifier(BaseClassifier):
                 "Set save_transformed_data=True in the constructor to save the "
                 "transformed data for later use"
             )
-        return self.transformed_data_
+        X_t = _X_transformed_tslearn(X)
+        return self.clf_.transform(X_t)
 
     def get_locations(self, X):
         """Compute shapelet match location for a set of time series.
@@ -205,7 +206,8 @@ class LearningShapeletClassifier(BaseClassifier):
                 "Set save_transformed_data=True in the constructor to save the "
                 "transformed data for later use"
             )
-        return self.clf_.locate(self.transformed_data_)
+        X_t = _X_transformed_tslearn(X)
+        return self.clf_.locate(X_t)
 
     @classmethod
     def _get_test_params(cls, parameter_set: str = "default") -> dict | list[dict]:


### PR DESCRIPTION
In `_fit`, `save_transformed_data=True` stored the tslearn-formatted input `X_t` instead of the actual shapelet transform. `get_transform(X)` and `get_locations(X)` both ignored their `X` argument — returning or operating on stored training data rather than transforming the given `X`.

- Store the real transform (`clf_.transform(X_t)`) in `transformed_data_`
- `get_transform(X)` now calls `clf_.transform()` on the given `X`
- `get_locations(X)` now calls `clf_.locate()` on the given `X`

Fixes #3380