### PR TITLE
[BUG] Padder: validate fill_value and reject array-likes (#3495)

### DIFF
--- a/aeon/transformations/collection/unequal_length/_pad.py
+++ b/aeon/transformations/collection/unequal_length/_pad.py
@@ -150,6 +150,19 @@ class Padder(BaseCollectionTransformer):
                     "padded_length is 'min' or 'max')."
                 )
 
+        # fill_value must be a scalar, a supported statistic string, or a callable.
+        # An array-like is silently misinterpreted by np.pad's constant_values
+        # (treated as a (before, after) pair), so reject it with a clear error.
+        if (
+            not callable(self.fill_value)
+            and not isinstance(self.fill_value, str)
+            and np.ndim(self.fill_value) != 0
+        ):
+            raise ValueError(
+                "fill_value must be a scalar, one of {'mean', 'median', 'min', "
+                "'max', 'last'}, or a callable; an array-like is not supported."
+            )
+
         # Determine if fill value is a function
         func = None
         if isinstance(self.fill_value, str):

--- a/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
+++ b/aeon/transformations/collection/unequal_length/tests/test_length_validation.py
@@ -46,3 +46,11 @@ def test_integer_length_parameters_must_be_positive_non_bool(
 def test_valid_length_parameters(transformer, parameter_name, valid_length):
     """Test valid target length parameters are accepted."""
     transformer(**{parameter_name: valid_length})
+
+
+def test_padder_rejects_array_fill_value():
+    """Padder should reject an array-like fill_value with a clear error (gh-3495)."""
+    X = [np.zeros((1, 3)), np.zeros((1, 5))]
+    padder = Padder(padded_length=6, fill_value=np.array([1, 2]))
+    with pytest.raises(ValueError, match="fill_value must be a scalar"):
+        padder.fit_transform(X)


### PR DESCRIPTION
Fixes #3495

## What was wrong

`Padder`'s docstring stated `fill_value` could be "a numpy array for each time series", but `_transform` passes it straight to `np.pad(..., constant_values=fill_value)`. `np.pad` interprets an array as a `(before, after)` pair, so a length-2 array silently pads every position with its second element, and other lengths raise an opaque broadcast `ValueError`.

## Fix

- Validate that `fill_value` is a scalar, a supported statistic string (`mean`/`median`/`min`/`max`/`last`), or a callable — raising a clear `ValueError` for array-likes.
- Correct the docstring to drop the unsupported array claim (and add the already-supported `last`).

## Test

Adds `test_padder_rejects_array_fill_value`. Verified it fails on `main` (no error raised) and passes with this change.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*