### PR TITLE
[BUG] Fix rehab loader 

### DIFF
--- a/aeon/datasets/rehabpile_loader.py
+++ b/aeon/datasets/rehabpile_loader.py
@@ -289,8 +289,9 @@ def load_rehab_pile_dataset(
                     f"name and your internet connection. Error: {e}"
                 ) from e
 
-    X = np.load(dataset_path_fold / files_to_load["X"])
-    y = np.load(dataset_path_fold / files_to_load["y"])
+    # RehabPile stores some arrays as object arrays, so pickle support is required.
+    X = np.load(dataset_path_fold / files_to_load["X"], allow_pickle=True)
+    y = np.load(dataset_path_fold / files_to_load["y"], allow_pickle=True)
 
     if return_meta:
         meta_path = dataset_path_meta / "info.json"

--- a/aeon/datasets/rehabpile_loader.py
+++ b/aeon/datasets/rehabpile_loader.py
@@ -293,6 +293,9 @@ def load_rehab_pile_dataset(
     X = np.load(dataset_path_fold / files_to_load["X"], allow_pickle=True)
     y = np.load(dataset_path_fold / files_to_load["y"], allow_pickle=True)
 
+    X = np.array(X.tolist())
+    y = np.array(y.tolist())
+
     if return_meta:
         meta_path = dataset_path_meta / "info.json"
         if not meta_path.exists():


### PR DESCRIPTION
fixes #3517 

aeon/datasets/rehabpile_loader.py now uses np.load(..., allow_pickle=True) for RehabPile .npy files.