### PR TITLE
[ENH] Add suggested fix field to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,6 +75,15 @@ body:
     required: true
 - type: textarea
   attributes:
+    label: Suggested fix
+    description: >
+      If you have an idea for where the issue comes from or how it could be
+      fixed, please describe it here. This is optional.
+    placeholder: >
+      For example: move the validation from __init__ to _fit, or add a guard for
+      empty input before calling the downstream function.
+- type: textarea
+  attributes:
     label: Versions
     description: |
       Please run the following code snippet and paste the output here.


### PR DESCRIPTION
## Summary

Adds an optional **Suggested fix** textarea to the bug report issue template.

## Why

Issue #3500 asks for a place where reporters can share an implementation idea without making that field mandatory. This gives maintainers extra triage context when a reporter has already investigated the bug, while keeping the normal bug-report flow unchanged.

## Validation

- `git diff --check`
- Verified `.github/ISSUE_TEMPLATE/bug_report.yml` contains the new optional field

Fixes #3500
