### PR TITLE
[BUG] Fix OHIT random state handling

### DIFF
--- a/aeon/transformations/collection/imbalance/_ohit.py
+++ b/aeon/transformations/collection/imbalance/_ohit.py
@@ -103,6 +103,7 @@ class OHIT(BaseCollectionTransformer):
             if key != class_majority
         }
         self.sampling_strategy_ = OrderedDict(sorted(sampling_strategy.items()))
+        self.random_state_ = check_random_state(self.random_state)
 
         return self
 
@@ -124,19 +125,17 @@ class OHIT(BaseCollectionTransformer):
             X_class = X[target_class_indices]
             n, m = X_class.shape
             # set the default value of k and kapa
-            if self.k is None:
-                self.k = int(np.ceil(n**0.5 * 1.25))
-            if self.kapa is None:
-                self.kapa = int(np.ceil(n**0.5))
+            k = self.k if self.k is not None else int(np.ceil(n**0.5 * 1.25))
+            kapa = self.kapa if self.kapa is not None else int(np.ceil(n**0.5))
 
             # Initialize NearestNeighbors for SNN similarity
-            self.nn_ = NearestNeighbors(metric=self.distance, n_neighbors=self.k + 1)
+            self.nn_ = NearestNeighbors(metric=self.distance, n_neighbors=k + 1)
 
-            clusters, cluster_label = self._cluster_minority(X_class)
+            clusters, cluster_label = self._cluster_minority(X_class, k, kapa)
             Me, eigen_matrices, eigen_values = self._covStruct(X_class, clusters)
 
             # allocate the number of synthetic samples to be generated for each cluster
-            random_state = check_random_state(self.random_state)
+            random_state = self.random_state_
             os_ind = np.tile(np.arange(0, n), int(np.floor(n_samples / n)))
             remaining = random_state.choice(
                 np.arange(0, n),
@@ -158,7 +157,7 @@ class OHIT(BaseCollectionTransformer):
             for i, _ in enumerate(clusters):
                 gen_i = np.sum(np.isin(os_ind, np.where(cluster_label == (i + 1))[0]))
                 X_new[count : count + gen_i, :] = self._generate_synthetic_samples(
-                    Me[i], eigen_matrices[i], eigen_values[i], gen_i, R
+                    Me[i], eigen_matrices[i], eigen_values[i], gen_i, R, random_state
                 )
                 count += gen_i
 
@@ -172,11 +171,9 @@ class OHIT(BaseCollectionTransformer):
         X_resampled = X_resampled[:, np.newaxis, :]
         return X_resampled, y_resampled
 
-    def _cluster_minority(self, X):
+    def _cluster_minority(self, X, k, kapa):
         """Apply DRSNN clustering on minority class samples."""
         n = X.shape[0]
-        k = self.k
-        kapa = self.kapa
         drT = self.drT
 
         self.nn_.fit(X)
@@ -256,7 +253,7 @@ class OHIT(BaseCollectionTransformer):
             Eigen_values.append(eigenValues)
         return Me, Eigen_matrices, Eigen_values
 
-    def _generate_synthetic_samples(self, Me, eigenMatrix, eigenValue, eta, R):
+    def _generate_synthetic_samples(self, Me, eigenMatrix, eigenValue, eta, R, rng):
         """Generate synthetic samples based on clustered minority samples."""
         # Initialize the output sample generator and probability arrays
         n_samples = int(np.ceil(eta * R))
@@ -273,7 +270,7 @@ class OHIT(BaseCollectionTransformer):
 
         for cnt in range(n_samples):
             # Generate a sample from the multivariate normal distribution
-            S = np.random.multivariate_normal(Mu, Sigma, 1)
+            S = rng.multivariate_normal(Mu, Sigma, 1)
             Prob[cnt] = multivariate_normal.pdf(S, Mu, Sigma)
 
             # Scale the sample with the eigenvalues

--- a/aeon/transformations/collection/imbalance/tests/test_ohit.py
+++ b/aeon/transformations/collection/imbalance/tests/test_ohit.py
@@ -5,6 +5,13 @@ import numpy as np
 from aeon.transformations.collection.imbalance import OHIT
 
 
+def _make_imbalanced_data(n_samples=100, majority_num=90, random_state=0):
+    rng = np.random.RandomState(random_state)
+    X = rng.rand(n_samples, 1, 10)
+    y = np.array([0] * majority_num + [1] * (n_samples - majority_num))
+    return X, y
+
+
 def test_ohit():
     """Test the OHIT class.
 
@@ -14,10 +21,8 @@ def test_ohit():
     """
     n_samples = 100  # Total number of labels
     majority_num = 90  # number of majority class
-    minority_num = n_samples - majority_num  # number of minority class
 
-    X = np.random.rand(n_samples, 1, 10)
-    y = np.array([0] * majority_num + [1] * minority_num)
+    X, y = _make_imbalanced_data(n_samples, majority_num)
 
     transformer = OHIT()
     transformer.fit(X, y)
@@ -28,3 +33,31 @@ def test_ohit():
     assert len(res_y) == 2 * majority_num
     assert res_count[0] == majority_num
     assert res_count[1] == majority_num
+
+
+def test_ohit_random_state_is_reproducible():
+    """Test OHIT returns the same samples for the same random state."""
+    X, y = _make_imbalanced_data()
+
+    res_X1, res_y1 = OHIT(random_state=49).fit_transform(X, y)
+    res_X2, res_y2 = OHIT(random_state=49).fit_transform(X, y)
+
+    np.testing.assert_array_equal(res_X1, res_X2)
+    np.testing.assert_array_equal(res_y1, res_y2)
+
+
+def test_ohit_default_k_and_kapa_do_not_mutate_params():
+    """Test fitted defaults do not overwrite constructor parameters."""
+    X_large, y_large = _make_imbalanced_data()
+    X_small, y_small = _make_imbalanced_data(n_samples=20, majority_num=16)
+    transformer = OHIT(random_state=49)
+
+    transformer.fit_transform(X_large, y_large)
+
+    assert transformer.get_params()["k"] is None
+    assert transformer.get_params()["kapa"] is None
+
+    transformer.fit_transform(X_small, y_small)
+
+    assert transformer.get_params()["k"] is None
+    assert transformer.get_params()["kapa"] is None


### PR DESCRIPTION
Closes #3501.
Closes #3499.

This fixes two OHIT state handling issues:

- build the fitted random state once during `fit` and pass it through synthetic sample generation instead of using the global `np.random` generator
- compute default `k`/`kapa` values as local fitted values instead of writing them back to constructor parameters

The added tests cover same-seed reproducibility and verify that default `k`/`kapa` do not mutate `get_params()` across fits.

Testing:

- `uv run pytest aeon/transformations/collection/imbalance/tests/test_ohit.py -q` initially could not run because the default pytest config requires plugins not installed in the minimal uv environment
- `uv run --with pytest-xdist --with pytest-rerunfailures --with pytest-timeout pytest aeon/transformations/collection/imbalance/tests/test_ohit.py -q`
- `uv run ruff check aeon/transformations/collection/imbalance/_ohit.py aeon/transformations/collection/imbalance/tests/test_ohit.py`
- `uv run ruff format --check aeon/transformations/collection/imbalance/_ohit.py aeon/transformations/collection/imbalance/tests/test_ohit.py`
- `git diff --check`

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.