### PR TITLE
[BUG] AutoARIMA: never select differencing order above max_d

### DIFF
--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -431,7 +431,7 @@ class AutoARIMA(BaseForecaster, IterativeForecastingMixin):
         series = np.array(y.squeeze(), dtype=np.float64)
         differenced_series = series.copy()
         self.d_ = 0
-        while not kpss_test(differenced_series)[1] and self.d_ <= self.max_d:
+        while not kpss_test(differenced_series)[1] and self.d_ < self.max_d:
             differenced_series = np.diff(differenced_series, n=1)
             self.d_ += 1
         include_constant = 1 if self.d_ == 0 else 0

--- a/aeon/forecasting/stats/tests/test_arima.py
+++ b/aeon/forecasting/stats/tests/test_arima.py
@@ -250,6 +250,19 @@ def test_autoarima_fit_sets_model_and_orders_within_bounds():
     assert 0 <= forecaster.q_ <= forecaster.max_q
 
 
+def test_autoarima_respects_max_d_zero():
+    """AutoARIMA(max_d=0) must not apply any non-seasonal differencing.
+
+    A pure trend series is non-stationary, so the differencing loop would
+    otherwise apply one difference; with max_d=0 the fitted order must stay 0.
+    Regression test for #3577.
+    """
+    y_trend = np.arange(50, dtype=float)
+    forecaster = AutoARIMA(max_d=0)
+    forecaster.fit(y_trend)
+    assert forecaster.d_ == 0
+
+
 def test_autoarima_predict_returns_finite_float():
     """_predict should return a finite float once fitted."""
     forecaster = AutoARIMA()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #3577.

#### What does this implement/fix?

`AutoARIMA._fit` could select a non-seasonal differencing order greater than `max_d`. The loop condition was:

```python
while not kpss_test(differenced_series)[1] and self.d_ <= self.max_d:
    differenced_series = np.diff(differenced_series, n=1)
    self.d_ += 1
```

Because of `self.d_ <= self.max_d`, the loop could enter when `self.d_ == self.max_d`, apply one more difference, and set `self.d_ = self.max_d + 1`. For `max_d=0` this produced `d_ == 1`, i.e. differencing was applied even though the user disabled it.

Changed the condition to `self.d_ < self.max_d`, so a new difference is only applied while `d_` is strictly below the configured maximum. The fitted order now always satisfies `0 <= d_ <= max_d`.

#### Test

Added `test_autoarima_respects_max_d_zero`: `AutoARIMA(max_d=0).fit(np.arange(50.))` now yields `d_ == 0` (it returned `1` before this change).