### PR TITLE
[BUG] fix: move RandomChannelSelector p validation from __init__ to _fit

### DIFF
--- a/aeon/transformations/collection/channel_selection/_random.py
+++ b/aeon/transformations/collection/channel_selection/_random.py
@@ -43,16 +43,16 @@ class RandomChannelSelector(BaseChannelSelector):
     }
 
     def __init__(self, p=0.4, random_state=None):
-        if p <= 0 or p > 1:
-            raise ValueError(
-                "Proportion of channels to select should be in the range (0,1]."
-            )
         self.p = p
         self.random_state = random_state
         super().__init__()
 
     def _fit(self, X, y):
         """Randomly select channels to retain."""
+        if self.p <= 0 or self.p > 1:
+            raise ValueError(
+                "Proportion of channels to select should be in the range (0,1]."
+            )
         rng = check_random_state(self.random_state)
         to_select = math.ceil(self.p * X.shape[1])
         self.channels_selected_ = rng.choice(

--- a/aeon/transformations/collection/channel_selection/tests/test_random.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_random.py
@@ -27,7 +27,8 @@ def test_random_channel_selector():
     r = RandomChannelSelector(p=1.0)
     X2 = r.fit_transform(X)
     assert X2.shape == X.shape
+    selector = RandomChannelSelector(p=0)
     with pytest.raises(
         ValueError, match="Proportion of channels to select should be in the range."
     ):
-        RandomChannelSelector(p=0).fit_transform(X)
+        selector.fit_transform(X)

--- a/aeon/transformations/collection/channel_selection/tests/test_random.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_random.py
@@ -30,4 +30,4 @@ def test_random_channel_selector():
     with pytest.raises(
         ValueError, match="Proportion of channels to select should be in the range."
     ):
-        RandomChannelSelector(p=0)
+        RandomChannelSelector(p=0).fit_transform(X)


### PR DESCRIPTION
## Fix

Fixes #3490

### Problem

`RandomChannelSelector.__init__` validates that `p` is in `(0, 1]`, but the sklearn clone contract requires that `__init__` only stores parameters without validation. This makes `RandomChannelSelector` inconsistent with other channel selectors in the same package.

### Solution

Move the range check for `p` from `__init__` to `_fit`.

### Changes

- `_random.py`: Removed validation from `__init__`, added it to `_fit`
- `test_random.py`: Updated test to expect `ValueError` at `fit_transform` time

### Testing

Test passes with the fix applied.