### PR TITLE
[DOC] Fix docstring inaccuracies and typos in unequal_length package

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -27,7 +27,7 @@ class Padder(BaseCollectionTransformer):
         in ``fit``. If an integer, will pad to that length.
         Calling ``fit`` is not required if ``padded_length`` is an int.
     fill_value : int, str or Callable, default=0
-        Value to pad with. Can be a float or a statistic string or an numpy array for
+        Value to pad with. Can be a float or a statistic string or a numpy array for
         each time series. Supported statistic strings are "mean", "median", "max",
         "min".
     add_noise : float or None, default=None
@@ -41,7 +41,7 @@ class Padder(BaseCollectionTransformer):
         collection could remain unequal length, a list of numpy arrays will be returned
         instead of a 3D numpy array.
     random_state : int, RandomState instance or None, default=None
-        Only used if add_noise is True.
+        Only used if add_noise is not None.
 
         If `int`, random_state is the seed used by the random number generator;
         If `RandomState` instance, random_state is the random number generator;
@@ -54,7 +54,7 @@ class Padder(BaseCollectionTransformer):
     >>> import numpy as np
     >>> X = []
     >>> for i in range(10): X.append(np.random.random((4, 75 + i)))
-    >>> padder = Padder(padded_length=200, fill_value =42)
+    >>> padder = Padder(padded_length=200, fill_value=42)
     >>> X2 = padder.fit_transform(X)
     >>> X2.shape
     (10, 4, 200)

--- a/aeon/transformations/collection/unequal_length/_resize.py
+++ b/aeon/transformations/collection/unequal_length/_resize.py
@@ -62,18 +62,18 @@ class Resizer(BaseCollectionTransformer):
             raise ValueError("resized_length must be 'min', 'max' or an integer.")
 
     def _transform(self, X, y=None):
-        """Fit a linear function on each channel of each series, then resample.
+        """Linearly interpolate each channel of each series to the target length.
 
         Parameters
         ----------
         X : 3D np.ndarray of shape = (n_cases, n_channels, n_timepoints) or
-            list size [n_cases] of 2D nump arrays, case i has shape (n_channels,
+            list size [n_cases] of 2D numpy arrays, case i has shape (n_channels,
             length_i). Collection of time series to transform
         y : ignored argument for interface compatibility
 
         Returns
         -------
-        3D numpy array of shape (n_cases, n_channels, self.length)
+        3D numpy array of shape (n_cases, n_channels, resized_length)
         """
         length = (
             self.resized_length

--- a/aeon/transformations/collection/unequal_length/_truncate.py
+++ b/aeon/transformations/collection/unequal_length/_truncate.py
@@ -112,7 +112,7 @@ class Truncator(BaseCollectionTransformer):
                 raise ValueError(
                     "min length of series in X is less than the provided "
                     "truncated_length (or less than the series seen in fit if "
-                    "truncated_length is str)."
+                    "truncated_length is a string)."
                 )
 
         Xt = [x[:, :truncated_length] for x in X]


### PR DESCRIPTION
Addresses part of #3496. A focused subset of docstring/typo fixes in the unequal_length package. None change behaviour.

_resize.py
- `_transform` summary said "Fit a linear function … then resample", but the implementation uses `np.interp` (piecewise linear interpolation); reworded to describe interpolation.
- "2D nump arrays" -> "2D numpy arrays".
- Return docstring referenced a non-existent `self.length`; corrected to `resized_length`.

_pad.py
- Grammar: "an numpy array" -> "a numpy array".
- `random_state`: said "Only used if add_noise is True", but `add_noise` is a float or None; reworded to "is not None".
- Example: removed stray space in `fill_value =42`.

_truncate.py
- Error text grammar: "truncated_length is str" -> "truncated_length is a string".