### PR TITLE
[BUG] Uniformize kernelspace name and display_name across notebooks

### DIFF
--- a/examples/anomaly_detection/anomaly_detection.ipynb
+++ b/examples/anomaly_detection/anomaly_detection.ipynb
@@ -242,7 +242,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/base/base_classes.ipynb
+++ b/examples/base/base_classes.ipynb
@@ -351,7 +351,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aeon_dev_311",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/benchmarking/benchmarking.ipynb
+++ b/examples/benchmarking/benchmarking.ipynb
@@ -34,7 +34,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/convolution_based.ipynb
+++ b/examples/classification/convolution_based.ipynb
@@ -580,7 +580,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/deep_learning.ipynb
+++ b/examples/classification/deep_learning.ipynb
@@ -297,7 +297,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/distance_based.ipynb
+++ b/examples/classification/distance_based.ipynb
@@ -499,7 +499,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/feature_based.ipynb
+++ b/examples/classification/feature_based.ipynb
@@ -467,7 +467,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aeon_cenv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/rotation_forest.ipynb
+++ b/examples/classification/rotation_forest.ipynb
@@ -181,7 +181,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myaeon",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/classification/shapelet_based.ipynb
+++ b/examples/classification/shapelet_based.ipynb
@@ -979,7 +979,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (Spyder)",
+   "display_name": "Python 3",
    "language": "python3",
    "name": "python3"
   },

--- a/examples/clustering/clustering.ipynb
+++ b/examples/clustering/clustering.ipynb
@@ -154,7 +154,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/clustering/feature_based_clustering.ipynb
+++ b/examples/clustering/feature_based_clustering.ipynb
@@ -1457,7 +1457,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/forecasting/forecasting.ipynb
+++ b/examples/forecasting/forecasting.ipynb
@@ -361,7 +361,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aeon-venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/forecasting/iterative.ipynb
+++ b/examples/forecasting/iterative.ipynb
@@ -289,7 +289,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aeon-venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/forecasting/stats/theta.ipynb
+++ b/examples/forecasting/stats/theta.ipynb
@@ -307,7 +307,7 @@
   "kernelspec": {
    "name": "python3",
    "language": "python",
-   "display_name": "Python 3 (ipykernel)"
+   "display_name": "Python 3"
   }
  },
  "nbformat": 4,

--- a/examples/networks/deep_learning.ipynb
+++ b/examples/networks/deep_learning.ipynb
@@ -782,7 +782,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 ('aeon-dev')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/segmentation/segmentation.ipynb
+++ b/examples/segmentation/segmentation.ipynb
@@ -31,7 +31,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/segmentation/segmentation_with_clasp.ipynb
+++ b/examples/segmentation/segmentation_with_clasp.ipynb
@@ -442,7 +442,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/similarity_search/code_speed.ipynb
+++ b/examples/similarity_search/code_speed.ipynb
@@ -663,9 +663,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (aeon .venv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "aeon-venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/similarity_search/distance_profiles.ipynb
+++ b/examples/similarity_search/distance_profiles.ipynb
@@ -408,7 +408,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (Spyder)",
+   "display_name": "Python 3",
    "language": "python3",
    "name": "python3"
   },

--- a/examples/transformations/channel_selection.ipynb
+++ b/examples/transformations/channel_selection.ipynb
@@ -148,7 +148,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "scikit-time",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/transformations/minirocket.ipynb
+++ b/examples/transformations/minirocket.ipynb
@@ -2245,7 +2245,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 ('env_aeon')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/transformations/smoothing_filters.ipynb
+++ b/examples/transformations/smoothing_filters.ipynb
@@ -358,7 +358,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/visualisation/plotting_distances.ipynb
+++ b/examples/visualisation/plotting_distances.ipynb
@@ -134,7 +134,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myaeon",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/visualisation/plotting_estimators.ipynb
+++ b/examples/visualisation/plotting_estimators.ipynb
@@ -2510,7 +2510,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myaeon",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/visualisation/plotting_results.ipynb
+++ b/examples/visualisation/plotting_results.ipynb
@@ -584,7 +584,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aeon",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Introduced in #3222, modified a kernelspace name in notebook metadata, causing a crash in the CI for the code speed notebook.

Uniformized the kernelspace name and display name across all notebooks