### PR TITLE
[ENH] Add parameters to method timer and stop `fit` timer from overwriting the attribute

### DIFF
--- a/aeon/anomaly_detection/collection/base.py
+++ b/aeon/anomaly_detection/collection/base.py
@@ -59,7 +59,7 @@ class BaseCollectionAnomalyDetector(BaseCollectionEstimator, BaseAnomalyDetector
         super().__init__()
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None):
         """Fit collection anomaly detector to training data.
 

--- a/aeon/anomaly_detection/series/base.py
+++ b/aeon/anomaly_detection/series/base.py
@@ -79,7 +79,7 @@ class BaseSeriesAnomalyDetector(BaseSeriesEstimator, BaseAnomalyDetector):
         super().__init__(axis=axis)
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None, axis=1):
         """Fit time series anomaly detector to X.
 

--- a/aeon/classification/base.py
+++ b/aeon/classification/base.py
@@ -69,7 +69,7 @@ class BaseClassifier(ClassifierMixin, BaseCollectionEstimator):
         super().__init__()
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y) -> BaseCollectionEstimator:
         """Fit time series classifier to training data.
 

--- a/aeon/classification/early_classification/base.py
+++ b/aeon/classification/early_classification/base.py
@@ -76,7 +76,7 @@ class BaseEarlyClassifier(ClassifierMixin, BaseCollectionEstimator):
 
         super().__init__()
 
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y):
         """Fit time series classifier to training data.
 

--- a/aeon/clustering/base.py
+++ b/aeon/clustering/base.py
@@ -31,7 +31,7 @@ class BaseClusterer(ClusterMixin, BaseCollectionEstimator):
         super().__init__()
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None) -> BaseCollectionEstimator:
         """Fit time series clusterer to training data.
 

--- a/aeon/forecasting/base.py
+++ b/aeon/forecasting/base.py
@@ -60,7 +60,7 @@ class BaseForecaster(BaseSeriesEstimator):
         super().__init__(axis)
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, y, exog=None, axis=1):
         """Fit forecaster to series y.
 

--- a/aeon/regression/base.py
+++ b/aeon/regression/base.py
@@ -59,7 +59,7 @@ class BaseRegressor(RegressorMixin, BaseCollectionEstimator):
         super().__init__()
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y) -> BaseCollectionEstimator:
         """Fit time series regressor to training data.
 

--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -78,7 +78,7 @@ class BaseSegmenter(BaseSeriesEstimator):
         super().__init__(axis=axis)
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None, axis=1):
         """Fit time series segmenter to X.
 

--- a/aeon/similarity_search/_base.py
+++ b/aeon/similarity_search/_base.py
@@ -120,7 +120,7 @@ class BaseSimilaritySearch(BaseCollectionEstimator):
 
         return X
 
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(
         self,
         X: np.ndarray,

--- a/aeon/transformations/collection/base.py
+++ b/aeon/transformations/collection/base.py
@@ -46,7 +46,7 @@ class BaseCollectionTransformer(BaseCollectionEstimator, BaseTransformer):
         super().__init__()
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None):
         """Fit transformer to X, optionally using y if supervised.
 

--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -30,7 +30,7 @@ class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
         super().__init__(axis=axis)
 
     @final
-    @method_timer("fit_time_millis_")
+    @method_timer("fit_time_millis_", overwrite=False, remove_on_start=True)
     def fit(self, X, y=None, axis=1):
         """Fit transformer to X, optionally using y if supervised.
 

--- a/aeon/utils/decorators/method_timer.py
+++ b/aeon/utils/decorators/method_timer.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Callable
 
 
-def method_timer(attr: str, overwrite=True, remove_on_start=True) -> Callable:
+def method_timer(attr: str, overwrite=True, remove_on_start=False) -> Callable:
     """Time a method call.
 
     A decorator factory that times a method call in milliseconds and writes it to
@@ -17,10 +17,10 @@ def method_timer(attr: str, overwrite=True, remove_on_start=True) -> Callable:
     attr : str
         The name of the attribute to write the timing to.
     overwrite : bool, default=True
-        Whether to overwrite the attribute if it exists.
-    remove_on_start : bool, default=True
-        Whether to remove the attribute if it exists before calling the decorated
-        method.
+        Whether the measured duration should overwrite a value assigned to the
+        attribute by the decorated method.
+    remove_on_start : bool, default=False
+        Whether to remove a value left by an earlier call before invoking the method.
 
     Returns
     -------

--- a/aeon/utils/decorators/method_timer.py
+++ b/aeon/utils/decorators/method_timer.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Callable
 
 
-def method_timer(attr: str) -> Callable:
+def method_timer(attr: str, overwrite=True, remove_on_start=True) -> Callable:
     """Time a method call.
 
     A decorator factory that times a method call in milliseconds and writes it to
@@ -16,6 +16,11 @@ def method_timer(attr: str) -> Callable:
     ----------
     attr : str
         The name of the attribute to write the timing to.
+    overwrite : bool, default=True
+        Whether to overwrite the attribute if it exists.
+    remove_on_start : bool, default=True
+        Whether to remove the attribute if it exists before calling the decorated
+        method.
 
     Returns
     -------
@@ -37,12 +42,16 @@ def method_timer(attr: str) -> Callable:
                     f"{attr!r} on {type(self).__name__}."
                 )
 
+            if remove_on_start and hasattr(self, attr):
+                delattr(self, attr)
+
             start = time.perf_counter()
             try:
                 return func(*args, **kwargs)
             finally:
                 ms = int((time.perf_counter() - start) * 1000)
