### PR TITLE
[BUG] Fix low-variance slice failures and ETS predict logic

### DIFF
--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -59,6 +59,7 @@ class BaseCollectionEstimator(BaseAeonEstimator):
         "capability:multivariate": False,
         "capability:unequal_length": False,
         "X_inner_type": "numpy3D",
+        "capability:small_scale": False,
     }
 
     @abstractmethod
@@ -177,6 +178,9 @@ class BaseCollectionEstimator(BaseAeonEstimator):
         allow_multivariate = self.get_tag("capability:multivariate")
         allow_missing = self.get_tag("capability:missing_values")
         allow_unequal = self.get_tag("capability:unequal_length")
+        allow_small_scale = self.get_tag(
+            "capability:small_scale", raise_error=False, tag_value_default=False
+        )
 
         # Check capabilities vs input
         problems = []
@@ -196,7 +200,8 @@ class BaseCollectionEstimator(BaseAeonEstimator):
             )
             raise ValueError(msg)
 
-        check_collection_variance(X)
+        if not allow_small_scale:
+            check_collection_variance(X)
 
         return metadata
 

--- a/aeon/base/_base_series.py
+++ b/aeon/base/_base_series.py
@@ -79,6 +79,7 @@ class BaseSeriesEstimator(BaseAeonEstimator):
         "capability:univariate": True,
         "capability:multivariate": False,
         "X_inner_type": "np.ndarray",  # one of VALID_SERIES_INNER_TYPES
+        "capability:small_scale": False,
     }
 
     @abstractmethod
@@ -203,6 +204,9 @@ class BaseSeriesEstimator(BaseAeonEstimator):
         allow_multivariate = self.get_tag("capability:multivariate")
         allow_univariate = self.get_tag("capability:univariate")
         allow_missing = self.get_tag("capability:missing_values")
+        allow_small_scale = self.get_tag(
+            "capability:small_scale", raise_error=False, tag_value_default=False
+        )
         if metadata["missing_values"] and not allow_missing:
             raise ValueError(
                 f"Missing values not supported by {self.__class__.__name__}"
@@ -216,7 +220,8 @@ class BaseSeriesEstimator(BaseAeonEstimator):
                 f"Univariate data not supported by {self.__class__.__name__}"
             )
 
-        check_series_variance(X, axis=axis)
+        if not allow_small_scale:
+            check_series_variance(X, axis=axis)
 
         return metadata
 

--- a/aeon/base/tests/test_base.py
+++ b/aeon/base/tests/test_base.py
@@ -140,6 +140,7 @@ EXPECTED_MOCK_TAGS = {
     "capability:train_estimate": False,
     "capability:unequal_length": True,
     "capability:univariate": True,
+    "capability:small_scale": False,
     "fit_is_empty": False,
     "non_deterministic": False,
     "python_dependencies": None,

--- a/aeon/base/tests/test_base_collection.py
+++ b/aeon/base/tests/test_base_collection.py
@@ -150,6 +150,16 @@ def test_check_X():
     ):
         dummy1._check_X(X)
 
+    # small scale
+    X_tiny = np.zeros((10, 1, 20))
+    X_tiny[1, 0, 1] = 1e-9
+    with pytest.raises(ValueError, match=r"too little variation"):
+        dummy1._check_X(X_tiny)
+
+    dummy2.set_tags(**{"capability:small_scale": True})
+    assert dummy2._check_X(X_tiny)
+
+
 
 @pytest.mark.parametrize("internal_type", COLLECTIONS_DATA_TYPES)
 @pytest.mark.parametrize("data", COLLECTIONS_DATA_TYPES)

--- a/aeon/base/tests/test_base_collection.py
+++ b/aeon/base/tests/test_base_collection.py
@@ -160,7 +160,6 @@ def test_check_X():
     assert dummy2._check_X(X_tiny)
 
 
-
 @pytest.mark.parametrize("internal_type", COLLECTIONS_DATA_TYPES)
 @pytest.mark.parametrize("data", COLLECTIONS_DATA_TYPES)
 def test_convert_X(internal_type, data):

--- a/aeon/base/tests/test_base_series.py
+++ b/aeon/base/tests/test_base_series.py
@@ -164,6 +164,18 @@ def test_check_X():
     with pytest.raises(ValueError, match="X must have at most 2 dimensions"):
         dummy._check_X(collection, axis=0)
 
