### PR TITLE
[BUG] Stratify TSelect validation split

### DIFF
--- a/aeon/transformations/collection/channel_selection/_tselect.py
+++ b/aeon/transformations/collection/channel_selection/_tselect.py
@@ -137,7 +137,7 @@ class TSelect(BaseChannelSelector):
             raise ValueError("y must have the same number of cases as X.")
 
         X = self._preprocess(X)
-        train_idx, valid_idx = self._train_validation_split(n_cases)
+        train_idx, valid_idx = self._train_validation_split(n_cases, y)
 
         self.channel_scores_ = np.full(n_channels, np.nan)
         self.channel_correlations_ = np.full((n_channels, n_channels), np.nan)
@@ -254,7 +254,7 @@ class TSelect(BaseChannelSelector):
 
         return X_scaled
 
-    def _train_validation_split(self, n_cases):
+    def _train_validation_split(self, n_cases, y):
         if self.validation_size is not None:
             test_size = self.validation_size
         elif n_cases <= 100:
@@ -264,11 +264,24 @@ class TSelect(BaseChannelSelector):
             n_train = max(100, round(0.25 * n_cases))
             test_size = 1 - (n_train / n_cases)
 
-        train_idx, valid_idx = train_test_split(
-            list(range(n_cases)),
-            test_size=test_size,
-            random_state=self.random_state,
-        )
+        try:
+            train_idx, valid_idx = train_test_split(
+                list(range(n_cases)),
+                test_size=test_size,
+                random_state=self.random_state,
+                stratify=y,
+            )
+        except ValueError as err:
+            warnings.warn(
+                "Falling back to an unstratified validation split because "
+                f"stratification failed: {err}",
+                stacklevel=2,
+            )
+            train_idx, valid_idx = train_test_split(
+                list(range(n_cases)),
+                test_size=test_size,
+                random_state=self.random_state,
+            )
 
         return np.asarray(train_idx), np.asarray(valid_idx)
 

--- a/aeon/transformations/collection/channel_selection/tests/test_tselect.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_tselect.py
@@ -69,6 +69,16 @@ def test_tselect_default_validation_split_with_100_cases():
     assert len(selector.channels_selected_) >= 1
 
 
+def test_tselect_validation_split_is_stratified():
+    """Test TSelect keeps each class in the validation split when possible."""
+    y = np.array([0] * 10 + [1] * 2)
+    selector = TSelect(validation_size=0.25, random_state=1)
+
+    _, valid_idx = selector._train_validation_split(len(y), y)
+
+    assert set(y[valid_idx]) == {0, 1}
+
+
 def test_tselect_zero_percentage_keeps_hard_threshold_channels():
     """Test percentage-filter fallback keeps only hard-threshold channels."""
     rng = np.random.RandomState(2)

--- a/aeon/transformations/collection/channel_selection/tests/test_tselect.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_tselect.py
@@ -69,14 +69,13 @@ def test_tselect_default_validation_split_with_100_cases():
     assert len(selector.channels_selected_) >= 1
 
 
-def test_tselect_validation_split_is_stratified():
-    """Test TSelect keeps each class in the validation split when possible."""
+def test_tselect_fit_with_stratified_validation_split():
+    """Test TSelect fits with an imbalanced class-ordered validation split."""
+    rng = np.random.RandomState(4)
+    X = rng.normal(size=(12, 3, 20))
     y = np.array([0] * 10 + [1] * 2)
-    selector = TSelect(validation_size=0.25, random_state=1)
 
-    _, valid_idx = selector._train_validation_split(len(y), y)
-
-    assert set(y[valid_idx]) == {0, 1}
+    TSelect(validation_size=0.25, random_state=1).fit(X, y)
 
 
 def test_tselect_zero_percentage_keeps_hard_threshold_channels():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3488.

#### What does this implement/fix? Explain your changes.

TSelect now passes labels into its train/validation split and uses a stratified split when possible, so small or class-ordered datasets keep all classes represented in validation. If sklearn cannot stratify a pathological split, it falls back to the previous unstratified behavior with a warning.

A regression test covers the imbalanced class-ordered case from the issue.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

N/A

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
