### PR TITLE
[DOC] Fix unequal length transformer docstrings

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -19,7 +19,7 @@ class Padder(BaseCollectionTransformer):
     """Pad unequal length time series to equal, fixed length.
 
     Pads the input dataset to either a fixed length or finds the max/min length
-    series across all series and channels and pads to that with zeroes.
+    series across all series and pads shorter series with ``fill_value``.
 
     Parameters
     ----------
@@ -28,10 +28,9 @@ class Padder(BaseCollectionTransformer):
         shortest series seen in ``fit``. If "max", will pad to the longest series seen
         in ``fit``. If an integer, will pad to that length.
         Calling ``fit`` is not required if ``padded_length`` is an int.
-    fill_value : int, str or Callable, default=0
-        Value to pad with. Can be a float or a statistic string or a numpy array for
-        each time series. Supported statistic strings are "mean", "median", "max",
-        "min".
+    fill_value : scalar, str or Callable, default=0
+        Value to pad with. Can be a scalar, supported statistic string, or callable.
+        Supported statistic strings are "mean", "median", "max", "min", and "last".
     add_noise : float or None, default=None
         Add noise to the padded values of the series.
         Randomly adds a value between 0 and ``add_noise`` to each padded value if
@@ -116,7 +115,7 @@ class Padder(BaseCollectionTransformer):
         elif self.padded_length == "max":
             self._padded_length = _get_max_length(X)
         else:
-            raise ValueError("pad_length must be 'min', 'max' or an integer.")
+            raise ValueError("padded_length must be 'min', 'max' or an integer.")
 
     def _transform(self, X, y=None):
         """Transform X and return a transformed version.
@@ -131,8 +130,9 @@ class Padder(BaseCollectionTransformer):
 
         Returns
         -------
-        Xt : numpy3D array (n_cases, n_channels, self._padded_length)
-            padded time series from X.
+        Xt : numpy3D array (n_cases, n_channels, self._padded_length) or list
+            Padded time series from X. A list is returned when ``error_on_long`` is
+            False because the collection may remain unequal length.
         """
         # Must call fit unless padded_length is an int
         pad_length = (

--- a/aeon/transformations/collection/unequal_length/_resize.py
+++ b/aeon/transformations/collection/unequal_length/_resize.py
@@ -18,8 +18,8 @@ class Resizer(BaseCollectionTransformer):
     """Resize unequal length time series to equal, fixed length.
 
     Resize the series using linear interpolation to either a fixed length or
-    finds the max/min length series across all series and channels and resizes
-    all series to that length.
+    finds the max/min length series across all series and resizes all series to that
+    length.
 
     Parameters
     ----------

--- a/aeon/transformations/collection/unequal_length/_truncate.py
+++ b/aeon/transformations/collection/unequal_length/_truncate.py
@@ -18,7 +18,7 @@ class Truncator(BaseCollectionTransformer):
     """Truncate unequal length time series to equal, fixed length.
 
     Truncates the input dataset to either a fixed series length or finds the
-    max/min length series across all series and channels and truncates to that.
+    max/min length series across all series and truncates to that.
 
     Parameters
     ----------
@@ -95,13 +95,15 @@ class Truncator(BaseCollectionTransformer):
         Parameters
         ----------
         X : list of [n_cases] 2D np.ndarray shape (n_channels, length_i)
-            where length_i can vary between time series.
+            where length_i can vary between time series or 3D numpy of equal length
+            series.
         y : ignored argument for interface compatibility
 
         Returns
         -------
-        Xt : numpy3D array (n_cases, n_channels, self._truncated_length)
-            truncated time series from X.
+        Xt : numpy3D array (n_cases, n_channels, self._truncated_length) or list
+            Truncated time series from X. A list is returned when ``error_on_short`` is
+            False because the collection may remain unequal length.
         """
         # Must call fit unless truncated_length is an int
         truncated_length = (


### PR DESCRIPTION
Title: Fix unequal length transformer docstrings

## Summary

Updates stale documentation in the unequal-length collection transformers to match the
current implementation:

- Describe min/max length as being found across series, not channels.
- Document `Padder.fill_value` as scalar/string/callable and include the supported
  `"last"` string.
- Use `padded_length` consistently in the Padder error message.
- Clarify list return cases for Padder and Truncator when unequal-length output may
  remain.
- Note that Truncator `_transform` accepts equal-length 3D numpy input.

## Test evidence

- `python -m compileall -q aeon/transformations/collection/unequal_length` passed.
- Targeted `rg` stale-string check found no remaining matches for the corrected issue
  text.
- `git diff --check` passed.

`pytest` was attempted but could not run because the active Python environment does not
have `pytest` installed. A runtime smoke check also could not run because `numpy` is not
installed in the active environment.

## Risks or notes for maintainers

This is documentation-only apart from one error-message string. Please review whether
`scalar` is the preferred docstring type wording for `Padder.fill_value`.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
