### PR TITLE
[MNT] Fix test_dispatch_loss_unknown_id_raises to use ID 3

### DIFF
--- a/aeon/forecasting/utils/tests/test_utils.py
+++ b/aeon/forecasting/utils/tests/test_utils.py
@@ -181,7 +181,7 @@ def test_dispatch_loss_unknown_id_raises():
     """An unknown loss function id raises a ValueError."""
     with pytest.raises(ValueError):
         dispatch_loss(
-            2,
+            3,
             np.array([0.5]),
             np.arange(10.0),
             np.array([1, 0, 0, 1], dtype=np.int32),


### PR DESCRIPTION
This pull request fixes the test failure/segfault in test_dispatch_loss_unknown_id_raises by changing the unknown function ID from 2 to 3, resolving the conflict with the new SARIMA function ID mapping.