### PR TITLE
[BUG] Validate Padder fill_value inputs

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -26,10 +26,9 @@ class Padder(BaseCollectionTransformer):
         shortest series seen in ``fit``. If "max", will pad to the longest series seen
         in ``fit``. If an integer, will pad to that length.
         Calling ``fit`` is not required if ``padded_length`` is an int.
-    fill_value : int, str or Callable, default=0
-        Value to pad with. Can be a float or a statistic string or an numpy array for
-        each time series. Supported statistic strings are "mean", "median", "max",
-        "min".
+    fill_value : scalar, str or Callable, default=0
+        Value to pad with. Can be a scalar, a statistic string, or a callable.
+        Supported statistic strings are "mean", "median", "max", "min".
     add_noise : float or None, default=None
         Add noise to the padded values of the series.
         Randomly adds a value between 0 and ``add_noise`` to each padded value if
@@ -169,6 +168,10 @@ class Padder(BaseCollectionTransformer):
                 )
         elif callable(self.fill_value):
             func = self.fill_value
+        elif not np.isscalar(self.fill_value):
+            raise ValueError(
+                "fill_value must be a scalar, supported statistic string, or callable."
+            )
 
         rng = check_random_state(self.random_state)
 

--- a/aeon/transformations/collection/unequal_length/tests/test_pad.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_pad.py
@@ -75,6 +75,19 @@ def test_padding_fixed_value():
     assert X_padded[0][0][100] == 42
 
 
+@pytest.mark.parametrize(
+    "fill_value",
+    [np.array([1.0, 2.0]), np.array([1.0, 2.0, 3.0])],
+)
+def test_padder_rejects_array_fill_value(fill_value):
+    """Test Padder rejects array fill values."""
+    X = [np.array([[5.0, 6.0], [7.0, 8.0]])]
+    padding_transformer = Padder(padded_length=4, fill_value=fill_value)
+
+    with pytest.raises(ValueError, match="fill_value must be a scalar"):
+        padding_transformer.fit_transform(X)
+
+
 def test_padding_fill_unequal_length():
     """Test padding unequal length longer than longest.
 


### PR DESCRIPTION
## Summary
- Remove the unsupported NumPy array claim from `Padder.fill_value` documentation.
- Validate non-string, non-callable `fill_value` inputs so array-like values raise a clear `ValueError` instead of being silently misinterpreted by `np.pad` or surfacing a broadcast error.
- Add regression coverage for length-2 and length-3 NumPy array fill values.

Closes #3495.

## Testing
- `uv run ruff check aeon/transformations/collection/unequal_length/_pad.py aeon/transformations/collection/unequal_length/tests/test_pad.py`
- `uv run ruff format --check aeon/transformations/collection/unequal_length/_pad.py aeon/transformations/collection/unequal_length/tests/test_pad.py`
- `uv run --with pytest-xdist --with pytest-rerunfailures --with pytest-timeout pytest aeon/transformations/collection/unequal_length/tests/test_pad.py::test_padder_rejects_array_fill_value -q`
- `uv run --with pytest-xdist --with pytest-rerunfailures --with pytest-timeout pytest aeon/transformations/collection/unequal_length/tests/test_pad.py -q`
- `uv run --with pytest-xdist --with pytest-rerunfailures --with pytest-timeout pytest aeon/transformations/collection/unequal_length/tests -q`
- `git diff --check`

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
