### PR TITLE
[DOC] add Examples sections to ShapeDTW distance functions

### DIFF
--- a/aeon/distances/elastic/_shape_dtw.py
+++ b/aeon/distances/elastic/_shape_dtw.py
@@ -187,6 +187,19 @@ def shape_dtw_distance(
         "ShapeDBA: Generating Effective Time Series Prototypes using ShapeDTW
         Barycenter Averaging" ECML/PKDD Workshop on Advanced Analytics and
         Learning on Temporal Data, Turin, Italy, 2023.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.distances import shape_dtw_distance
+    >>> x = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    >>> y = np.array([11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    >>> shape_dtw_distance(x, y)  # 1D series
+    1000.0
+    >>> x = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [0, 1, 0, 2, 0]])
+    >>> y = np.array([[11, 12, 13, 14], [7, 8, 9, 20], [1, 3, 4, 5]])
+    >>> shape_dtw_distance(x, y)  # 2D series with 3 channels, unequal length
+    564.0
     """
     if x.ndim == 1 and y.ndim == 1:
         _x = x.reshape((1, x.shape[0]))
@@ -348,6 +361,18 @@ def shape_dtw_cost_matrix(
     ------
     ValueError
         If x and y are not 1D or 2D arrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.distances import shape_dtw_cost_matrix
+    >>> x = np.array([[1, 2, 3, 4]])
+    >>> y = np.array([[1, 2, 3, 4]])
+    >>> shape_dtw_cost_matrix(x, y)
+    array([[ 0.,  3., 13., 32.],
+           [ 3.,  0.,  3., 13.],
+           [13.,  3.,  0.,  3.],
+           [32., 13.,  3.,  0.]])
     """
     if x.ndim == 1 and y.ndim == 1:
         _x = x.reshape((1, x.shape[0]))
@@ -483,6 +508,15 @@ def shape_dtw_alignment_path(
     ------
     ValueError
         If x and y are not 1D or 2D arrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from aeon.distances import shape_dtw_alignment_path
+    >>> x = np.array([[1, 2, 3, 6]])
+    >>> y = np.array([[1, 2, 3, 4]])
+    >>> shape_dtw_alignment_path(x, y)
+    ([(0, 0), (1, 1), (2, 2), (3, 3)], 4.0)
     """
     cost_matrix = shape_dtw_cost_matrix(
         x=x,


### PR DESCRIPTION
#### Reference Issues/PRs

Related to the ongoing effort to add `Examples` sections across the API (see #3224 for the validation utilities). This PR covers the `ShapeDTW` distance functions.

#### What does this implement/fix? Explain your changes.

The `ShapeDTW` family in `aeon/distances/elastic/_shape_dtw.py` was missing `Examples` docstring sections that every other elastic distance family already provides. Only `shape_dtw_pairwise_distance` had one.

This PR adds runnable `Examples` sections to the three remaining public functions, bringing the family in line with the rest of `aeon.distances`:

- `shape_dtw_distance` (1D and multivariate unequal-length series)
- `shape_dtw_cost_matrix`
- `shape_dtw_alignment_path`

All examples follow the existing style used by the `dtw_*` functions and were verified to run (doctests pass).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Docstring-only change; no behaviour is modified.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors. (Will use the @all-contributors bot after merge.)
- [x] The PR title starts with [DOC].
