### PR TITLE
[BUG] fix(padder): validate fill_value to reject arrays and unsupported types

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -28,10 +28,9 @@ class Padder(BaseCollectionTransformer):
         shortest series seen in ``fit``. If "max", will pad to the longest series seen
         in ``fit``. If an integer, will pad to that length.
         Calling ``fit`` is not required if ``padded_length`` is an int.
-    fill_value : int, str or Callable, default=0
-        Value to pad with. Can be a float or a statistic string or a numpy array for
-        each time series. Supported statistic strings are "mean", "median", "max",
-        "min".
+    fill_value : int, float, str or Callable, default=0
+        Value to pad with. Scalar (int/float), statistic string (mean, median, max,
+        min, last), or callable taking a 1D array and returning a scalar.
     add_noise : float or None, default=None
         Add noise to the padded values of the series.
         Randomly adds a value between 0 and ``add_noise`` to each padded value if
@@ -86,6 +85,22 @@ class Padder(BaseCollectionTransformer):
         self.random_state = random_state
 
         super().__init__()
+
+        if isinstance(self.fill_value, str):
+            if self.fill_value not in ("mean", "median", "max", "min", "last"):
+                raise ValueError(
+                    f"Supported string values: mean, median, max, min, last. "
+                    f"Got {self.fill_value!r}."
+                )
+        elif callable(self.fill_value):
+            pass
+        elif isinstance(self.fill_value, bool) or not isinstance(
+            self.fill_value, (int, float)
+        ):
+            raise TypeError(
+                f"fill_value must be a scalar (int/float), a supported "
+                f"statistic string, or a callable. Got {type(self.fill_value)}."
+            )
 
         self.set_tags(
             **{
@@ -166,11 +181,6 @@ class Padder(BaseCollectionTransformer):
                     return x[-1]
 
                 func = last
-            else:
-                raise ValueError(
-                    "Supported str values for fill_value are {mean, median, min, "
-                    "max, last}."
-                )
         elif callable(self.fill_value):
             func = self.fill_value
 

--- a/aeon/transformations/collection/unequal_length/tests/test_pad.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_pad.py
@@ -156,8 +156,23 @@ def test_padding_integer_input_with_noise():
 
 def test_padder_incorrect_paras():
     """Test Padder with incorrect parameters."""
-    X = np.random.rand(2, 2, 20)
+    with pytest.raises(ValueError, match="Supported string values"):
+        Padder(padded_length=22, fill_value="FOOBAR")
 
-    padding_transformer = Padder(padded_length=22, fill_value="FOOBAR")
-    with pytest.raises(ValueError, match="Supported str values for fill_value are"):
-        padding_transformer.fit_transform(X)
+
+def test_padder_rejects_array_fill_value():
+    """Test Padder rejects array fill values."""
+    with pytest.raises(TypeError, match="fill_value must be a scalar"):
+        Padder(fill_value=np.array([1.0, 2.0]))
+
+
+def test_padder_rejects_list_fill_value():
+    """Test Padder rejects list fill values."""
+    with pytest.raises(TypeError, match="fill_value must be a scalar"):
+        Padder(fill_value=[1, 2])
+
+
+def test_padder_rejects_none_fill_value():
+    """Test Padder rejects None fill values."""
+    with pytest.raises(TypeError, match="fill_value must be a scalar"):
+        Padder(fill_value=None)


### PR DESCRIPTION
Fixes #3495. Add `fill_value` validation in `__init__`, fix the misleading docstring, and add regression tests for array, list, and `None` inputs.

The root cause was that unsupported non-scalar values could reach `np.pad`, where NumPy arrays such as `np.array([1., 2.])` are interpreted as before/after constant pairs instead of being rejected as unsupported per-series fill values. Constructor-time validation now rejects those inputs before transform time.

Validation run:
- `pytest aeon/transformations/collection/unequal_length/tests/test_pad.py`
- `pre-commit run black --files aeon/transformations/collection/unequal_length/_pad.py aeon/transformations/collection/unequal_length/tests/test_pad.py`
- `pre-commit run isort --files aeon/transformations/collection/unequal_length/_pad.py aeon/transformations/collection/unequal_length/tests/test_pad.py`
- `pre-commit run ruff --files aeon/transformations/collection/unequal_length/_pad.py aeon/transformations/collection/unequal_length/tests/test_pad.py`

Careful review: `fill_value=True` is now rejected despite being an `int` subclass, matching the scalar numeric contract and avoiding bool-as-constant ambiguity.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.