### PR TITLE
[BUG] Validate p in _fit instead of __init__ for RandomChannelSelector

### DIFF
--- a/aeon/transformations/collection/channel_selection/_random.py
+++ b/aeon/transformations/collection/channel_selection/_random.py
@@ -43,16 +43,16 @@ class RandomChannelSelector(BaseChannelSelector):
     }
 
     def __init__(self, p=0.4, random_state=None):
-        if p <= 0 or p > 1:
-            raise ValueError(
-                "Proportion of channels to select should be in the range (0,1]."
-            )
         self.p = p
         self.random_state = random_state
         super().__init__()
 
     def _fit(self, X, y):
         """Randomly select channels to retain."""
+        if self.p <= 0 or self.p > 1:
+            raise ValueError(
+                "Proportion of channels to select should be in the range (0,1]."
+            )
         rng = check_random_state(self.random_state)
         to_select = math.ceil(self.p * X.shape[1])
         self.channels_selected_ = rng.choice(

--- a/aeon/transformations/collection/channel_selection/tests/test_random.py
+++ b/aeon/transformations/collection/channel_selection/tests/test_random.py
@@ -27,7 +27,10 @@ def test_random_channel_selector():
     r = RandomChannelSelector(p=1.0)
     X2 = r.fit_transform(X)
     assert X2.shape == X.shape
+    # Invalid p is accepted at construction and only validated in fit, matching the
+    # sklearn clone contract followed by the other channel selectors.
+    selector = RandomChannelSelector(p=0)
     with pytest.raises(
         ValueError, match="Proportion of channels to select should be in the range."
     ):
-        RandomChannelSelector(p=0)
+        selector.fit(X)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3490

#### What does this implement/fix? Explain your changes.

`RandomChannelSelector.__init__` raised `ValueError` when `p` was outside
`(0, 1]`. Validating in the constructor violates the scikit-learn clone
contract: `__init__` should only store parameters unchanged and defer
validation to `fit`. This is also inconsistent with the other selectors in
the same package (`ChannelScorer`, `ElbowClass*`), which validate at the
start of `_fit`.

This PR:
- Moves the `p` range check from `__init__` to the start of `_fit`, leaving
  `__init__` to only assign `self.p` / `self.random_state`.
- Updates `test_random` so an invalid `p` is accepted at construction and
  the `ValueError` is asserted at `fit` time instead.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Behaviour is unchanged except for *when* the error is raised (at `fit`
rather than at construction). The error message is preserved. All 16 tests
in `channel_selection/tests/` pass locally and pre-commit (ruff, black,
isort, codespell) is clean.
