### PR TITLE
[BUG] Respect outlier_norm in pycatch22 path

### DIFF
--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -408,7 +408,7 @@ class Catch22(BaseCollectionTransformer):
 
                 if self.outlier_norm and feature in [3, 4]:
                     c22[dim + n] = features[feature](outlier_series)
-                if feature == 22:
+                elif feature == 22:
                     c22[dim + n] = np.mean(series)
                 elif feature == 23:
                     c22[dim + n] = np.std(series)

--- a/aeon/transformations/collection/feature_based/tests/test_catch22.py
+++ b/aeon/transformations/collection/feature_based/tests/test_catch22.py
@@ -76,6 +76,20 @@ def test_catch22_wrapper_on_basic_motions():
     )
 
 
+def test_catch22_wrapper_outlier_norm():
+    """Test outlier features use the normalised series in the pycatch22 path."""
+    c22 = Catch22(use_pycatch22=True, outlier_norm=True)
+    features = [None] * 24
+    features[3] = np.mean
+    features[4] = np.mean
+
+    result = c22._transform_case_pycatch22(
+        np.array([[1.0, 2.0, 6.0]]), [3, 4], features
+    )
+
+    testing.assert_allclose(result, 0, atol=1e-12)
+
+
 feature_names = ["DN_HistogramMode_5", "CO_f1ecac", "FC_LocalSimple_mean3_stderr"]
 
 feature_names_short = [


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3632.

#### What does this implement/fix? Explain your changes.

Changes the pycatch22 dispatch chain so the two `DN_OutlierInclude` features keep the result computed from the z-normalised series when `outlier_norm=True`, rather than immediately overwriting it with a result from the raw series.

Adds a focused regression test covering both affected feature indices without requiring the optional pycatch22 dependency.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Validation:
- `python -m ruff check aeon/transformations/collection/feature_based/_catch22.py aeon/transformations/collection/feature_based/tests/test_catch22.py`
- `python -m py_compile aeon/transformations/collection/feature_based/_catch22.py aeon/transformations/collection/feature_based/tests/test_catch22.py`
- `git diff --check`
- Extracted-method regression probe against the changed `_transform_case_pycatch22` implementation

The repository's targeted pytest command could not run locally because this disk-constrained runner does not have aeon's scientific Python dependencies installed (`numba` is the first missing import). The focused test is included for the upstream CI environment.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, I will use the all-contributors bot after the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV].

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.
