### PR TITLE
[BUG] Fix nightly tests related to SFA failing

### DIFF
--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -653,7 +653,13 @@ class SFAFast(BaseCollectionTransformer):
             elif self.alphabet_allocation_method == "log_scale":
                 variance = np.log2((self.dft_variance[self.support]) + 1)
 
-            normed_scale = variance / variance.mean()
+            # Treat zero-mean-variance
+            variance_mean = variance.mean()
+            if variance_mean <= 0 or not np.isfinite(variance_mean):
+                normed_scale = np.ones_like(variance)
+            else:
+                normed_scale = variance / variance_mean
+
             self.letter_bits = assign_bits_dynamically(normed_scale, self.bit_budget)
             self.alphabet_sizes = [
                 int(2 ** self.letter_bits[i]) for i in range(len(self.letter_bits))
@@ -1349,7 +1355,7 @@ def create_dict(feature_names, features_idx):
     return relevant_features
 
 
-@njit(fastmath=True, cache=True, parallel=True)
+@njit(fastmath={"contract"}, cache=True, parallel=True)
 def mcb(dft, alphabet_sizes, word_length_actual, binning_method):
     max_alphabet_size = np.max(alphabet_sizes)
 
@@ -1450,7 +1456,7 @@ def _transform_words_case(
     return words, dfts
 
 
-@njit(fastmath=True, cache=True)
+@njit(fastmath={"contract"}, cache=True)
 def assign_bits_dynamically(variance, budget, max_bit_val=9):
     """Assign bits dynamically based on variance and budget.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-env",
     "pytest-doctestplus",
     "pytest-mock",
     "pytest-randomly",
@@ -195,6 +196,9 @@ filterwarnings = [
     "ignore::UserWarning",
     "ignore:numpy.dtype size changed",
     "ignore:numpy.ufunc size changed",
+]
+env = [
+    "NUMBA_DISABLE_JIT=1",
 ]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "pytest-env",
     "pytest-doctestplus",
     "pytest-mock",
     "pytest-randomly",
@@ -196,9 +195,6 @@ filterwarnings = [
     "ignore::UserWarning",
     "ignore:numpy.dtype size changed",
     "ignore:numpy.ufunc size changed",
-]
-env = [
-    "NUMBA_DISABLE_JIT=1",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
Nightly tests occasionally fail due to errors with sfa.
See: https://github.com/aeon-toolkit/aeon/actions/runs/28651558930/job/84970580199?pr=3602

The root cause is likely related to division by zero and numba handing NaN values incorrectly when using fastmath.

Fixes:
- Change to fastmath={"contract"} for MCB discretization
- Fix division by zero for dynamic alphabet computation

