### PR TITLE
[BUG] Fix AutocorrelationFunctionTransformer crash with default n_lags=None

### DIFF
--- a/aeon/transformations/collection/_acf.py
+++ b/aeon/transformations/collection/_acf.py
@@ -66,7 +66,7 @@ class AutocorrelationFunctionTransformer(BaseCollectionTransformer):
     def _transform(self, X, y=None):
         n_cases, n_channels, n_timepoints = X.shape
         if self.n_lags is None:
-            lags = n_timepoints / 4
+            lags = int(max(1, n_timepoints / 4))
         else:
             lags = self.n_lags(X) if callable(self.n_lags) else self.n_lags
         if lags > n_timepoints - self.min_values:

--- a/aeon/transformations/collection/tests/test_acf.py
+++ b/aeon/transformations/collection/tests/test_acf.py
@@ -12,3 +12,13 @@ def test_acf():
     acf = AutocorrelationFunctionTransformer(n_lags=100)
     with pytest.raises(ValueError, match=r"must be smaller than n_timepoints - 1"):
         acf.fit_transform(X)
+
+
+def test_acf_default_n_lags():
+    """Test the default n_lags=None resolves to an integer n_timepoints // 4."""
+    X = np.random.random((4, 2, 20))
+    default = AutocorrelationFunctionTransformer().fit_transform(X)
+    # default lags = n_timepoints / 4 = 5
+    assert default.shape == (4, 2, 5)
+    explicit = AutocorrelationFunctionTransformer(n_lags=5).fit_transform(X)
+    np.testing.assert_allclose(default, explicit)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3551.

#### What does this implement/fix? Explain your changes.

`AutocorrelationFunctionTransformer._transform` computed the default number of
lags as `lags = n_timepoints / 4`, which is a `float`. That value is then used as
an array dimension (`np.zeros((n_cases, n_channels, lags))`) and as the numba
kernel's `max_lag`, so the transformer raised `TypeError: 'float' object cannot be
interpreted as an integer` for **every** input under its documented default
`n_lags=None`. The `None` path was never covered because the existing docstring and
test only pass an explicit integer `n_lags`.

The fix casts the default to an int the same way the sibling
`AutoCorrelationSeriesTransformer` already does
(`aeon/transformations/series/_acf.py`):

```python
lags = int(max(1, n_timepoints / 4))
```

`max(1, ...)` keeps at least one lag for very short series, matching the sibling's
behaviour. For the common case the result is unchanged numerically: the default now
equals passing `n_lags = n_timepoints // 4` explicitly (verified in the new test).

Added `test_acf_default_n_lags` covering the previously-crashing `n_lags=None` path.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

The pre-existing docstring example (`n_lags=10`) is unchanged; its doctest output is
identical.

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
