### PR TITLE
[MNT] Deprecation of StatsModelsACF and StatsModelsPACF

### DIFF
--- a/aeon/transformations/series/_acf.py
+++ b/aeon/transformations/series/_acf.py
@@ -4,6 +4,7 @@ __maintainer__ = ["TonyBagnall"]
 __all__ = ["AutoCorrelationSeriesTransformer", "StatsModelsACF", "StatsModelsPACF"]
 
 import numpy as np
+from deprecated.sphinx import deprecated
 from numba import njit
 
 from aeon.transformations.series.base import BaseSeriesTransformer
@@ -131,8 +132,22 @@ class AutoCorrelationSeriesTransformer(BaseSeriesTransformer):
         return [{}, {"n_lags": 1}]
 
 
+# TODO: remove in v1.7.0
+@deprecated(
+    version="1.6.0",
+    reason=(
+        "StatsModelsACF is deprecated and will be removed in v1.7.0. "
+        "Use AutoCorrelationSeriesTransformer or statsmodels.tsa.stattools.acf "
+        "directly instead."
+    ),
+    category=FutureWarning,
+)
 class StatsModelsACF(BaseSeriesTransformer):
     """Auto-correlation wrapper for statsmodels.
+
+    Deprecated and will be removed in v1.7.0. Use
+    :class:`AutoCorrelationSeriesTransformer` or
+    :func:`statsmodels.tsa.stattools.acf` directly instead.
 
     The autocorrelation function measures how correlated a timeseries is
     with itself at different lags. The StatsModelsACF returns
@@ -254,8 +269,20 @@ class StatsModelsACF(BaseSeriesTransformer):
         return [{}, {"n_lags": 1}]
 
 
+# TODO: remove in v1.7.0
+@deprecated(
+    version="1.6.0",
+    reason=(
+        "StatsModelsPACF is deprecated and will be removed in v1.7.0. "
+        "Use statsmodels.tsa.stattools.pacf directly instead."
+    ),
+    category=FutureWarning,
+)
 class StatsModelsPACF(BaseSeriesTransformer):
     """Partial auto-correlation wrapper for statsmodels.
+
+    Deprecated and will be removed in v1.7.0. Use
+    :func:`statsmodels.tsa.stattools.pacf` directly instead.
 
     The partial autocorrelation function measures the conditional correlation
     between a timeseries and its self at different lags. In particular,

--- a/aeon/transformations/series/tests/test_acf.py
+++ b/aeon/transformations/series/tests/test_acf.py
@@ -6,8 +6,6 @@ from numpy.testing import assert_array_almost_equal
 
 from aeon.transformations.series._acf import (
     AutoCorrelationSeriesTransformer,
-    StatsModelsACF,
-    StatsModelsPACF,
 )
 
 
@@ -26,17 +24,6 @@ def test_acf():
     y = acf.fit_transform(x, axis=0)
     assert y.shape == (n_lags, 1)
     # Test with axis = 0
-
-
-@pytest.mark.parametrize(
-    "transformer",
-    [StatsModelsACF, StatsModelsPACF],
-)
-def test_statsmodels_transformers_deprecated(transformer):
-    """Test that statsmodels wrappers raise their deprecation warnings."""
-    match = f"{transformer.__name__}.*removed in v1.7.0"
-    with pytest.warns(FutureWarning, match=match):
-        transformer()
 
 
 TEST_DATA = [

--- a/aeon/transformations/series/tests/test_acf.py
+++ b/aeon/transformations/series/tests/test_acf.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from aeon.transformations.series._acf import AutoCorrelationSeriesTransformer
+from aeon.transformations.series._acf import (
+    AutoCorrelationSeriesTransformer,
+    StatsModelsACF,
+    StatsModelsPACF,
+)
 
 
 def test_acf():
@@ -22,6 +26,17 @@ def test_acf():
     y = acf.fit_transform(x, axis=0)
     assert y.shape == (n_lags, 1)
     # Test with axis = 0
+
+
+@pytest.mark.parametrize(
+    "transformer",
+    [StatsModelsACF, StatsModelsPACF],
+)
+def test_statsmodels_transformers_deprecated(transformer):
+    """Test that statsmodels wrappers raise their deprecation warnings."""
+    match = f"{transformer.__name__}.*removed in v1.7.0"
+    with pytest.warns(FutureWarning, match=match):
+        transformer()
 
 
 TEST_DATA = [


### PR DESCRIPTION
Reference Issues/PRs

part of #3562 
closes #3529 

deprecates two series transformers, StatsModelsACF and StatsModelsPACF. Neither are used in aeon, so are provided purely as very thin wrappers for statsmodels. We have very few thin wrappers like this left. We have an ACF series transformer, PACF easy to implement if anyone wants it.
