### PR TITLE
[BUG] Guard EncoderClassifier missing checkpoint load

### DIFF
--- a/aeon/classification/deep_learning/_encoder.py
+++ b/aeon/classification/deep_learning/_encoder.py
@@ -287,14 +287,15 @@ class EncoderClassifier(BaseDeepClassifier):
             callbacks=self.callbacks_,
         )
 
-        try:
+        model_path = self.file_path + self.file_name_ + ".keras"
+        if os.path.exists(model_path):
             self.model_ = tf.keras.models.load_model(
-                self.file_path + self.file_name_ + ".keras",
+                model_path,
                 compile=False,
             )
             if not self.save_best_model:
-                os.remove(self.file_path + self.file_name_ + ".keras")
-        except FileNotFoundError:
+                os.remove(model_path)
+        else:
             self.model_ = deepcopy(self.training_model_)
 
         if self.save_last_model:

--- a/aeon/classification/deep_learning/tests/test_encoder.py
+++ b/aeon/classification/deep_learning/tests/test_encoder.py
@@ -43,12 +43,19 @@ def test_encoder_uses_training_model_when_checkpoint_missing(monkeypatch, tmp_pa
         def __deepcopy__(self, memo):
             return fallback_model
 
-    classifier = EncoderClassifier(
-        batch_size=2,
-        file_path=str(tmp_path) + os.sep,
-        n_epochs=1,
-        random_state=0,
-    )
+    classifier = EncoderClassifier.__new__(EncoderClassifier)
+    classifier.batch_size = 2
+    classifier.best_file_name = "best_model"
+    classifier.callbacks = None
+    classifier.file_path = str(tmp_path) + os.sep
+    classifier.init_file_name = "init_model"
+    classifier.n_classes_ = 2
+    classifier.n_epochs = 1
+    classifier.save_best_model = False
+    classifier.save_init_model = False
+    classifier.save_last_model = False
+    classifier.verbose = False
+    monkeypatch.setattr(classifier, "convert_y_to_keras", lambda y: np.eye(2)[y])
     monkeypatch.setattr(
         classifier,
         "build_model",

--- a/aeon/classification/deep_learning/tests/test_encoder.py
+++ b/aeon/classification/deep_learning/tests/test_encoder.py
@@ -1,0 +1,65 @@
+"""Tests for EncoderClassifier."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+
+from aeon.classification.deep_learning import EncoderClassifier
+
+
+def test_encoder_uses_training_model_when_checkpoint_missing(monkeypatch, tmp_path):
+    """Test EncoderClassifier handles a missing best-checkpoint file."""
+
+    class _ModelCheckpoint:
+        def __init__(self, filepath, monitor, save_best_only):
+            self.filepath = filepath
+            self.monitor = monitor
+            self.save_best_only = save_best_only
+
+    class _Models:
+        load_model_called = False
+
+        @classmethod
+        def load_model(cls, model_path, compile=False):
+            cls.load_model_called = True
+            raise AssertionError(f"load_model should not be called for {model_path}")
+
+    fake_tensorflow = SimpleNamespace(
+        keras=SimpleNamespace(
+            callbacks=SimpleNamespace(ModelCheckpoint=_ModelCheckpoint),
+            models=_Models,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "tensorflow", fake_tensorflow)
+
+    fallback_model = object()
+
+    class _TrainingModel:
+        def fit(self, X, y, batch_size, epochs, verbose, callbacks):
+            return SimpleNamespace(history={"loss": [0.0]})
+
+        def __deepcopy__(self, memo):
+            return fallback_model
+
+    classifier = EncoderClassifier(
+        batch_size=2,
+        file_path=str(tmp_path) + os.sep,
+        n_epochs=1,
+        random_state=0,
+    )
+    monkeypatch.setattr(
+        classifier,
+        "build_model",
+        lambda input_shape, n_classes: _TrainingModel(),
+    )
+
+    X = np.zeros((4, 1, 5))
+    y = np.array([0, 1, 0, 1])
+
+    fitted = classifier._fit(X, y)
+
+    assert fitted is classifier
+    assert classifier.model_ is fallback_model
+    assert not _Models.load_model_called


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3470.

#### What does this implement/fix? Explain your changes.

This updates `EncoderClassifier` so it checks whether the temporary best-checkpoint `.keras` file exists before calling `tf.keras.models.load_model`. When no checkpoint file was written, the classifier now falls back to the in-memory trained model, matching the intended fallback path without relying on Keras raising a particular missing-file exception type.

This addresses the intermittent CI failure where Keras raised `ValueError: File not found` for the temporary checkpoint path during `check_non_state_changing_method`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether the missing-checkpoint fallback should be limited to `EncoderClassifier` or generalized across other deep-learning classifiers in a follow-up.

#### Did you add any tests for the change?

Yes. Added a focused regression test that uses a fake TensorFlow module to simulate no checkpoint file being created and verifies that `load_model` is not called for the missing path.

Validation run locally:

```
uv run --extra dev python -m pytest aeon/classification/deep_learning/tests/test_encoder.py
uv run --extra dev python -m py_compile aeon/classification/deep_learning/_encoder.py aeon/classification/deep_learning/tests/test_encoder.py
uv run --extra dev pre-commit run --files aeon/classification/deep_learning/_encoder.py aeon/classification/deep_learning/tests/test_encoder.py
```