### PR TITLE
[BUG] fix(unequal_length): validate integer target lengths reject bool and non-positive values

### DIFF
--- a/aeon/transformations/collection/unequal_length/_commons.py
+++ b/aeon/transformations/collection/unequal_length/_commons.py
@@ -4,7 +4,22 @@ These should ideally be incorporated into the collection data utilities in utils
 the future.
 """
 
+import numbers
+
 import numpy as np
+
+
+def _is_positive_integer_length(value):
+    return isinstance(value, numbers.Integral) and not isinstance(value, bool)
+
+
+def _validate_positive_integer_length(value, parameter_name):
+    """Validate an integer target length parameter."""
+    msg = f"{parameter_name} must be a positive integer, 'min' or 'max'."
+    if isinstance(value, bool):
+        raise ValueError(msg)
+    if isinstance(value, numbers.Integral) and value < 1:
+        raise ValueError(msg)
 
 
 def _get_min_length(X):

--- a/aeon/transformations/collection/unequal_length/_commons.py
+++ b/aeon/transformations/collection/unequal_length/_commons.py
@@ -10,7 +10,12 @@ import numpy as np
 
 
 def _is_positive_integer_length(value):
-    return isinstance(value, numbers.Integral) and not isinstance(value, bool)
+    """Return whether value is a positive non-bool integer length."""
+    return (
+        isinstance(value, numbers.Integral)
+        and not isinstance(value, bool)
+        and value >= 1
+    )
 
 
 def _validate_positive_integer_length(value, parameter_name):

--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -10,6 +10,8 @@ from aeon.transformations.collection.base import BaseCollectionTransformer
 from aeon.transformations.collection.unequal_length._commons import (
     _get_max_length,
     _get_min_length,
+    _is_positive_integer_length,
+    _validate_positive_integer_length,
 )
 
 
@@ -75,6 +77,8 @@ class Padder(BaseCollectionTransformer):
         error_on_long=True,
         random_state=None,
     ):
+        _validate_positive_integer_length(padded_length, "padded_length")
+
         self.padded_length = padded_length
         self.fill_value = fill_value
         self.add_noise = add_noise
@@ -85,7 +89,7 @@ class Padder(BaseCollectionTransformer):
 
         self.set_tags(
             **{
-                "fit_is_empty": isinstance(padded_length, int),
+                "fit_is_empty": _is_positive_integer_length(padded_length),
                 "removes_unequal_length": error_on_long,
             }
         )
@@ -133,7 +137,7 @@ class Padder(BaseCollectionTransformer):
         # Must call fit if pad_length is None
         pad_length = (
             self.padded_length
-            if isinstance(self.padded_length, int)
+            if _is_positive_integer_length(self.padded_length)
             else self._padded_length
         )
 

--- a/aeon/transformations/collection/unequal_length/_resize.py
+++ b/aeon/transformations/collection/unequal_length/_resize.py
@@ -9,6 +9,8 @@ from aeon.transformations.collection.base import BaseCollectionTransformer
 from aeon.transformations.collection.unequal_length._commons import (
     _get_max_length,
     _get_min_length,
+    _is_positive_integer_length,
+    _validate_positive_integer_length,
 )
 
 
@@ -47,11 +49,13 @@ class Resizer(BaseCollectionTransformer):
     }
 
     def __init__(self, resized_length="max"):
+        _validate_positive_integer_length(resized_length, "resized_length")
+
         self.resized_length = resized_length
 
         super().__init__()
 
-        self.set_tags(**{"fit_is_empty": isinstance(resized_length, int)})
+        self.set_tags(**{"fit_is_empty": _is_positive_integer_length(resized_length)})
 
     def _fit(self, X, y=None):
         if self.resized_length == "min":
@@ -77,7 +81,7 @@ class Resizer(BaseCollectionTransformer):
         """
         length = (
             self.resized_length
-            if isinstance(self.resized_length, int)
+            if _is_positive_integer_length(self.resized_length)
             else self._resized_length
         )
 

--- a/aeon/transformations/collection/unequal_length/_truncate.py
+++ b/aeon/transformations/collection/unequal_length/_truncate.py
@@ -9,6 +9,8 @@ from aeon.transformations.collection.base import BaseCollectionTransformer
 from aeon.transformations.collection.unequal_length._commons import (
     _get_max_length,
     _get_min_length,
+    _is_positive_integer_length,
+    _validate_positive_integer_length,
 )
 
 
@@ -51,6 +53,8 @@ class Truncator(BaseCollectionTransformer):
     }
 
     def __init__(self, truncated_length="min", error_on_short=True):
