### PR TITLE
[BUG] Relegate flat test to a warning

### DIFF
--- a/aeon/base/_base_collection.py
+++ b/aeon/base/_base_collection.py
@@ -19,6 +19,7 @@ State:
     fitted state inspection - check_is_fitted()
 """
 
+import warnings
 from abc import abstractmethod
 
 import numpy as np
@@ -196,7 +197,16 @@ class BaseCollectionEstimator(BaseAeonEstimator):
             )
             raise ValueError(msg)
 
-        check_collection_variance(X)
+        if not check_collection_variance(X, raise_error=False):
+            warnings.warn(
+                f"Data seen by instance of {type(self).__name__} has one or more "
+                "case/channel pairs with very little variation (std <= 1e-07). "
+                "Some aeon methods may treat these series as effectively constant. "
+                "If this is unintended, rescale (e.g., multiply by a constant) or "
+                "normalise your data.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         return metadata
 

--- a/aeon/base/tests/test_base_collection.py
+++ b/aeon/base/tests/test_base_collection.py
@@ -230,6 +230,22 @@ def test_preprocess_collection(data):
     assert meta == cls.metadata_
 
 
+def test_check_X_low_variance_warns():
+    """Test near-constant data warns rather than raises in _check_X.
+
+    Interval and shapelet based estimators call transformers on small subseries
+    internally, which are often near-constant. A hard error here aborts fits on
+    valid data, see issue #3570.
+    """
+    dummy = MockClassifier()
+    X = np.ones((5, 1, 10))
+    X[0][0][0] += 1e-8
+
+    with pytest.warns(UserWarning, match="very little variation"):
+        meta = dummy._check_X(X)
+    assert meta
+
+
 def test_convert_np_list():
     """Test np-list of 1D numpy converted to 2D."""
     x1 = np.random.random(size=(1, 10))

--- a/aeon/classification/tests/test_sklearn_compatability.py
+++ b/aeon/classification/tests/test_sklearn_compatability.py
@@ -108,8 +108,15 @@ def test_sklearn_parameter_tuning(parameter_tuning_method):
     X, y = make_example_3d_numpy(
         n_cases=20, n_channels=2, n_timepoints=30, min_cases_per_label=10
     )
+
+    # seed the search where possible, the unstratified random subsampling in the
+    # halving methods can otherwise produce single class folds which raise an error
+    kwargs = {}
+    if parameter_tuning_method is not GridSearchCV:
+        kwargs["random_state"] = 0
+
     parameter_tuning_method = parameter_tuning_method(
-        clf, param_grid, cv=StratifiedKFold(n_splits=2)
+        clf, param_grid, cv=StratifiedKFold(n_splits=2), **kwargs
     )
     parameter_tuning_method.fit(X, y)
     assert isinstance(


### PR DESCRIPTION
Fixes overnight test fail for hybrid notebook, fixes #3570 

 - aeon/base/_base_collection.py:199 — _check_X now calls check_collection_variance(X, raise_error=False) and emits a UserWarning instead of raising, so near-constant internal slices no longer abort fits. The standalone check_collection_variance() function still raises by default for anyone calling it directly.
  - aeon/base/tests/test_base_collection.py — added test_check_X_low_variance_warns as a regression test.

Verified three ways: the exact input that crashed the notebook (first difference of ItalyPowerDemand case 15, interval [13:16], std =  5.3e-9) now completes Catch22.fit_transform with a warning; the notebook's HC2 cell (HIVECOTEV2(time_limit_in_minutes=0.2) on  ItalyPowerDemand) runs end-to-end with accuracy 1.0; and the 122 base/validation tests all pass. One caveat on my earlier message: the
  "0/10 seeds failed" DrCIF repro was accidentally run against a stale aeon 1.5.0 install in .venv, so it was meaningless — the  deterministic slice-level evidence is what confirms the diagnosis and the fix.
