### PR TITLE
Validate NaiveForecaster seasonal_period

### DIFF
--- a/aeon/forecasting/_naive.py
+++ b/aeon/forecasting/_naive.py
@@ -13,6 +13,18 @@ from aeon.forecasting.base import (
 )
 
 
+def _validate_seasonal_period(value, n_timepoints):
+    """Validate the seasonal period for seasonal-last forecasts."""
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)) or value < 1:
+        raise ValueError(f"seasonal_period must be a positive integer, got {value!r}.")
+    if value > n_timepoints:
+        raise ValueError(
+            "seasonal_period must be less than or equal to the number of observations, "
+            f"got seasonal_period={value} and n_timepoints={n_timepoints}."
+        )
+    return int(value)
+
+
 class NaiveForecaster(
     BaseForecaster, DirectForecastingMixin, IterativeForecastingMixin
 ):
@@ -27,7 +39,6 @@ class NaiveForecaster(
             - "last" predicts the last value of the input series for all horizon steps.
             - "mean": predicts the mean of the input series for all horizon steps.
             - "seasonal_last": predicts the last season value in the training series.
-              Returns np.nan if the effective seasonal data is empty.
     seasonal_period : int, default=1
         The seasonal period to use for the "seasonal_last" strategy.
         E.g., 12 for monthly data with annual seasonality.
@@ -55,8 +66,12 @@ class NaiveForecaster(
         elif self.strategy == "mean":
             return np.mean(y_squeezed)
         elif self.strategy == "seasonal_last":
-            period = y_squeezed[-self.seasonal_period :]
-            idx = (self.horizon - 1) % self.seasonal_period
+            y_squeezed = np.ravel(y_squeezed)
+            seasonal_period = _validate_seasonal_period(
+                self.seasonal_period, y_squeezed.shape[-1]
+            )
+            period = y_squeezed[-seasonal_period:]
+            idx = (self.horizon - 1) % seasonal_period
             return period[idx]
         else:
             raise ValueError(

--- a/aeon/forecasting/tests/test_naive.py
+++ b/aeon/forecasting/tests/test_naive.py
@@ -61,6 +61,27 @@ def test_naive_forecaster_seasonal_last_strategy():
     np.testing.assert_array_equal(pred, expected)
 
 
+@pytest.mark.parametrize("seasonal_period", [0, -1, 1.5, "2", True])
+def test_naive_forecaster_seasonal_last_rejects_invalid_period(seasonal_period):
+    """Test seasonal_last rejects invalid seasonal periods."""
+    forecaster = NaiveForecaster(
+        strategy="seasonal_last", seasonal_period=seasonal_period
+    )
+
+    with pytest.raises(ValueError, match="seasonal_period must be a positive integer"):
+        forecaster.predict(np.arange(5.0))
+
+
+def test_naive_forecaster_seasonal_last_rejects_period_longer_than_series():
+    """Test seasonal_last rejects periods longer than the observed series."""
+    forecaster = NaiveForecaster(
+        strategy="seasonal_last", seasonal_period=10, horizon=10
+    )
+
+    with pytest.raises(ValueError, match="number of observations"):
+        forecaster.predict(np.arange(5.0))
+
+
 def test_predict():
     """Test different input for private predict."""
     forecaster = NaiveForecaster(strategy="mean")


### PR DESCRIPTION
Fixes #3576.

## Summary
- validate `seasonal_period` for `NaiveForecaster(strategy="seasonal_last")`
- raise clear `ValueError`s for non-positive/non-integer periods and periods longer than the observed series
- add regression coverage for both issue cases

## Tests
- `python -m py_compile aeon\forecasting\_naive.py aeon\forecasting\tests\test_naive.py`
- lightweight regression script executing the updated seasonal_last path

`pytest aeon\forecasting\tests\test_naive.py -q` was not run because the local Python 3.11 environment did not have the project dependencies installed, and dependency installation timed out.