### PR TITLE
[BUG] Force ETS to fit seasonal when given period,

### DIFF
--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -429,6 +429,7 @@ class AutoETS(BaseForecaster):
         data = np.asarray(y.squeeze(), dtype=np.float64)
         if self.seasonal_period is None:
             seasonal_period = 0
+            require_seasonality = False
         elif self.seasonal_period < 1:
             raise ValueError(
                 f"seasonal_period must be a positive integer or None, "
@@ -436,10 +437,12 @@ class AutoETS(BaseForecaster):
             )
         else:
             seasonal_period = self.seasonal_period
+            require_seasonality = True
         best_model = auto_ets(
             data,
             self.allow_multiplicative_trend,
             seasonal_period,
+            require_seasonality,
         )
         self.error_type_ = int(best_model[0])
         self.trend_type_ = int(best_model[1])
@@ -501,10 +504,16 @@ class AutoETS(BaseForecaster):
 
 
 @njit(fastmath=True, cache=True)
-def auto_ets(data, allow_multiplicative_trend=False, seasonal_period=0):
+def auto_ets(
+    data,
+    allow_multiplicative_trend=False,
+    seasonal_period=0,
+    require_seasonality=False,
+):
     """Calculate model parameters based on the internal nelder-mead implementation."""
     if seasonal_period < 1:
         seasonal_period = calc_seasonal_period(data)
+        require_seasonality = False
     # Technically only needs to be 2 * seasonal periods to calculate initial conditions,
     # but makes no sense to run a seasonal model with any less than 2 seasonal periods
     # worth of usable data even that might be a bit low
@@ -517,7 +526,17 @@ def auto_ets(data, allow_multiplicative_trend=False, seasonal_period=0):
             break
     model = np.empty(4, dtype=np.int32)
     best_model = np.empty(4, dtype=np.int32)
+    best_model[0] = 1
+    best_model[1] = 0
+    best_model[2] = 0
+    best_model[3] = 1
+    best_seasonal_model = np.empty(4, dtype=np.int32)
+    best_seasonal_model[0] = 1
+    best_seasonal_model[1] = 0
+    best_seasonal_model[2] = 1
+    best_seasonal_model[3] = seasonal_period
     best_aic = np.inf
+    best_seasonal_aic = np.inf
     t_max = 3 if allow_multiplicative_trend else 2
     for error_type in range(1, 3):
         if error_type == 2 and not all_pos:
@@ -538,4 +557,9 @@ def auto_ets(data, allow_multiplicative_trend=False, seasonal_period=0):
                 if aic < best_aic:
                     best_aic = aic
                     best_model[:] = model
+                if seasonality_type != 0 and aic < best_seasonal_aic:
+                    best_seasonal_aic = aic
+                    best_seasonal_model[:] = model
+    if require_seasonality and seasonal_enabled and best_seasonal_aic < np.inf:
+        return best_seasonal_model
     return best_model

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -531,10 +531,6 @@ def auto_ets(
     best_model[2] = 0
     best_model[3] = 1
     best_seasonal_model = np.empty(4, dtype=np.int32)
-    best_seasonal_model[0] = 1
-    best_seasonal_model[1] = 0
-    best_seasonal_model[2] = 1
-    best_seasonal_model[3] = seasonal_period
     best_aic = np.inf
     best_seasonal_aic = np.inf
     t_max = 3 if allow_multiplicative_trend else 2

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -370,10 +370,10 @@ class AutoETS(BaseForecaster):
     ----------
     seasonal_period : int or None, default=None
         The seasonal period to use in automatic model selection. If ``None``,
-        the seasonal period is estimated from the data. Seasonal candidate models
-        are only considered when the series length is greater than four times the
-        selected seasonal period; otherwise AutoETS falls back to non-seasonal
-        candidates.
+        the seasonal period is estimated from the data. If an integer is supplied,
+        AutoETS selects the best seasonal model when the series length is greater
+        than four times the supplied period, even if a non-seasonal candidate has
+        a lower AIC. Otherwise, AutoETS falls back to non-seasonal candidates.
     allow_multiplicative_trend : bool, default=False
         Whether to include multiplicative trend models in the automatic model search.
 

--- a/aeon/forecasting/stats/tests/test_ets.py
+++ b/aeon/forecasting/stats/tests/test_ets.py
@@ -245,6 +245,20 @@ def test_autoets_uses_provided_seasonal_period():
     assert forecaster.wrapped_model_._seasonal_period == 4
 
 
+def test_autoets_provided_seasonal_period_overrides_nonseasonal_aic_winner():
+    """A supplied seasonal period should force a seasonal model when possible."""
+    y = np.linspace(10.0, 30.0, 80) + 0.01 * np.sin(np.arange(80))
+
+    unconstrained = AutoETS()
+    unconstrained.fit(y)
+    forced = AutoETS(seasonal_period=4)
+    forced.fit(y)
+
+    assert unconstrained.seasonality_type_ == 0
+    assert forced.seasonality_type_ != 0
+    assert forced.seasonal_period_ == 4
+
+
 def test_autoets_invalid_seasonal_period_raises():
     """AutoETS should reject invalid supplied seasonal periods."""
     forecaster = AutoETS(seasonal_period=0)


### PR DESCRIPTION
 fixes #3476

In the failing case, AutoETS(seasonal_period=4) still allowed the automatic search to return a non-seasonal model with seasonality_type_ == 0. That made the test fail here:

  assert forecaster.seasonality_type_ != 0

The intended contract of this test is: if the user explicitly supplies a valid seasonal period and the series is long enough for seasonal ETS candidates, AutoETS should use that period in a seasonal model rather than silently falling back to no seasonality.

The fix keeps the normal AIC search intact, but also tracks the best seasonal candidate separately. When seasonal_period was explicitly provided and at least one finite seasonal fit exists, AutoETS returns the best seasonal model. If the seasonal period is inferred automatically, the existing behaviour is unchanged.

This also avoids a fragile CI-dependent result where optimizer/AIC differences could make the selected model non-seasonal even for a deliberately seasonal test series.