### PR TITLE
[DOC] Fix imbalance transformer docstrings

### DIFF
--- a/aeon/transformations/collection/imbalance/__init__.py
+++ b/aeon/transformations/collection/imbalance/__init__.py
@@ -1,4 +1,4 @@
-"""Supervised transformers to rebalance colelctions of time series."""
+"""Supervised transformers to rebalance collections of time series."""
 
 __all__ = ["ADASYN", "SMOTE", "OHIT", "ESMOTE"]
 

--- a/aeon/transformations/collection/imbalance/_adasyn.py
+++ b/aeon/transformations/collection/imbalance/_adasyn.py
@@ -34,10 +34,18 @@ class ADASYN(SMOTE):
 
     Parameters
     ----------
-        random_state : int or None, optional (default=None)
-            Random seed for reproducibility.
-        n_neighbors : int, optional (default=5)
-            Number of nearest neighbours used to construct synthetic samples.
+    n_neighbors : int, default=5
+        Number of nearest neighbours used to construct synthetic samples.
+    random_state : int, RandomState instance or None, default=None
+        Controls random number generation for reproducibility.
+    distance : str or callable, default="euclidean"
+        Distance metric used for nearest-neighbour search.
+    distance_params : dict or None, default=None
+        Additional keyword arguments for the distance metric.
+    n_jobs : int, default=1
+        Number of jobs to run in parallel for nearest-neighbour search.
+    weights : str or callable, default="uniform"
+        Weight function used in prediction by the nearest-neighbour estimator.
 
     References
     ----------

--- a/aeon/transformations/collection/imbalance/_esmote.py
+++ b/aeon/transformations/collection/imbalance/_esmote.py
@@ -27,10 +27,14 @@ class ESMOTE(BaseCollectionTransformer):
     distance : str or callable, default="twe"
         The distance metric to use for the nearest neighbors search and alignment path
         of synthetic time series.
+    distance_params : dict or None, default=None
+        Additional keyword arguments for the distance metric.
     weights : str or callable, default = 'uniform'
         Mechanism for weighting a vote one of: ``'uniform'``, ``'distance'``,
         or a callable
         function.
+    n_jobs : int, default=1
+        Number of jobs to run in parallel for nearest-neighbour search.
     random_state : int, RandomState instance or None, default=None
         If `int`, random_state is the seed used by the random number generator;
         If `RandomState` instance, random_state is the random number generator;
@@ -186,9 +190,8 @@ class ESMOTE(BaseCollectionTransformer):
         """
         Generate a single synthetic sample using soft distance.
 
-        This is use soft distance to align the current time series with its nearest
-        neighbor, and then generate a synthetic sample by subtracting the aligned
-        nearest neighbor from the current time series.
+        This uses an elastic distance to align the current time series with its nearest
+        neighbor, then generates a synthetic sample from their aligned difference.
 
         # shape: (c, l) or (l)
         # shape: (c, l) or (l)

--- a/aeon/transformations/collection/imbalance/_ohit.py
+++ b/aeon/transformations/collection/imbalance/_ohit.py
@@ -28,7 +28,8 @@ class OHIT(BaseCollectionTransformer):
     Nearest Neighbor (DRSNN) clustering algorithm. It identifies high-density regions
     among the minority class using DRSNN, then produces synthetic samples within
     these clusters. Covariance estimation for high-dimensional data is performed using
-    shrinkage techniques.
+    shrinkage techniques. The current implementation supports univariate time series
+    only.
 
     The DRSNN procedure involves three main parameters:
     - `drT`: the density ratio threshold (typically set around 1).

--- a/aeon/transformations/collection/imbalance/_smote.py
+++ b/aeon/transformations/collection/imbalance/_smote.py
@@ -25,7 +25,7 @@ from aeon.utils.validation import check_n_jobs
 
 class SMOTE(BaseCollectionTransformer):
     """
-    Synthetic Minority Over-sampling TEchnique (SMOTE) for imbalanced datasets.
+    Synthetic Minority Over-sampling Technique (SMOTE) for imbalanced datasets.
 
     Generates synthetic samples of the minority class to address class imbalance.
     SMOTE constructs new samples by interpolating between existing minority samples
@@ -39,7 +39,8 @@ class SMOTE(BaseCollectionTransformer):
     ----------
     n_neighbors : int, default=5
         Number of nearest neighbours used to generate synthetic samples. A
-        `sklearn.neighbors.NearestNeighbors` instance is fitted for this purpose.
+        `_SingleClassKNN` wrapper around `KNeighborsTimeSeriesClassifier` is fitted
+        for this purpose.
     random_state : int, RandomState instance or None, default=None
         Controls the random number generation for reproducibility:
         - If `int`, sets the random seed.
@@ -213,7 +214,7 @@ class SMOTE(BaseCollectionTransformer):
 
         .. math::
            \mathbf{s_{s}} = \mathbf{s_{i}} + \mathcal{u}(0, 1) \times
-           (\mathbf{s_{i}} - \mathbf{s_{nn}}) \,
+           (\mathbf{s_{nn}} - \mathbf{s_{i}}) \,
 
         where \mathbf{s_{s}} is the new synthetic samples, \mathbf{s_{i}} is
         the current sample, \mathbf{s_{nn}} is a randomly selected neighbors of
@@ -266,10 +267,6 @@ class SMOTE(BaseCollectionTransformer):
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return `"default"` set.
-            ClassifierChannelEnsemble provides the following special sets:
-            - "results_comparison" - used in some classifiers to compare against
-              previously generated results where the default set of parameters
-              cannot produce suitable probability estimates
 
         Returns
         -------


### PR DESCRIPTION
Fixes #3503.

Corrects typos and stale docstrings across the imbalance transformers. The update documents the actual SMOTE neighbour implementation and sample formula, completes ADASYN and ESMOTE parameter descriptions, and clarifies that OHIT currently supports univariate time series only.

All repository pre-commit hooks pass on the changed files.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
