### PR TITLE
[BUG] fix RandomShapeletTransform distance instability for high offsets

### DIFF
--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -821,18 +821,23 @@ def _online_shapelet_distance(series, shapelet, sorted_indicies, position, lengt
     if position + length > len(series):
         position = int((len(series) - length) / 2)
 
+    # Subtract a fixed reference before accumulating sum/sum-of-squares.
+    # This avoids catastrophic cancellation when the series has a large
+    # constant offset relative to its variance (see GH #3643).
+    ref = series[position]
     subseq = series[position : position + length]
 
     sum = 0.0
     sum2 = 0.0
     for i in subseq:
-        sum += i
-        sum2 += i * i
+        v = i - ref
+        sum += v
+        sum2 += v * v
 
     mean = sum / length
     std = math.sqrt((sum2 - mean * mean * length) / length)
     if std > AEON_NUMBA_STD_THRESHOLD:
-        subseq = (subseq - mean) / std
+        subseq = (subseq - (mean + ref)) / std
     else:
         subseq = np.zeros(length)
 
@@ -855,8 +860,8 @@ def _online_shapelet_distance(series, shapelet, sorted_indicies, position, lengt
             if not traverse[n]:
                 continue
 
-            start = series[pos - n]
-            end = series[pos - n + length]
+            start = series[pos - n] - ref
+            end = series[pos - n + length] - ref
 
             sums[n] += mod * end - mod * start
             sums2[n] += mod * end * end - mod * start * start
@@ -867,7 +872,11 @@ def _online_shapelet_distance(series, shapelet, sorted_indicies, position, lengt
             dist = 0
             use_std = std > AEON_NUMBA_STD_THRESHOLD
             for j in range(length):
-                val = (series[pos + sorted_indicies[j]] - mean) / std if use_std else 0
+                val = (
+                    (series[pos + sorted_indicies[j]] - (mean + ref)) / std
+                    if use_std
+                    else 0
+                )
                 temp = shapelet[sorted_indicies[j]] - val
                 dist += temp * temp
 

--- a/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/tests/test_shapelet_transform.py
@@ -1,0 +1,45 @@
+"""Tests for RandomShapeletTransform helpers."""
+
+import numpy as np
+
+from aeon.transformations.collection.shapelet_based._shapelet_transform import (
+    _online_shapelet_distance,
+)
+from aeon.utils.numba.general import z_normalise_series
+
+
+def test_online_shapelet_distance_offset_invariance():
+    """z-normalised shapelet distance should be invariant to constant offset.
+
+    Regression test for GH #3643: rolling variance used an unstable formula
+    that cancelled for high-offset, low-variance series, so adding a constant
+    could change the distance from ~0 to ~1.
+    """
+    rng = np.random.RandomState(0)
+    position = 30
+    length = 20
+
+    # Unit-scale series: float64 preserves the signal after adding a large offset.
+    series = rng.normal(size=100)
+    shapelet = z_normalise_series(series[position : position + length])
+    sorted_indices = np.argsort(np.abs(shapelet))[::-1].astype(np.int32)
+
+    base = _online_shapelet_distance(series, shapelet, sorted_indices, position, length)
+    shifted = _online_shapelet_distance(
+        series + 1e8, shapelet, sorted_indices, position, length
+    )
+    assert np.allclose(shifted, base, rtol=1e-8, atol=1e-8)
+
+    # High-offset, low-variance series from the issue report. Exact equality
+    # is limited by float64 quantisation of series+1e8, but the distance must
+    # stay near zero rather than collapsing to ~1.
+    series = rng.normal(scale=1e-5, size=100)
+    shapelet = z_normalise_series(series[position : position + length])
+    sorted_indices = np.argsort(np.abs(shapelet))[::-1].astype(np.int32)
+
+    base = _online_shapelet_distance(series, shapelet, sorted_indices, position, length)
+    shifted = _online_shapelet_distance(
+        series + 1e8, shapelet, sorted_indices, position, length
+    )
+    assert base < 1e-6
+    assert shifted < 1e-3


### PR DESCRIPTION
## Fix

Fixes #3643

### Problem

`_online_shapelet_distance` computed rolling variance as:

```python
std = math.sqrt((sum2 - mean * mean * length) / length)
```

When a series has a large constant offset and comparatively small variation, this subtracts two nearly equal large values (catastrophic cancellation). The resulting std is wrong (often effectively zero or meaningless), so z-normalised shapelet distances are no longer invariant to adding a constant.

Issue reproducer on main:

- `base_distance ≈ 0`
- `shifted_distance ≈ 1` after `series + 1e8`

### Solution

Subtract a fixed reference value (`series[position]`) before accumulating the rolling sum and sum of squares. This removes the large common offset without allocating a centred copy, and keeps the incremental update structure.

When reconstructing the true window mean for z-normalisation, use `mean + ref`.

### Changes

- `_shapelet_transform.py`: stable rolling sum / sum-of-squares in `_online_shapelet_distance`
- `tests/test_shapelet_transform.py`: regression test for offset invariance

### Testing

- New regression test covers:
  - unit-scale series with large offset (`allclose`)
  - high-offset, low-variance series from the issue (distance stays near 0, not ~1)
- Verified the unstable formula yields a bogus std (~1.26) on the issue data, while the fixed path recovers the true std (~1e-5)