### PR TITLE
[BUG] fix outlier_norm using wrong feature indices in pycatch22 path

### DIFF
--- a/aeon/transformations/collection/feature_based/_catch22.py
+++ b/aeon/transformations/collection/feature_based/_catch22.py
@@ -398,7 +398,7 @@ class Catch22(BaseCollectionTransformer):
             dim = i * len(f_idx)
             series = list(X[i])
 
-            if self.outlier_norm and (3 in f_idx or 4 in f_idx):
+            if self.outlier_norm and (13 in f_idx or 14 in f_idx):
                 outlier_series = list(z_normalise_series(X[i]))
 
             for n, feature in enumerate(f_idx):
@@ -406,9 +406,9 @@ class Catch22(BaseCollectionTransformer):
                 if not transform_feature[f_count]:
                     continue
 
-                if self.outlier_norm and feature in [3, 4]:
+                if self.outlier_norm and feature in [13, 14]:
                     c22[dim + n] = features[feature](outlier_series)
-                if feature == 22:
+                elif feature == 22:
                     c22[dim + n] = np.mean(series)
                 elif feature == 23:
                     c22[dim + n] = np.std(series)

--- a/aeon/transformations/collection/feature_based/tests/test_catch22.py
+++ b/aeon/transformations/collection/feature_based/tests/test_catch22.py
@@ -1453,3 +1453,50 @@ catch22wrapper_basic_motions_data = np.array(
         ],
     ]
 )
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("pycatch22", severity="none"),
+    reason="skip test if required soft dependency pycatch22 not available",
+)
+def test_catch22_pycatch22_outlier_norm():
+    """Test that outlier_norm passes z-normalised series to DN_OutlierInclude.
+
+    Regression test for GH #3632: the outlier_norm condition checked the
+    wrong feature indices, so DN_OutlierInclude (features 13, 14) was
+    always computed on the raw series when use_pycatch22=True.
+    """
+    rng = np.random.RandomState(42)
+    X = rng.random((3, 1, 50))
+    X[0, 0, 5] = 100.0  # extreme outlier to ensure z-norm differs from raw
+
+    import pycatch22
+
+    passed_series = {}
+    real_p = pycatch22.DN_OutlierInclude_p_001_mdrmd
+    real_n = pycatch22.DN_OutlierInclude_n_001_mdrmd
+
+    def track_p(s):
+        passed_series["p"] = np.array(s)
+        return real_p(s)
+
+    def track_n(s):
+        passed_series["n"] = np.array(s)
+        return real_n(s)
+
+    pycatch22.DN_OutlierInclude_p_001_mdrmd = track_p
+    pycatch22.DN_OutlierInclude_n_001_mdrmd = track_n
+    try:
+        Catch22(use_pycatch22=True, outlier_norm=True, replace_nans=True).fit_transform(
+            X
+        )
+    finally:
+        pycatch22.DN_OutlierInclude_p_001_mdrmd = real_p
+        pycatch22.DN_OutlierInclude_n_001_mdrmd = real_n
+
+    # The series passed to DN_OutlierInclude should be z-normalised
+    # (mean ~ 0, std ~ 1) when outlier_norm=True
+    assert abs(np.mean(passed_series["p"])) < 1e-10
+    assert abs(np.std(passed_series["p"]) - 1.0) < 1e-10
+    assert abs(np.mean(passed_series["n"])) < 1e-10
+    assert abs(np.std(passed_series["n"]) - 1.0) < 1e-10


### PR DESCRIPTION
## Fix

Fixes #3632

### Problem

In `_transform_case_pycatch22`, the `outlier_norm` condition checked features `[3, 4]` (`CO_FirstMin_ac`, `CO_HistogramAMI_even_2_5`) instead of `[13, 14]` (`DN_OutlierInclude_p_001_mdrmd`, `DN_OutlierInclude_n_001_mdrmd`). This meant `DN_OutlierInclude` was always computed on the raw series when `use_pycatch22=True`, making `outlier_norm=True` ineffective for these features.

Additionally, `if feature == 22:` should be `elif feature == 22:` to prevent the `else` branch from overwriting the `outlier_norm` result.

The numba path (`_transform_case`) correctly uses features 13 and 14 for `outlier_norm`.

### Changes

- `_catch22.py`: Fixed feature indices `[3, 4]` → `[13, 14]` and changed `if` → `elif` for feature 22
- `tests/test_catch22.py`: Added `test_catch22_pycatch22_outlier_norm` regression test that uses mock to verify the z-normalised series is passed to `DN_OutlierInclude`

### Testing

All 4 existing catch22 tests pass, plus the new regression test.