-                setattr(self, attr, ms)
+                if overwrite or not hasattr(self, attr):
+                    setattr(self, attr, ms)
 
         return wrapper
 

--- a/aeon/utils/decorators/tests/test_method_timer.py
+++ b/aeon/utils/decorators/tests/test_method_timer.py
@@ -42,6 +42,47 @@ def test_method_timer_sets_attr_even_if_method_raises():
     assert a.t_ms >= 0
 
 
+@pytest.mark.parametrize("overwrite", [True, False])
+@pytest.mark.parametrize(
+    "remove_on_start, expected_existing", [(True, False), (False, True)]
+)
+def test_method_timer_options(overwrite, remove_on_start, expected_existing):
+    """Test overwrite and remove_on_start options."""
+
+    class _A:
+        @method_timer("t_ms", overwrite=overwrite, remove_on_start=remove_on_start)
+        def f(self):
+            existing = hasattr(self, "t_ms")
+            self.t_ms = "method value"
+            return existing
+
+    a = _A()
+    a.t_ms = "existing value"
+
+    assert a.f() is expected_existing
+    if overwrite:
+        assert isinstance(a.t_ms, int)
+        assert a.t_ms >= 0
+    else:
+        assert a.t_ms == "method value"
+
+
+def test_method_timer_sets_attr_if_existing_attr_removed():
+    """Test timer is stored if the method does not replace a removed attribute."""
+
+    class _A:
+        @method_timer("t_ms", overwrite=False, remove_on_start=True)
+        def f(self):
+            assert not hasattr(self, "t_ms")
+
+    a = _A()
+    a.t_ms = "existing value"
+    a.f()
+
+    assert isinstance(a.t_ms, int)
+    assert a.t_ms >= 0
+
+
 def test_method_timer_missing_self_raises_typeerror():
     """Test raises TypeError if the decorated function is missing self."""
 

--- a/aeon/utils/decorators/tests/test_method_timer.py
+++ b/aeon/utils/decorators/tests/test_method_timer.py
@@ -83,6 +83,21 @@ def test_method_timer_sets_attr_if_existing_attr_removed():
     assert a.t_ms >= 0
 
 
+def test_method_timer_default_keeps_existing_attr_during_call():
+    """Test the default leaves an existing attribute available to the method."""
+
+    class _A:
+        @method_timer("t_ms")
+        def f(self):
+            return self.t_ms
+
+    a = _A()
+    a.t_ms = "existing value"
+
+    assert a.f() == "existing value"
+    assert isinstance(a.t_ms, int)
+
+
 def test_method_timer_missing_self_raises_typeerror():
     """Test raises TypeError if the decorated function is missing self."""
 

--- a/aeon/utils/decorators/tests/test_method_timer.py
+++ b/aeon/utils/decorators/tests/test_method_timer.py
@@ -6,19 +6,20 @@ from aeon.utils.decorators.method_timer import method_timer
 
 
 def test_method_timer_sets_attr_and_returns_value():
-    """Test sets the attribute and returns the method output."""
+    """Test default behaviour, output, timing, and preserved metadata."""
 
     class _A:
         @method_timer("t_ms")
         def f(self, x):
             """Docstring here."""
+            assert self.t_ms == "existing value"
             return x + 1
 
     a = _A()
+    a.t_ms = "existing value"
     out = a.f(3)
 
     assert out == 4
-    assert hasattr(a, "t_ms")
     assert isinstance(a.t_ms, int)
     assert a.t_ms >= 0
     assert _A.f.__name__ == "f"
@@ -37,29 +38,24 @@ def test_method_timer_sets_attr_even_if_method_raises():
     with pytest.raises(ValueError, match="nope"):
         a.boom()
 
-    assert hasattr(a, "t_ms")
     assert isinstance(a.t_ms, int)
     assert a.t_ms >= 0
 
 
 @pytest.mark.parametrize("overwrite", [True, False])
-@pytest.mark.parametrize(
-    "remove_on_start, expected_existing", [(True, False), (False, True)]
-)
-def test_method_timer_options(overwrite, remove_on_start, expected_existing):
-    """Test overwrite and remove_on_start options."""
+def test_method_timer_options(overwrite):
+    """Test removal and optional overwriting of a method-supplied value."""
 
     class _A:
-        @method_timer("t_ms", overwrite=overwrite, remove_on_start=remove_on_start)
+        @method_timer("t_ms", overwrite=overwrite, remove_on_start=True)
         def f(self):
-            existing = hasattr(self, "t_ms")
+            assert not hasattr(self, "t_ms")
             self.t_ms = "method value"
-            return existing
 
     a = _A()
     a.t_ms = "existing value"
+    a.f()
 
-    assert a.f() is expected_existing
     if overwrite:
         assert isinstance(a.t_ms, int)
         assert a.t_ms >= 0
@@ -81,21 +77,6 @@ def test_method_timer_sets_attr_if_existing_attr_removed():
 
     assert isinstance(a.t_ms, int)
     assert a.t_ms >= 0
-
-
-def test_method_timer_default_keeps_existing_attr_during_call():
-    """Test the default leaves an existing attribute available to the method."""
-
-    class _A:
-        @method_timer("t_ms")
-        def f(self):
-            return self.t_ms
-
-    a = _A()
-    a.t_ms = "existing value"
-
-    assert a.f() == "existing value"
-    assert isinstance(a.t_ms, int)
 
 
 def test_method_timer_missing_self_raises_typeerror():


### PR DESCRIPTION
Allows estimators to set their own fit time if they want. Mostly useful for estimators which load from results files.