+        _validate_positive_integer_length(truncated_length, "truncated_length")
+
         self.truncated_length = truncated_length
         self.error_on_short = error_on_short
 
@@ -58,7 +62,7 @@ class Truncator(BaseCollectionTransformer):
 
         self.set_tags(
             **{
-                "fit_is_empty": isinstance(truncated_length, int),
+                "fit_is_empty": _is_positive_integer_length(truncated_length),
                 "removes_unequal_length": error_on_short,
             }
         )
@@ -102,7 +106,7 @@ class Truncator(BaseCollectionTransformer):
         # Must call fit unless truncated_length is an int
         truncated_length = (
             self.truncated_length
-            if isinstance(self.truncated_length, int)
+            if _is_positive_integer_length(self.truncated_length)
             else self._truncated_length
         )
 

--- a/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
@@ -1,5 +1,6 @@
 """Test unequal length transformer target length validation."""
 
+import numpy as np
 import pytest
 
 from aeon.transformations.collection.unequal_length import Padder, Resizer, Truncator
@@ -29,12 +30,15 @@ def test_integer_length_parameters_must_be_positive_non_bool(
     ("transformer", "parameter_name", "valid_length"),
     [
         (Padder, "padded_length", 1),
+        (Padder, "padded_length", np.int64(1)),
         (Padder, "padded_length", "min"),
         (Padder, "padded_length", "max"),
         (Resizer, "resized_length", 1),
+        (Resizer, "resized_length", np.int64(1)),
         (Resizer, "resized_length", "min"),
         (Resizer, "resized_length", "max"),
         (Truncator, "truncated_length", 1),
+        (Truncator, "truncated_length", np.int64(1)),
         (Truncator, "truncated_length", "min"),
         (Truncator, "truncated_length", "max"),
     ],

--- a/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
@@ -1,0 +1,44 @@
+"""Test unequal length transformer target length validation."""
+
+import pytest
+
+from aeon.transformations.collection.unequal_length import Padder, Resizer, Truncator
+
+
+@pytest.mark.parametrize(
+    ("transformer", "parameter_name"),
+    [
+        (Padder, "padded_length"),
+        (Resizer, "resized_length"),
+        (Truncator, "truncated_length"),
+    ],
+)
+@pytest.mark.parametrize("invalid_length", [False, True, 0, -1])
+def test_integer_length_parameters_must_be_positive_non_bool(
+    transformer, parameter_name, invalid_length
+):
+    """Test integer target length parameters reject bool and non-positive values."""
+    with pytest.raises(
+        ValueError,
+        match=f"{parameter_name} must be a positive integer",
+    ):
+        transformer(**{parameter_name: invalid_length})
+
+
+@pytest.mark.parametrize(
+    ("transformer", "parameter_name", "valid_length"),
+    [
+        (Padder, "padded_length", 1),
+        (Padder, "padded_length", "min"),
+        (Padder, "padded_length", "max"),
+        (Resizer, "resized_length", 1),
+        (Resizer, "resized_length", "min"),
+        (Resizer, "resized_length", "max"),
+        (Truncator, "truncated_length", 1),
+        (Truncator, "truncated_length", "min"),
+        (Truncator, "truncated_length", "max"),
+    ],
+)
+def test_valid_length_parameters(transformer, parameter_name, valid_length):
+    """Test valid target length parameters are accepted."""
+    transformer(**{parameter_name: valid_length})


### PR DESCRIPTION
Fixes #3497.

Padder, Resizer, and Truncator accept integer length parameters (padded_length, resized_length, truncated_length) without validating they are positive integers. Python bool is a subclass of int, so True/False are silently accepted. Zero and negative integers are also accepted, producing silent wrong output or opaque errors.

Changes

- Added shared validation in aeon/transformations/collection/unequal_length/_commons.py: _is_positive_integer_length (bool-safe Integral check) and _validate_positive_integer_length (raises ValueError on bool or int < 1).
- Wired _validate_positive_integer_length into Padder.__init__, Resizer.__init__, and Truncator.__init__.
- Replaced isinstance(..., int) length detection in set_tags and transform paths with the bool-safe _is_positive_integer_length predicate.
- Added tests/test_length_validation.py covering invalid (True, False, 0, -1) and valid (1, 'min', 'max') cases for all three transformers.

Verification

- pytest aeon/transformations/collection/unequal_length/tests/ -> 53 passed
- ruff check aeon/transformations/collection/unequal_length/ -> passed

This pull request includes code written with the assistance of AI. The code has not yet been reviewed by a human.