### PR TITLE
[ENH] Add noise to ets test

### DIFF
--- a/aeon/forecasting/stats/tests/test_ets.py
+++ b/aeon/forecasting/stats/tests/test_ets.py
@@ -235,7 +235,8 @@ def test_autoets_wrapped_model_parameters_match_selected_types():
 
 def test_autoets_uses_provided_seasonal_period():
     """AutoETS should use a provided seasonal period instead of inferring one."""
-    y = np.tile(np.array([10.0, 30.0, 12.0, 28.0]), 8)
+    base = np.tile(np.array([10.0, 30.0, 12.0, 28.0]), 8)
+    y = base + 0.05 * np.sin(np.arange(base.size) * 0.7)
 
     forecaster = AutoETS(seasonal_period=4)
     forecaster.fit(y)


### PR DESCRIPTION
Temporary solution to the problem identified in #3545 in order to get overnights passing with codcov

ETS fails when seasonality fit is perfect, and when you turn numba off this causes a numeric error. Solution is a guard against zero variance we use throughout the toolkit, but I want to do that carefully and standardise better across tool kit, hence this short term fix to get code cov working

