### PR TITLE
Fix AutoARIMA(max_d=0) still differencing once

### DIFF
--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -431,7 +431,7 @@ class AutoARIMA(BaseForecaster, IterativeForecastingMixin):
         series = np.array(y.squeeze(), dtype=np.float64)
         differenced_series = series.copy()
         self.d_ = 0
-        while not kpss_test(differenced_series)[1] and self.d_ <= self.max_d:
+        while not kpss_test(differenced_series)[1] and self.d_ < self.max_d:
             differenced_series = np.diff(differenced_series, n=1)
             self.d_ += 1
         include_constant = 1 if self.d_ == 0 else 0


### PR DESCRIPTION
The while loop used `self.d_ <= self.max_d`, so when max_d=0 the loop could still enter (d_=0 <= 0 is true), apply np.diff, and set d_=1. Changed to `<` so the loop stops before exceeding the limit.

Closes #3577