+    # check small scale capability False
+    X_tiny = np.zeros(20)
+    X_tiny[1] = 1e-9
+    dummy.set_tags(**{"capability:univariate": True})
+    with pytest.raises(ValueError, match="too little variation"):
+        dummy._check_X(X_tiny, axis=1)
+
+    # check small scale capability True
+    dummy.set_tags(**{"capability:small_scale": True})
+    assert dummy._check_X(X_tiny, axis=1)
+
+
 
 @pytest.mark.parametrize("input_type", VALID_INPUT_TYPES)
 def test_convert_X_ndarray_inner(input_type):

--- a/aeon/base/tests/test_base_series.py
+++ b/aeon/base/tests/test_base_series.py
@@ -176,7 +176,6 @@ def test_check_X():
     assert dummy._check_X(X_tiny, axis=1)
 
 
-
 @pytest.mark.parametrize("input_type", VALID_INPUT_TYPES)
 def test_convert_X_ndarray_inner(input_type):
     """Test _convert_X on with np.ndarray inner type."""

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -249,7 +249,31 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
         float
             single prediction self.horizon steps ahead of y.
         """
-        return self.forecast_
+        data = np.asarray(y.squeeze(), dtype=np.float64)
+        (
+            _,
+            level,
+            trend,
+            seasonality,
+            n_timepoints,
+            _,
+            _,
+            _,
+            _,
+            _,
+        ) = _ets_fit(self.parameters_, data, self._model)
+        forecast = _numba_predict(
+            self._trend_type,
+            self._seasonality_type,
+            level,
+            trend,
+            seasonality,
+            self.phi_,
+            self.horizon,
+            n_timepoints,
+            self._seasonal_period,
+        )
+        return forecast
 
     def _initialise(self, data):
         """

--- a/aeon/transformations/collection/_periodogram.py
+++ b/aeon/transformations/collection/_periodogram.py
@@ -50,6 +50,7 @@ class PeriodogramTransformer(BaseCollectionTransformer):
         "capability:multivariate": True,
         "capability:unequal_length": True,
         "X_inner_type": ["np-list", "numpy3D"],
+        "capability:small_scale": True,
     }
 
     def __init__(

--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -178,6 +178,7 @@ class Catch22(BaseCollectionTransformer):
         "capability:multivariate": True,
         "capability:multithreading": True,
         "fit_is_empty": True,
+        "capability:small_scale": True,
     }
 
     def __init__(

--- a/aeon/utils/tags/_tags.py
+++ b/aeon/utils/tags/_tags.py
@@ -113,6 +113,11 @@ ESTIMATOR_TAGS = {
         "type": "bool",
         "description": "Can the estimator set `n_jobs` to use multiple threads?",
     },
+    "capability:small_scale": {
+        "class": "estimator",
+        "type": "bool",
+        "description": "Can the estimator handle small scale/low variance time series input?",
+    },
     "capability:train_estimate": {
         "class": ["classifier", "regressor"],
         "type": "bool",

--- a/aeon/utils/tags/_tags.py
+++ b/aeon/utils/tags/_tags.py
@@ -116,7 +116,8 @@ ESTIMATOR_TAGS = {
     "capability:small_scale": {
         "class": "estimator",
         "type": "bool",
-        "description": "Can the estimator handle small scale/low variance time series input?",
+        "description": "Can the estimator handle small scale/low variance "
+        "time series input?",
     },
     "capability:train_estimate": {
         "class": ["classifier", "regressor"],


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3582.

#### What does this implement/fix? Explain your changes.

This PR implements fixes for two issues:

1. **Low-Variance Checks in Base Estimators**:
   - Added a new tag `"capability:small_scale"` (defaulting to `False`) to conditionally bypass standard deviation / variance checks on short sliced intervals.
   - Enabled this tag on `Catch22` and `PeriodogramTransformer`. This prevents models like `DrCIFClassifier` and `HIVECOTEV2` from crashing on datasets (like `ItalyPowerDemand`) due to random sub-intervals having extremely low variance.
   - Registered `"capability:small_scale"` in `aeon.utils.tags.ESTIMATOR_TAGS`.

2. **ETS / AutoETS Predict Logic**:
   - Refactored `ETS._predict` to dynamically run the filtering/forecast (`_ets_fit`) on the incoming series `y` using the learned parameters.
   - This resolves the issue where `ets.predict(y_train) == ets.predict(y_test)` was always returning the same static forecast.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

None.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
