### PR TITLE
[BUG] fix SFA.get_words() crash when window_size < n_timepoints

### DIFF
--- a/aeon/transformations/collection/dictionary_based/_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa.py
@@ -477,8 +477,13 @@ class SFA(BaseCollectionTransformer):
         Array of words
         """
         words = np.squeeze(self.words)
+        if words.ndim == 1:
+            words = words.reshape(1, -1)
         return np.array(
-            [_get_chars(word, self.word_length, self.alphabet_size) for word in words]
+            [
+                [_get_chars(w, self.word_length, self.alphabet_size) for w in case]
+                for case in words
+            ]
         )
 
     def _binning(self, X, y=None):

--- a/aeon/transformations/collection/dictionary_based/_sfa_fast.py
+++ b/aeon/transformations/collection/dictionary_based/_sfa_fast.py
@@ -776,8 +776,13 @@ class SFAFast(BaseCollectionTransformer):
         Array of words
         """
         words = np.squeeze(self.words)
+        if words.ndim == 1:
+            words = words.reshape(1, -1)
         return np.array(
-            [_get_chars(word, self.word_length, self.letter_bits) for word in words]
+            [
+                [_get_chars(w, self.word_length, self.letter_bits) for w in case]
+                for case in words
+            ]
         )
 
     def transform_words(self, X):

--- a/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
+++ b/aeon/transformations/collection/dictionary_based/tests/test_sfa.py
@@ -286,3 +286,22 @@ def test_sfa_dynamic(alphabet_allocation_method):
 
     # Check if the budget is correctly allocated
     assert np.mean(np.log2(p.alphabet_sizes)) <= np.log2(alphabet_size)
+
+
+@pytest.mark.parametrize("cls", [SFA, SFAFast])
+def test_get_words_multiple_windows(cls):
+    """Test get_words works when window_size < n_timepoints.
+
+    Regression test for GH #3537: np.squeeze did not remove the n_windows
+    axis, causing _get_chars to receive an array instead of a scalar.
+    """
+    X = np.array([[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]]])
+    y = np.array([0])
+
+    sfa = cls(word_length=4, alphabet_size=4, window_size=6, save_words=True)
+    sfa.fit(X, y)
+    sfa.transform(X)
+
+    words = sfa.get_words()
+    # 1 case, 5 windows, 4 letters per word
+    assert words.shape == (1, 5, 4)


### PR DESCRIPTION
## Fix

Fixes #3537

### Problem

Both `SFA.get_words()` and `SFAFast.get_words()` raise a numba `TypingError` whenever a series has more than one sliding window (i.e. `window_size < n_timepoints`). `np.squeeze` does not remove the `n_windows` axis, so `_get_chars` receives an array instead of a scalar integer.

### Solution

Reshape to 2D after squeeze and iterate over `(n_cases, n_windows)`:
```python
words = np.squeeze(self.words)
if words.ndim == 1:
    words = words.reshape(1, -1)
return np.array([
    [_get_chars(w, self.word_length, ...) for w in case]
    for case in words
])
```

### Changes

- `_sfa.py`: Fixed `get_words()` iteration
- `_sfa_fast.py`: Fixed `get_words()` iteration
- `tests/test_sfa.py`: Added `test_get_words_multiple_windows` regression test

### Testing

All 82 existing SFA tests pass, plus the new regression test.