### PR TITLE
[ENH] Guard ETS AIC against zero residual variance

### DIFF
--- a/aeon/forecasting/stats/tests/test_ets.py
+++ b/aeon/forecasting/stats/tests/test_ets.py
@@ -246,6 +246,19 @@ def test_autoets_uses_provided_seasonal_period():
     assert forecaster.wrapped_model_._seasonal_period == 4
 
 
+def test_autoets_uses_provided_seasonal_period_for_exact_periodic_series():
+    """A zero-variance seasonal fit should still have finite AIC."""
+    y = np.tile(np.array([10.0, 30.0, 12.0, 28.0]), 8)
+
+    forecaster = AutoETS(seasonal_period=4)
+    forecaster.fit(y)
+
+    assert forecaster.seasonality_type_ != 0
+    assert forecaster.seasonal_period_ == 4
+    assert np.isfinite(forecaster.wrapped_model_.aic_)
+    assert np.isfinite(forecaster.wrapped_model_.likelihood_)
+
+
 def test_autoets_provided_seasonal_period_overrides_nonseasonal_aic_winner():
     """A supplied seasonal period should force a seasonal model when possible."""
     y = np.linspace(10.0, 30.0, 80) + 0.01 * np.sin(np.arange(80))

--- a/aeon/forecasting/utils/_loss_functions.py
+++ b/aeon/forecasting/utils/_loss_functions.py
@@ -273,7 +273,9 @@ def _ets_fit(params, data, model):
             -LARGE_LOSS,
             0,
         )
-    variance = sse_ / n_timepoints
+    if sse_ < 0.0:
+        sse_ = 0.0
+    variance = max(sse_ / n_timepoints, EPS)
     likelihood = -0.5 * n_timepoints * (np.log(2 * np.pi) + np.log(variance) + 1)
     if error_type == 2:
         likelihood -= log_fitted_sum


### PR DESCRIPTION
## Summary

Guards the ETS likelihood/AIC calculation against zero residual variance.

## Why

For exact seasonal fits, `sse_ / n_timepoints` can be `0`, which sends the likelihood path through `log(0)`. That produces non-finite likelihood/AIC values, so otherwise valid seasonal candidates can be discarded by AutoETS.

## Changes

- Clamp tiny negative SSE from numerical round-off to `0`.
- Clamp the residual variance used in the likelihood calculation to the existing positive `EPS` floor before taking `log`.
- Add a regression test for the exact periodic `AutoETS(seasonal_period=4)` series from #3545.

## Testing

- `uv run pytest aeon/forecasting/stats/tests/test_ets.py -q` (28 passed)
- `git diff --check`

Fixes #3545
