### PR TITLE
Fix docstring typos and inaccuracies in channel_selection (#3491)

### DIFF
--- a/aeon/transformations/collection/channel_selection/_channel_scorer.py
+++ b/aeon/transformations/collection/channel_selection/_channel_scorer.py
@@ -5,6 +5,7 @@ __all__ = ["ChannelScorer"]
 
 import math
 from collections.abc import Callable
+from typing import Any
 from typing import Dict as TypingDict
 from typing import List as TypingList
 
@@ -21,7 +22,7 @@ class ChannelScorer(BaseChannelSelector):
     """Performs channel selection using a single channel classifier or regressor.
 
     ChannelScorer uses a time series classifier or regressor to score each channel
-    using an estimate of accuracy on the training data foo classifiers or mean
+    using an estimate of accuracy on the training data for classifiers or mean
     squared error for regressors. It then selects a proportion of the top
     channels to keep. It can be configured through the constructor to use any time
     series estimator and could easily be adapted to use forward selection or elbow
@@ -47,6 +48,13 @@ class ChannelScorer(BaseChannelSelector):
     proportion : float, default = 0.4
         Proportion of channels to keep, rounded up to nearest integer.
 
+    Attributes
+    ----------
+    estimator_ : BaseClassifier or BaseRegressor
+        The fitted estimator used to score each channel.
+    channels_selected_ : list
+        List of selected channel indices.
+
     References
     ----------
     ..[1]: Alejandro Pasos Ruiz and Anthony Bagnall. "Dimension selection strategies
@@ -61,7 +69,7 @@ class ChannelScorer(BaseChannelSelector):
 
     def __init__(
         self,
-        estimator: BaseAeonEstimator | None,
+        estimator: BaseAeonEstimator,
         scoring_function: Callable = None,
         score_sign: float = None,
         proportion: float = 0.4,
@@ -114,7 +122,7 @@ class ChannelScorer(BaseChannelSelector):
 
         n_channels = X.shape[1]
         scores = np.zeros(n_channels)
-        # Evaluate each channel with the classifier
+        # Evaluate each channel with the estimator
         for i in range(n_channels):
             preds = self.estimator_.fit_predict(X[:, i, :], y)
             scores[i] = score_sign * scoring_function(
@@ -128,7 +136,7 @@ class ChannelScorer(BaseChannelSelector):
         return self
 
     @classmethod
-    def _get_test_params(cls, parameter_set: str = "default") -> TypingDict[str, any]:
+    def _get_test_params(cls, parameter_set: str = "default") -> TypingDict[str, Any]:
         """Return testing parameter settings for the estimator.
 
         Parameters

--- a/aeon/transformations/collection/channel_selection/_elbow_class.py
+++ b/aeon/transformations/collection/channel_selection/_elbow_class.py
@@ -68,7 +68,7 @@ def _create_distance_matrix(
             class values {len(class_vals)} must be of same length.")
 
     distance_pair = list(itertools.combinations(range(0, class_vals.shape[0]), 2))
-    # create a dictionary of class values and their indexes
+    # create a dictionary of class values and their indices
     idx_class = {i: class_vals[i] for i in range(0, len(class_vals))}
 
     distance_frame = pd.DataFrame()
@@ -111,8 +111,10 @@ class _ClassPrototype:
 
     Attributes
     ----------
-    prototype : str
+    prototype_type : str
         Class prototype to be used for class prototype creation.
+    mean_centering : bool
+        If True, mean centering is applied to the class prototype.
 
     Notes
     -----
@@ -156,14 +158,14 @@ class _ClassPrototype:
         return np.mean(class_X, axis=0)
 
     def _create_mad_prototype(self, X: np.ndarray, y: np.array) -> np.array:
-        """Create mad class prototype for each class."""
+        """Create MAD class prototype for each class."""
         classes_ = np.unique(y)
 
         channel_median = []
         for class_ in classes_:
             class_idx = np.where(
                 y == class_
-            )  # find the indexes of data point where particular class is located
+            )  # find the indices of data point where particular class is located
 
             class_median = np.median(X[class_idx], axis=0)
             class_median = self._mad_median(X[class_idx], class_median)
@@ -178,7 +180,7 @@ class _ClassPrototype:
         return np.vstack(channel_mean)
 
     def _create_median_prototype(self, X: np.ndarray, y: np.array):
-        """Create mean class prototype for each class."""
+        """Create median class prototype for each class."""
         classes_ = np.unique(y)
         channel_median = [np.median(X[y == class_], axis=0) for class_ in classes_]
         return np.vstack(channel_median)
@@ -223,15 +225,13 @@ class ElbowClassSum(BaseChannelSelector):
 
     Parameters
     ----------
-    distance : str
-        Distance metric to use for creating the class prototype.
-        Default: 'euclidean'
-    prototype_type : str
+    distance : str, default = "euclidean"
+        Distance metric to use for the pairwise distance matrix between
+        class prototypes.
+    prototype_type : str, default = "mean"
         Type of class prototype to use for representing a class.
-        Default: 'mean'
-    mean_center : bool
+    mean_center : bool, default = False
         If True, mean centering is applied to the class prototype.
-        Default: False
 
     Attributes
     ----------
@@ -327,15 +327,16 @@ class ElbowClassPairwise(BaseChannelSelector):
     Overview: From the input of multivariate time series data, create a distance
     matrix [1] by calculating the distance between each class centroid. The ECP
     selects the subset of channels using the elbow method that maximizes the
-    distance between each class centroids pair across all channels.
+    distance between each pair of class centroids across all channels.
 
     Note: Channels, variables, dimensions, features are used interchangeably in
     literature.
 
     Parameters
     ----------
-    distance : str, default  = "euclidean"
-        Distance metric to use for creating the class prototype.
+    distance : str, default = "euclidean"
+        Distance metric to use for the pairwise distance matrix between
+        class prototypes.
     prototype_type : str, default = "mad"
         Type of class prototype to use for representing a class.
         Options: ['mean', 'median', 'mad'].

--- a/aeon/transformations/collection/channel_selection/base.py
+++ b/aeon/transformations/collection/channel_selection/base.py
@@ -14,7 +14,7 @@ from aeon.transformations.collection.base import BaseCollectionTransformer
 class BaseChannelSelector(BaseCollectionTransformer):
     """Abstract base class for channel selection transformers.
 
-    Extends BaseCollectionTransformer by implementing``_transform`` to return
+    Extends BaseCollectionTransformer by implementing ``_transform`` to return
     channels selected in fit.
 
     Attributes

--- a/aeon/transformations/collection/channel_selection/tests/test_tselect.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_tselect.py
@@ -1,4 +1,4 @@
-"""Test tselect channel channel selector."""
+"""Test TSelect channel selector."""
 
 import numpy as np
 
@@ -6,7 +6,7 @@ from aeon.transformations.collection.channel_selection import TSelect
 
 
 def test_tselect_fit_transform_shape():
-    """Test tselect channel selector."""
+    """Test TSelect channel selector."""
     rng = np.random.RandomState(0)
     X = rng.normal(size=(30, 5, 20))
     y = np.array([0, 1] * 15)
@@ -25,7 +25,7 @@ def test_tselect_fit_transform_shape():
 
 
 def test_tselect_attributes():
-    """Test tselect channel selector."""
+    """Test TSelect channel selector."""
     rng = np.random.RandomState(1)
     X = rng.normal(size=(40, 4, 15))
     y = np.array([0, 1] * 20)
@@ -40,7 +40,7 @@ def test_tselect_attributes():
 
 
 def test_tselect_keeps_predictive_channel():
-    """Test t-select channel selector."""
+    """Test TSelect channel selector."""
     rng = np.random.RandomState(2)
     X = rng.normal(size=(60, 3, 20))
     y = np.array([0, 1] * 30)


### PR DESCRIPTION
Fixes all docstring issues listed in #3491 across 4 files in the channel_selection package:

**Typos:** corrected "foo"→"for", "mean"→"median" (copy-paste bug), missing space before literal, duplicated "channel"

**Inaccurate docstrings:** fixed `distance` parameter descriptions (it's used for pairwise distance, not prototype creation), corrected `_ClassPrototype` Attributes section, MAD capitalization, awkward wording

**Typing:** `any` → `Any` in return annotation

**Polish:** standardized `Default:`→inline `default=` format, `indexes`→`indices`, `tselect`/`t-select`→`TSelect` in docstrings, added missing Attributes section to ChannelScorer, removed misleading `| None` from estimator type hint

This pull request includes code written with the assistance of AI. The code has not yet been reviewed by a human.