### PR TITLE
[BUG] Fix sporadic fail for Inception time file save

### DIFF
--- a/aeon/regression/deep_learning/_inception_time.py
+++ b/aeon/regression/deep_learning/_inception_time.py
@@ -752,13 +752,14 @@ class IndividualInceptionRegressor(BaseDeepRegressor):
             callbacks=self.callbacks_,
         )
 
-        try:
-            self.model_ = tf.keras.models.load_model(
-                self.file_path + self.file_name_ + ".keras", compile=False
-            )
+        # with save_best_only=True the checkpoint file is not guaranteed to have
+        # been written, fall back to the trained model if it is missing
+        file_path = self.file_path + self.file_name_ + ".keras"
+        if os.path.exists(file_path):
+            self.model_ = tf.keras.models.load_model(file_path, compile=False)
             if not self.save_best_model:
-                os.remove(self.file_path + self.file_name_ + ".keras")
-        except FileNotFoundError:
+                os.remove(file_path)
+        else:
             self.model_ = deepcopy(self.training_model_)
 
         if self.save_last_model:

--- a/aeon/regression/deep_learning/tests/test_inception_time.py
+++ b/aeon/regression/deep_learning/tests/test_inception_time.py
@@ -7,7 +7,10 @@ import tempfile
 import numpy as np
 import pytest
 
-from aeon.regression.deep_learning import InceptionTimeRegressor
+from aeon.regression.deep_learning import (
+    InceptionTimeRegressor,
+    IndividualInceptionRegressor,
+)
 from aeon.testing.data_generation import make_example_3d_numpy
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
@@ -47,3 +50,48 @@ def test_save_load_inceptiontime():
 
         assert len(preds) == len(y)
         np.testing.assert_array_equal(preds, y_pred_orig)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("tensorflow", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_inception_missing_checkpoint_fallback(monkeypatch):
+    """Test fit completes when the best-model checkpoint is never written."""
+    with tempfile.TemporaryDirectory() as temp:
+        temp_dir = os.path.join(temp, "")
+
+        X, y = make_example_3d_numpy(
+            n_cases=10,
+            n_channels=1,
+            n_timepoints=12,
+            return_y=True,
+            regression_target=True,
+        )
+
+        # stop the ModelCheckpoint callback being added so no .keras file is
+        # written during fit, simulating a checkpoint that was never saved
+        monkeypatch.setattr(
+            IndividualInceptionRegressor,
+            "_get_model_checkpoint_callback",
+            lambda self, callbacks, file_path, file_name: callbacks,
+        )
+
+        model = IndividualInceptionRegressor(
+            n_epochs=1,
+            batch_size=4,
+            depth=1,
+            kernel_size=4,
+            use_residual=False,
+            random_state=42,
+            file_path=temp_dir,
+            callbacks=[],
+        )
+        model.fit(X, y)
+
+        assert model.model_ is not None
+        assert glob.glob(os.path.join(temp_dir, "*.keras")) == []
+
+        preds = model.predict(X)
+        assert isinstance(preds, np.ndarray)
+        assert len(preds) == len(y)


### PR DESCRIPTION
Reference Issues/PRs

Fixes #3595.

IndividualInceptionRegressor._fit loads the temporary best-model checkpoint after training and previously guarded this with except FileNotFoundError.

However, Keras raises ValueError, not FileNotFoundError, when load_model is called on a missing .keras path. With ModelCheckpoint(save_best_only=True), the checkpoint file is occasionally never written. When that happened, the ValueError escaped and fit crashed, causing the intermittent CI failure in check_regressor_random_state_deep_learning seen in #3595:

ValueError: File not found: filepath=./1782872340055533900.keras.
Please ensure the file is an accessible `.keras` zip file.

This PR replaces the try/except with an explicit os.path.exists check on the checkpoint path:

if the checkpoint exists, it is loaded with compile=False and removed when save_best_model=False, preserving existing behaviour;
if the checkpoint does not exist, model_ falls back to a copy of the trained in-memory model;
no broad ValueError is caught, so genuine model-loading or deserialisation errors still surface.

This PR also adds a fast regression test that simulates the missing-checkpoint case by preventing the ModelCheckpoint callback from being added, then asserts that fit completes, no .keras file was written, and predict works.

Note: the same except FileNotFoundError pattern exists in other deep-learning modules, including classification, clustering, forecasting, and self-supervised transformers, so they may be susceptible to the same intermittent failure. This PR deliberately only fixes the regressor that failed in CI; aligning the others is left for a follow-up.


Verified locally:

both tests in test_inception_time.py pass;
the exact failing CI check, check_regressor_random_state_deep_learning on IndividualInceptionRegressor, passes;
pre-commit is clean on the modified files.