### PR TITLE
[BUG] Fix ESMOTE sample generation

### DIFF
--- a/aeon/transformations/collection/imbalance/_esmote.py
+++ b/aeon/transformations/collection/imbalance/_esmote.py
@@ -155,6 +155,8 @@ class ESMOTE(BaseCollectionTransformer):
                 nn_ts,
                 distance=self.distance,
                 step=steps[count],
+                return_bias=False,
+                **self._distance_params,
             )
 
         y_new = np.full(n_samples, fill_value=y_type, dtype=y_dtype)
@@ -179,7 +181,7 @@ class ESMOTE(BaseCollectionTransformer):
         transformation_precomputed: bool = False,
         transformed_x: np.ndarray | None = None,
         transformed_y: np.ndarray | None = None,
-        return_bias=True,
+        return_bias=False,
     ):
         """
         Generate a single synthetic sample using soft distance.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/latest/contributing.html.

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
If you are a new contributor, do not delete this template without a suitable
replacement or reason. If in doubt, ask for help. We're here to help!

Please be aware that we are a team of volunteers so patience is
necessary when waiting for a review or reply. There may not be a quick turnaround for
reviews during slow periods. While we value all contributions big or small, pull
requests which do not follow our guidelines may be closed.
-->

#### Reference Issues/PRs

Fixes #3498 
Fixes #3502 

#### What does this implement/fix? Explain your changes.



This PR fixes two issues in `ESMOTE` sample generation.
First, `_make_samples` now explicitly requests a generated synthetic time series
from `_generate_sample_use_elastic_distance` rather than receiving the alignment
bias. The default value of `return_bias` is also changed to `False`, matching
the method name and normal sample-generation behaviour.
Second, `distance_params` are now passed from `_make_samples` into
`_generate_sample_use_elastic_distance`, so the parameters used for
nearest-neighbour search are also used when computing the elastic alignment path
during sample generation.


