### PR TITLE
[BUG] Validate RandomChannelSelector p during fit

### DIFF
--- a/aeon/transformations/collection/channel_selection/_random.py
+++ b/aeon/transformations/collection/channel_selection/_random.py
@@ -43,16 +43,16 @@ class RandomChannelSelector(BaseChannelSelector):
     }
 
     def __init__(self, p=0.4, random_state=None):
-        if p <= 0 or p > 1:
-            raise ValueError(
-                "Proportion of channels to select should be in the range (0,1]."
-            )
         self.p = p
         self.random_state = random_state
         super().__init__()
 
     def _fit(self, X, y):
         """Randomly select channels to retain."""
+        if self.p <= 0 or self.p > 1:
+            raise ValueError(
+                "Proportion of channels to select should be in the range (0,1]."
+            )
         rng = check_random_state(self.random_state)
         to_select = math.ceil(self.p * X.shape[1])
         self.channels_selected_ = rng.choice(

--- a/aeon/transformations/collection/channel_selection/tests/test_random.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_random.py
@@ -27,7 +27,8 @@ def test_random_channel_selector():
     r = RandomChannelSelector(p=1.0)
     X2 = r.fit_transform(X)
     assert X2.shape == X.shape
+    r = RandomChannelSelector(p=0)
     with pytest.raises(
         ValueError, match="Proportion of channels to select should be in the range."
     ):
-        RandomChannelSelector(p=0)
+        r.fit(X)


### PR DESCRIPTION
## Summary

Moves `RandomChannelSelector.p` validation from construction to `_fit`, matching aeon's estimator convention that constructors store parameters unchanged and validation happens during fitting.

## Related issue

Fixes #3490

## Changes

- Remove the `p` range check from `__init__`.
- Validate `p` at the start of `_fit` before selecting channels.
- Update the existing test so invalid `p` can be constructed but raises on `fit`.

## Testing

- `uv run pytest aeon/transformations/collection/channel_selection/tests/test_random.py -q`
- `git diff --check`
