### PR TITLE
[DOC] Fix pad_length/truncated_length naming and test docstring in unequal_length

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -36,8 +36,8 @@ class Padder(BaseCollectionTransformer):
         float.
         Adds no noise if None.
     error_on_long : bool, default=True
-        If True, raise an error if a series is longer than pad_length.
-        If False, will ignore series longer than pad_length. As the series
+        If True, raise an error if a series is longer than padded_length.
+        If False, will ignore series longer than padded_length. As the series
         collection could remain unequal length, a list of numpy arrays will be returned
         instead of a 3D numpy array.
     random_state : int, RandomState instance or None, default=None
@@ -127,10 +127,10 @@ class Padder(BaseCollectionTransformer):
 
         Returns
         -------
-        Xt : numpy3D array (n_cases, n_channels, self.pad_length_)
+        Xt : numpy3D array (n_cases, n_channels, self._padded_length)
             padded time series from X.
         """
-        # Must call fit if pad_length is None
+        # Must call fit unless padded_length is an int
         pad_length = (
             self.padded_length
             if isinstance(self.padded_length, int)
@@ -141,8 +141,9 @@ class Padder(BaseCollectionTransformer):
             max_length = _get_max_length(X)
             if max_length > pad_length:
                 raise ValueError(
-                    "max length of series in X is greater than the provided pad_length"
-                    "(or greater than the series seen in fit if pad_length is None)."
+                    "max length of series in X is greater than the provided "
+                    "padded_length (or greater than the series seen in fit if "
+                    "padded_length is 'min' or 'max')."
                 )
 
         # Determine if fill value is a function

--- a/aeon/transformations/collection/unequal_length/_truncate.py
+++ b/aeon/transformations/collection/unequal_length/_truncate.py
@@ -96,7 +96,7 @@ class Truncator(BaseCollectionTransformer):
 
         Returns
         -------
-        Xt : numpy3D array (n_cases, n_channels, self.truncated_length_)
+        Xt : numpy3D array (n_cases, n_channels, self._truncated_length)
             truncated time series from X.
         """
         # Must call fit unless truncated_length is an int

--- a/aeon/transformations/collection/unequal_length/tests/test_pad.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_pad.py
@@ -90,7 +90,7 @@ def test_padding_fill_unequal_length():
 
 
 def test_padding_min():
-    """Test Truncator handles unequal length data correctly."""
+    """Test Padder handles unequal length data correctly."""
     X, _ = make_example_3d_numpy_list()
     X2, _ = make_example_3d_numpy_list(min_n_timepoints=6, max_n_timepoints=16)
     min_length = _get_min_length(X)


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses part of #3496. Follows the focused-subset approach of the already-merged #3528. Intentionally stays out of the lanes of the in-flight PRs #3512, #3523, #3524 (fill_value rewrites and length validation) and #3507 (integer length validation).

#### What does this implement/fix? Explain your changes.

Mechanical docstring, comment, and error-message fixes in `aeon.transformations.collection.unequal_length`. No behaviour change.

`_pad.py`
- `error_on_long` docstring referred to the parameter as `pad_length`; the parameter is named `padded_length`.
- `_transform` `"Must call fit if pad_length is None"` comment used the wrong name and an inaccurate sentinel (`None` is not a valid value); reworded to `"Must call fit unless padded_length is an int"` to match the matching comment in `_truncate.py`.
- `_transform` length-check `ValueError` used `pad_length` in both the message body and the trailing clause; corrected to `padded_length` and incidentally fixed the missing space between two adjacent string literals.
- `_transform` return docstring referenced `self.pad_length_`; the fitted attribute is `_padded_length`.

`_truncate.py`
- `_transform` return docstring referenced `self.truncated_length_`; the fitted attribute is `_truncated_length`.

`tests/test_pad.py`
- `test_padding_min` docstring said `"Test Truncator handles unequal length data correctly."` for a `Padder` test; corrected to `Padder`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Diff is 9 insertions, 8 deletions across 3 files; pure text. Pre-commit hooks pass locally on the changed files.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.