### PR TITLE
[BUG] Skip Monster dataset loader tests during PR CI (fixes #3466)

### DIFF
--- a/aeon/datasets/tests/test_monster_loader.py
+++ b/aeon/datasets/tests/test_monster_loader.py
@@ -8,9 +8,14 @@ from aeon.datasets.monster_loader import (
     load_monster_dataset,
     load_monster_dataset_names,
 )
+from aeon.testing.testing_config import PR_TESTING
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("huggingface_hub", severity="none"),
     reason="required soft dependency huggingface-hub not available",
@@ -24,6 +29,10 @@ def test_monster_dataset_names():
     assert all(isinstance(name, str) for name in dataset_names)
 
 
+@pytest.mark.skipif(
+    PR_TESTING,
+    reason="Only run on overnights because of read from internet.",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("huggingface_hub", severity="none"),
     reason="required soft dependency huggingface-hub not available",


### PR DESCRIPTION
## Reference Issues/PRs

Fixes #3466.

## What does this implement/fix? Explain your changes.

`test_monster_dataset_names` and `test_load_monster_dataset` read dataset metadata/files from HuggingFace. In PR CI this intermittently hits HTTP 429 ("Too Many Requests"), which HuggingFace raises as `huggingface_hub.errors.HfHubHTTPError`. That type is not in `CONNECTION_ERRORS` (which holds `urllib.error.HTTPError` and friends, not the `requests`-based error HF uses), so the existing `@pytest.mark.xfail(raises=CONNECTION_ERRORS)` does not catch it and the job hard-fails instead of treating it as an expected connection problem.

Following the established pattern for the other remote-data loaders (e.g. `test_rehabpile_loader.py`, `test_tsad_datasets.py`), this gates both tests with `@pytest.mark.skipif(PR_TESTING, ...)` so they only run on the overnight builds — which is what was requested in the issue ("make this overnight test only"). The existing `huggingface_hub` soft-dependency skip and the `xfail` are kept.

Verified locally: with `--prtesting True` both tests skip with reason *"Only run on overnights because of read from internet."*; `pre-commit` (ruff/isort/black) passes.

## PR checklist

- This pull request includes code written with the assistance of AI.
