### PR TITLE
[BUG] AutoARIMA: respect max_d in the differencing loop (#3577)

### DIFF
--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -431,7 +431,10 @@ class AutoARIMA(BaseForecaster, IterativeForecastingMixin):
         series = np.array(y.squeeze(), dtype=np.float64)
         differenced_series = series.copy()
         self.d_ = 0
-        while not kpss_test(differenced_series)[1] and self.d_ <= self.max_d:
+        # Stop before exceeding max_d: with `<=`, the loop could enter when
+        # ``self.d_ == self.max_d`` and apply one more difference, pushing the
+        # selected order past the configured maximum (e.g. max_d=0 -> d_=1).
+        while not kpss_test(differenced_series)[1] and self.d_ < self.max_d:
             differenced_series = np.diff(differenced_series, n=1)
             self.d_ += 1
         include_constant = 1 if self.d_ == 0 else 0

--- a/aeon/forecasting/stats/tests/test_arima.py
+++ b/aeon/forecasting/stats/tests/test_arima.py
@@ -251,8 +251,11 @@ def test_autoarima_fit_sets_model_and_orders_within_bounds():
 
 
 def test_autoarima_respects_max_d_zero():
-    """max_d=0 must disable non-seasonal differencing, even for a non-stationary
-    (trending) series that would otherwise be differenced (gh-3577)."""
+    """max_d=0 must disable non-seasonal differencing (gh-3577).
+
+    Even for a non-stationary (trending) series that would otherwise be
+    differenced, max_d=0 must keep d at 0.
+    """
     trending = np.arange(60, dtype=float)
     forecaster = AutoARIMA(max_p=1, max_d=0, max_q=1)
     forecaster.fit(trending)

--- a/aeon/forecasting/stats/tests/test_arima.py
+++ b/aeon/forecasting/stats/tests/test_arima.py
@@ -250,6 +250,15 @@ def test_autoarima_fit_sets_model_and_orders_within_bounds():
     assert 0 <= forecaster.q_ <= forecaster.max_q
 
 
+def test_autoarima_respects_max_d_zero():
+    """max_d=0 must disable non-seasonal differencing, even for a non-stationary
+    (trending) series that would otherwise be differenced (gh-3577)."""
+    trending = np.arange(60, dtype=float)
+    forecaster = AutoARIMA(max_p=1, max_d=0, max_q=1)
+    forecaster.fit(trending)
+    assert forecaster.d_ == 0
+
+
 def test_autoarima_predict_returns_finite_float():
     """_predict should return a finite float once fitted."""
     forecaster = AutoARIMA()


### PR DESCRIPTION
Fixes #3577

## What was wrong

`AutoARIMA._fit` selects the non-seasonal differencing order with:

```python
while not kpss_test(differenced_series)[1] and self.d_ <= self.max_d:
    differenced_series = np.diff(differenced_series, n=1)
    self.d_ += 1
```

Because the guard is `self.d_ <= self.max_d`, the loop can enter when `self.d_ == self.max_d`, apply one more difference, and increment `self.d_` past the configured maximum. With `max_d=0` (differencing disabled) a non-stationary series is still differenced once, ending at `d_ = 1`.

## Fix

Use `self.d_ < self.max_d`, so at most `max_d` differences are applied.

## Test

Adds `test_autoarima_respects_max_d_zero`: fits `AutoARIMA(max_d=0)` on a trending (non-stationary) series and asserts `d_ == 0`. Verified it fails on `main` (`d_ == 1`) and passes with this change.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*