### PR TITLE
[BUG] OHIT: seed sample generation and stop mutating k/kapa

### DIFF
--- a/aeon/transformations/collection/imbalance/_ohit.py
+++ b/aeon/transformations/collection/imbalance/_ohit.py
@@ -123,16 +123,15 @@ class OHIT(BaseCollectionTransformer):
                 continue
             X_class = X[target_class_indices]
             n, m = X_class.shape
-            # set the default value of k and kapa
-            if self.k is None:
-                self.k = int(np.ceil(n**0.5 * 1.25))
-            if self.kapa is None:
-                self.kapa = int(np.ceil(n**0.5))
+            # set the default value of k and kapa without mutating the
+            # constructor parameters (sklearn convention)
+            k = self.k if self.k is not None else int(np.ceil(n**0.5 * 1.25))
+            kapa = self.kapa if self.kapa is not None else int(np.ceil(n**0.5))
 
             # Initialize NearestNeighbors for SNN similarity
-            self.nn_ = NearestNeighbors(metric=self.distance, n_neighbors=self.k + 1)
+            self.nn_ = NearestNeighbors(metric=self.distance, n_neighbors=k + 1)
 
-            clusters, cluster_label = self._cluster_minority(X_class)
+            clusters, cluster_label = self._cluster_minority(X_class, k, kapa)
             Me, eigen_matrices, eigen_values = self._covStruct(X_class, clusters)
 
             # allocate the number of synthetic samples to be generated for each cluster
@@ -158,7 +157,7 @@ class OHIT(BaseCollectionTransformer):
             for i, _ in enumerate(clusters):
                 gen_i = np.sum(np.isin(os_ind, np.where(cluster_label == (i + 1))[0]))
                 X_new[count : count + gen_i, :] = self._generate_synthetic_samples(
-                    Me[i], eigen_matrices[i], eigen_values[i], gen_i, R
+                    Me[i], eigen_matrices[i], eigen_values[i], gen_i, R, random_state
                 )
                 count += gen_i
 
@@ -172,11 +171,9 @@ class OHIT(BaseCollectionTransformer):
         X_resampled = X_resampled[:, np.newaxis, :]
         return X_resampled, y_resampled
 
-    def _cluster_minority(self, X):
+    def _cluster_minority(self, X, k, kapa):
         """Apply DRSNN clustering on minority class samples."""
         n = X.shape[0]
-        k = self.k
-        kapa = self.kapa
         drT = self.drT
 
         self.nn_.fit(X)
@@ -256,7 +253,9 @@ class OHIT(BaseCollectionTransformer):
             Eigen_values.append(eigenValues)
         return Me, Eigen_matrices, Eigen_values
 
-    def _generate_synthetic_samples(self, Me, eigenMatrix, eigenValue, eta, R):
+    def _generate_synthetic_samples(
+        self, Me, eigenMatrix, eigenValue, eta, R, random_state
+    ):
         """Generate synthetic samples based on clustered minority samples."""
         # Initialize the output sample generator and probability arrays
         n_samples = int(np.ceil(eta * R))
@@ -273,7 +272,7 @@ class OHIT(BaseCollectionTransformer):
 
         for cnt in range(n_samples):
             # Generate a sample from the multivariate normal distribution
-            S = np.random.multivariate_normal(Mu, Sigma, 1)
+            S = random_state.multivariate_normal(Mu, Sigma, 1)
             Prob[cnt] = multivariate_normal.pdf(S, Mu, Sigma)
 
             # Scale the sample with the eigenvalues

--- a/aeon/transformations/collection/imbalance/tests/test_ohit.py
+++ b/aeon/transformations/collection/imbalance/tests/test_ohit.py
@@ -28,3 +28,26 @@ def test_ohit():
     assert len(res_y) == 2 * majority_num
     assert res_count[0] == majority_num
     assert res_count[1] == majority_num
+
+
+def test_ohit_random_state_reproducible():
+    """Same random_state gives identical output."""
+    X = np.random.RandomState(0).rand(100, 1, 10)
+    y = np.array([0] * 90 + [1] * 10)
+
+    res1 = OHIT(random_state=49).fit_transform(X, y)[0]
+    res2 = OHIT(random_state=49).fit_transform(X, y)[0]
+
+    assert np.array_equal(res1, res2)
+
+
+def test_ohit_does_not_mutate_params():
+    """fit_transform leaves k and kapa as set in the constructor."""
+    X = np.random.RandomState(0).rand(100, 1, 10)
+    y = np.array([0] * 90 + [1] * 10)
+
+    transformer = OHIT(random_state=49)
+    transformer.fit_transform(X, y)
+
+    assert transformer.get_params()["k"] is None
+    assert transformer.get_params()["kapa"] is None


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3501. Fixes #3499.

#### What does this implement/fix? Explain your changes.

Two related correctness issues in `OHIT`:

- `_generate_synthetic_samples` drew from the global `np.random` instead of the seeded generator built in `_transform`, so output was non-deterministic even with a fixed `random_state`. It now uses the passed-in `check_random_state` generator.
- `_transform` wrote the computed defaults back to `self.k` / `self.kapa` when they were `None`, which mutates the constructor parameters, corrupts `get_params()`, and leaks the first dataset's values into later `fit_transform` calls (a reused instance could then raise on a smaller minority class). The defaults are now computed into locals and passed down, leaving the parameters untouched.

Added regression tests for both: same-seed reproducibility and that `k`/`kapa` stay as set in the constructor.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
