### PR TITLE
[BUG] KASBA fix and clustering tests

### DIFF
--- a/aeon/clustering/averaging/_kasba_average.py
+++ b/aeon/clustering/averaging/_kasba_average.py
@@ -177,10 +177,20 @@ def kasba_average(
         distances_to_center = pw_dist.flatten()
 
         # Cost is the sum of distance to the cent
-        if abs(previous_cost - cost) < tol:
+        if not np.isfinite(cost):
+            barycenter = prev_barycenter
+            distances_to_center = previous_distance_to_center
+            cost = previous_cost
+            if verbose:
+                print(  # noqa: T001, T201
+                    f"[KASBA-BA] epoch {i}, early convergence non-finite cost"
+                )
+            break
+        elif abs(previous_cost - cost) < tol:
             if previous_cost < cost:
                 barycenter = prev_barycenter
                 distances_to_center = previous_distance_to_center
+                cost = previous_cost
 
             if verbose:
                 print(  # noqa: T001, T201
@@ -191,6 +201,7 @@ def kasba_average(
         elif previous_cost < cost:
             barycenter = prev_barycenter
             distances_to_center = previous_distance_to_center
+            cost = previous_cost
             if verbose:
                 print(  # noqa: T001, T201
                     f"[KASBA-BA] epoch {i}, early convergence cost increasing: {cost} "

--- a/aeon/clustering/tests/test_k_medoids.py
+++ b/aeon/clustering/tests/test_k_medoids.py
@@ -9,6 +9,7 @@ from sklearn import metrics
 from aeon.clustering._cluster_initialisation import _CENTRE_INITIALISER_INDEXES
 from aeon.clustering._k_medoids import TimeSeriesKMedoids
 from aeon.datasets import load_basic_motions, load_gunpoint
+from aeon.testing.data_generation import make_example_3d_numpy
 
 
 def test_kmedoids_uni():
@@ -253,3 +254,128 @@ def test_medoids_init_invalid():
             random_state=1,
         )
         kmedoids.fit(X_train)
+
+
+def _small_data(n_cases=12, seed=0):
+    return make_example_3d_numpy(n_cases, 1, 10, random_state=seed, return_y=False)
+
+
+def test_kmedoids_callable_distance_predict():
+    """Fit and predict work with a callable distance."""
+    from aeon.distances import euclidean_distance
+
+    X = _small_data()
+    km = TimeSeriesKMedoids(
+        n_clusters=2,
+        distance=euclidean_distance,
+        method="alternate",
+        n_init=1,
+        random_state=1,
+    )
+    km.fit(X)
+    preds = km.predict(X)
+    assert preds.shape == (12,)
+    assert set(np.unique(preds)) <= {0, 1}
+
+
+@pytest.mark.parametrize("method", ["alternate", "pam"])
+def test_kmedoids_index_array_init(method):
+    """A fixed array of medoid indexes is used directly by both methods."""
+    X = _small_data()
+    km = TimeSeriesKMedoids(
+        n_clusters=2,
+        init=np.array([0, 1]),
+        method=method,
+        n_init=1,
+        random_state=1,
+    )
+    km.fit(X)
+    assert km.labels_.shape == (12,)
+    assert len(np.unique(km.labels_)) == 2
+    assert np.isfinite(km.inertia_)
+
+
+def test_kmedoids_build_init():
+    """The PAM BUILD initialiser runs and warns when n_init > 1."""
+    X = _small_data()
+    km = TimeSeriesKMedoids(
+        n_clusters=3, init="build", method="pam", n_init=1, random_state=1
+    )
+    km.fit(X)
+    assert km.labels_.shape == (12,)
+    assert len(np.unique(km.labels_)) == 3
+
+    with pytest.warns(UserWarning, match="n_init will be set to 1"):
+        TimeSeriesKMedoids(
+            n_clusters=2, init="build", method="pam", n_init=5, random_state=1
+        ).fit(X)
+
+
+def test_kmedoids_param_validation():
+    """Invalid method and oversized n_clusters raise at fit time."""
+    X = _small_data(n_cases=5)
+    with pytest.raises(ValueError, match="method invalid is not supported"):
+        TimeSeriesKMedoids(n_clusters=2, method="invalid").fit(X)
+    with pytest.raises(ValueError, match="cannot be larger than"):
+        TimeSeriesKMedoids(n_clusters=10).fit(X)
+
+
+@pytest.mark.parametrize("method", ["alternate", "pam"])
+def test_kmedoids_verbose_output(method, capsys):
+    """Verbose fits report convergence or per-iteration inertia."""
+    X = _small_data(n_cases=15, seed=2)
+    km = TimeSeriesKMedoids(
+        n_clusters=2,
+        method=method,
+        n_init=1,
+        verbose=True,
+        random_state=2,
+        init="first",
+    )
+    km.fit(X)
+    out = capsys.readouterr().out
+    assert "Converged" in out or "inertia" in out
+
+
+def test_kmedoids_pam_large_tol_stops_early(capsys):
+    """A huge tolerance triggers the inertia-based convergence exit."""
+    X = _small_data(n_cases=15, seed=3)
+    km = TimeSeriesKMedoids(
+        n_clusters=2,
+        method="pam",
+        n_init=1,
+        tol=1e15,
+        random_state=3,
+        init="first",
+        verbose=True,
+    )
+    km.fit(X)
+    assert km.n_iter_ <= 3
+    assert "Converged" in capsys.readouterr().out
+
+
+def test_kmedoids_pam_max_iter_warns():
+    """Hitting max_iter without convergence emits a ConvergenceWarning."""
+    from sklearn.exceptions import ConvergenceWarning
+
+    X = _small_data(n_cases=15, seed=4)
+    km = TimeSeriesKMedoids(
+        n_clusters=2,
+        method="pam",
+        n_init=1,
+        max_iter=1,
+        random_state=4,
+        init="first",
+    )
+    with pytest.warns(ConvergenceWarning, match="Maximum number of iteration"):
+        km.fit(X)
+
+
+def test_kmedoids_distance_cache_symmetry():
+    """The distance cache is honoured in either orientation."""
+    X = _small_data(n_cases=4)
+    km = TimeSeriesKMedoids(n_clusters=2, random_state=0)
+    km._check_params(X)
+    # only the reversed orientation is populated
+    km._distance_cache[1, 0] = 7.0
+    assert km._compute_distance(X, 0, 1) == 7.0

--- a/aeon/clustering/tests/test_k_shape.py
+++ b/aeon/clustering/tests/test_k_shape.py
@@ -1,0 +1,141 @@
+"""Tests for KShape clustering."""
+
+import numpy as np
+import pytest
+
+from aeon.clustering import KShape
+from aeon.clustering._k_shape import (
+    _ncc_time_major,
+    _sbd_align_1d,
+    _shape_extraction,
+    _shift_zeropad_1d,
+)
+from aeon.testing.data_generation import make_example_3d_numpy
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_kshape_fit_structure(n_channels):
+    """Fitted KShape produces a valid partition, centres and diagnostics."""
+    n_cases, n_timepoints, n_clusters = 12, 12, 2
+    X = make_example_3d_numpy(
+        n_cases, n_channels, n_timepoints, random_state=1, return_y=False
+    )
+
+    ks = KShape(n_clusters=n_clusters, random_state=1)
+    ks.fit(X)
+
+    assert ks.labels_.shape == (n_cases,)
+    assert np.issubdtype(ks.labels_.dtype, np.integer)
+    assert set(np.unique(ks.labels_)) <= set(range(n_clusters))
+
+    assert ks.cluster_centres_.shape == (n_clusters, n_channels, n_timepoints)
+    assert np.all(np.isfinite(ks.cluster_centres_))
+
+    assert np.isfinite(ks.inertia_) and ks.inertia_ >= 0
+    assert ks.n_iter_ >= 1
+
+    preds = ks.predict(X)
+    assert preds.shape == (n_cases,)
+    assert set(np.unique(preds)) <= set(range(n_clusters))
+
+
+def test_kshape_no_z_normalise_and_multiple_inits():
+    """z_normalise=False and n_init > 1 both fit and predict cleanly."""
+    X = make_example_3d_numpy(10, 1, 10, random_state=2, return_y=False)
+    ks = KShape(n_clusters=2, z_normalise=False, n_init=2, random_state=2)
+    ks.fit(X)
+    preds = ks.predict(X)
+    assert preds.shape == (10,)
+    assert np.isfinite(ks.inertia_)
+
+
+def test_kshape_zero_and_array_init():
+    """'zero' and explicit ndarray initial centres are both accepted."""
+    X = make_example_3d_numpy(10, 1, 10, random_state=3, return_y=False)
+
+    ks_zero = KShape(n_clusters=2, init="zero", random_state=3).fit(X)
+    assert ks_zero.cluster_centres_.shape == (2, 1, 10)
+
+    init = X[:2].copy()
+    ks_arr = KShape(n_clusters=2, init=init, random_state=3).fit(X)
+    assert ks_arr.cluster_centres_.shape == (2, 1, 10)
+
+
+def test_kshape_param_validation():
+    """Invalid constructor parameters raise at fit time."""
+    X = make_example_3d_numpy(6, 1, 8, random_state=0, return_y=False)
+
+    with pytest.raises(ValueError, match="n_clusters must be a positive integer"):
+        KShape(n_clusters=0).fit(X)
+    with pytest.raises(ValueError, match="cannot be larger than"):
+        KShape(n_clusters=10).fit(X)
+    with pytest.raises(ValueError, match="max_iter must be a positive integer"):
+        KShape(n_clusters=2, max_iter=0).fit(X)
+    with pytest.raises(ValueError, match="n_init must be a positive integer"):
+        KShape(n_clusters=2, n_init=0).fit(X)
+    with pytest.raises(ValueError, match="tol must be non-negative"):
+        KShape(n_clusters=2, tol=-1.0).fit(X)
+    with pytest.raises(ValueError, match="init must be 'random', 'zero'"):
+        KShape(n_clusters=2, init="bad").fit(X)
+    with pytest.raises(ValueError, match="If init is an array"):
+        KShape(n_clusters=2, init=np.zeros((3, 1, 8))).fit(X)
+
+
+def test_kshape_verbose_max_iter_and_tol(capsys):
+    """Verbose printing, the max_iter exit, and the tol-based exit."""
+    X = make_example_3d_numpy(10, 1, 10, random_state=4, return_y=False)
+
+    ks = KShape(n_clusters=2, max_iter=1, verbose=True, random_state=4).fit(X)
+    assert ks.n_iter_ == 1
+    assert "iter=1" in capsys.readouterr().out
+
+    # this configuration needs six iterations to reach label stability, so
+    # a huge tolerance must stop it early via the inertia criterion instead
+    X_big = make_example_3d_numpy(24, 1, 16, random_state=2, return_y=False)
+    baseline = KShape(n_clusters=3, max_iter=50, random_state=2).fit(X_big)
+    ks_tol = KShape(n_clusters=3, tol=1e12, max_iter=50, random_state=2).fit(X_big)
+    assert ks_tol.n_iter_ < baseline.n_iter_
+
+
+def test_kshape_empty_cluster_reseeded():
+    """Empty clusters are reseeded with a random training case."""
+    X = make_example_3d_numpy(5, 1, 8, random_state=5, return_y=False)
+    # more clusters than distinct random initial labels makes an empty
+    # cluster very likely; the fit must still produce valid output
+    ks = KShape(n_clusters=4, random_state=3, max_iter=5).fit(X)
+    assert ks.labels_.shape == (5,)
+    assert ks.cluster_centres_.shape == (4, 1, 8)
+    assert np.all(np.isfinite(ks.cluster_centres_))
+
+
+def test_shift_zeropad_1d():
+    """Zero-padded shifting covers all shift regimes."""
+    x = np.arange(1.0, 5.0)
+    np.testing.assert_array_equal(_shift_zeropad_1d(x, 0), x)
+    np.testing.assert_array_equal(_shift_zeropad_1d(x, 2), [0.0, 0.0, 1.0, 2.0])
+    np.testing.assert_array_equal(_shift_zeropad_1d(x, -2), [3.0, 4.0, 0.0, 0.0])
+    # shifts of at least the length blank the series entirely
+    np.testing.assert_array_equal(_shift_zeropad_1d(x, 5), np.zeros(4))
+    np.testing.assert_array_equal(_shift_zeropad_1d(x, -5), np.zeros(4))
+
+
+def test_ncc_time_major_zero_norm():
+    """Zero-norm inputs return an all-zero correlation."""
+    out = _ncc_time_major(np.zeros((6, 1)), np.zeros((6, 1)))
+    assert out.shape == (11,)
+    assert np.all(out == 0.0)
+
+
+def test_sbd_align_1d_zero_centre():
+    """A zero centre leaves the series unaligned."""
+    x = np.arange(5.0)
+    np.testing.assert_array_equal(_sbd_align_1d(np.zeros(5), x), x)
+
+
+def test_shape_extraction_input_validation():
+    """Shape extraction rejects empty and non-2D input."""
+    P = np.eye(4) - 0.25 * np.ones((4, 4))
+    with pytest.raises(ValueError, match="cannot be empty"):
+        _shape_extraction(np.empty((0, 4)), P)
+    with pytest.raises(ValueError, match="must be 2D"):
+        _shape_extraction(np.zeros(4), P)

--- a/aeon/clustering/tests/test_kasba.py
+++ b/aeon/clustering/tests/test_kasba.py
@@ -1,29 +1,59 @@
 """Test KASBA."""
 
 import numpy as np
+import pytest
 
-from aeon.benchmarking.metrics.clustering import clustering_accuracy_score
 from aeon.clustering import KASBA
 from aeon.testing.data_generation import make_example_3d_numpy
 
 
-def test_univariate_kasba():
-    """Test KASBA on univariate data."""
-    X, y = make_example_3d_numpy(20, 1, 10, random_state=1, return_y=True)
+@pytest.mark.parametrize("n_channels", [1, 3])
+def test_kasba_fit_structure(n_channels):
+    """Fitted KASBA produces a valid partition, centers and diagnostics."""
+    n_cases, n_timepoints, n_clusters = 20, 10, 2
+    X = make_example_3d_numpy(
+        n_cases, n_channels, n_timepoints, random_state=1, return_y=False
+    )
 
-    kasba = KASBA(n_clusters=len(np.unique(y)), random_state=1)
-
+    kasba = KASBA(n_clusters=n_clusters, random_state=1)
     kasba.fit(X)
-    score = clustering_accuracy_score(y, kasba.labels_)
-    assert score == 0.95
+
+    # labels form a valid partition over the requested clusters
+    assert kasba.labels_.shape == (n_cases,)
+    assert np.issubdtype(kasba.labels_.dtype, np.integer)
+    assert set(np.unique(kasba.labels_)) <= set(range(n_clusters))
+    # with more cases than clusters no cluster should be empty
+    assert len(np.unique(kasba.labels_)) == n_clusters
+
+    # centers have one average series per cluster
+    assert kasba.cluster_centers_.shape == (n_clusters, n_channels, n_timepoints)
+    assert np.all(np.isfinite(kasba.cluster_centers_))
+
+    # fit diagnostics
+    assert np.isfinite(kasba.inertia_) and kasba.inertia_ >= 0
+    assert kasba.n_iter_ >= 1
 
 
-def test_multivariate_kasba():
-    """Test KASBA on multivariate data."""
-    X, y = make_example_3d_numpy(20, 3, 10, random_state=1, return_y=True)
+@pytest.mark.parametrize("n_channels", [1, 3])
+def test_kasba_predict_consistent_with_fit(n_channels):
+    """Predict assigns training data to the same clusters as fit."""
+    X = make_example_3d_numpy(20, n_channels, 10, random_state=1, return_y=False)
 
-    kasba = KASBA(n_clusters=len(np.unique(y)), random_state=1)
-
+    kasba = KASBA(n_clusters=2, random_state=1)
     kasba.fit(X)
-    score = clustering_accuracy_score(y, kasba.labels_)
-    assert score == 0.55
+
+    preds = kasba.predict(X)
+    assert preds.shape == (20,)
+    # on convergence, assignment to the final centers reproduces labels_
+    assert np.array_equal(preds, kasba.labels_)
+
+
+def test_kasba_reproducible_with_random_state():
+    """The same random_state yields identical labels and centers."""
+    X = make_example_3d_numpy(20, 1, 10, random_state=1, return_y=False)
+
+    first = KASBA(n_clusters=2, random_state=7).fit(X)
+    second = KASBA(n_clusters=2, random_state=7).fit(X)
+
+    assert np.array_equal(first.labels_, second.labels_)
+    np.testing.assert_allclose(first.cluster_centers_, second.cluster_centers_)


### PR DESCRIPTION
1. removes a flaky KASBA correctness test on random data that sporadically fails
2. fixes #3606 that gives a sporadic fail by adding an infinity guard
3. adds more test coverage