### PR TITLE
[BUG] Respect requested distance in elbow class selector

### DIFF
--- a/aeon/transformations/collection/channel_selection/_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/_elbow_class.py
@@ -87,7 +87,7 @@ def _create_distance_matrix(
                     lambda row: aeon_distance(
                         row[: row.shape[0] // 2],
                         row[row.shape[0] // 2 :],
-                        method="dtw",
+                        method=distance,
                     ),
                     axis=1,
                     arr=np.concatenate((cls1_ch, cls2_ch), axis=1),

--- a/aeon/transformations/collection/channel_selection/tests/test_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_elbow_class.py
@@ -31,6 +31,21 @@ def test_create_distance_matrix():
     assert res.shape == (1, 1)
 
 
+def test_create_distance_matrix_uses_requested_distance():
+    """Test distance matrix uses the requested non-Euclidean distance."""
+    X = np.array(
+        [
+            [[0, 0, 0], [1, 2, 3]],
+            [[0, 1, 2], [1, 3, 5]],
+        ]
+    )
+
+    dtw_res = _create_distance_matrix(X, np.array([0, 1]), distance="dtw")
+    manhattan_res = _create_distance_matrix(X, np.array([0, 1]), distance="manhattan")
+
+    assert not np.array_equal(dtw_res.to_numpy(), manhattan_res.to_numpy())
+
+
 def test_prototype():
     """Test function in _ClassPrototype."""
     p = _ClassPrototype()

--- a/aeon/transformations/collection/channel_selection/tests/test_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_elbow_class.py
@@ -46,6 +46,14 @@ def test_create_distance_matrix_uses_requested_distance():
     assert not np.array_equal(dtw_res.to_numpy(), manhattan_res.to_numpy())
 
 
+def test_create_distance_matrix_rejects_invalid_distance():
+    """Test invalid distance strings are rejected."""
+    X = np.array([[[1, 2, 3]], [[1, 2, 3]]])
+
+    with pytest.raises(ValueError):
+        _create_distance_matrix(X, np.array([0, 1]), distance="not_a_distance")
+
+
 def test_prototype():
     """Test function in _ClassPrototype."""
     p = _ClassPrototype()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3489.

#### What does this implement/fix? Explain your changes.

`_create_distance_matrix` now passes the requested non-Euclidean distance method through to `aeon.distances.distance` instead of always using `dtw`. Added a regression test that verifies different requested distances produce different distance matrices.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

N/A.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, I can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] N/A - no new estimator/function was added to the online API documentation.
- [ ] N/A - this is a minor bug fix, so I have not added myself as a maintainer.

##### For developers with write access
- [ ] N/A - I do not have write access and did not update CODEOWNERS.
