### PR TITLE
[ENH] add drift strategy to NaiveForecaster

### DIFF
--- a/aeon/forecasting/_naive.py
+++ b/aeon/forecasting/_naive.py
@@ -23,17 +23,21 @@ class NaiveForecaster(
     ----------
     strategy : str, default="last"
         The forecasting strategy to use.
-        Options: "last", "mean", "seasonal_last".
+        Options: "last", "mean", "seasonal_last", "drift".
             - "last" predicts the last value of the input series for all horizon steps.
             - "mean": predicts the mean of the input series for all horizon steps.
             - "seasonal_last": predicts the last season value in the training series.
+            - "drift": extrapolates the straight line drawn through the first and last
+              observations, predicting ``y[-1] + horizon * (y[-1] - y[0]) / (n - 1)``
+              where ``n`` is the series length.
     seasonal_period : int, default=1
         The seasonal period to use for the "seasonal_last" strategy.
         E.g., 12 for monthly data with annual seasonality.
     horizon : int, default =1
         The number of time steps ahead to forecast. If horizon is one, the forecaster
         will learn to predict one point ahead.
-        Only relevant for "seasonal_last".
+        Only affects the "seasonal_last" and "drift" strategies; "last" and "mean"
+        ignore it.
     """
 
     _tags = {
@@ -71,8 +75,18 @@ class NaiveForecaster(
             period = y_squeezed[-self.seasonal_period :]
             idx = (self.horizon - 1) % self.seasonal_period
             return period[idx]
+        elif self.strategy == "drift":
+            values = np.atleast_1d(y_squeezed)
+            n = len(values)
+            if n < 2:
+                raise ValueError(
+                    "strategy='drift' requires at least two observations to "
+                    f"estimate a trend, got {n}."
+                )
+            slope = (values[-1] - values[0]) / (n - 1)
+            return float(values[-1] + self.horizon * slope)
         else:
             raise ValueError(
                 f"Unknown strategy: {self.strategy}. "
-                "Valid strategies are 'last', 'mean', 'seasonal_last'."
+                "Valid strategies are 'last', 'mean', 'seasonal_last', 'drift'."
             )

--- a/aeon/forecasting/tests/test_naive.py
+++ b/aeon/forecasting/tests/test_naive.py
@@ -61,6 +61,48 @@ def test_naive_forecaster_seasonal_last_strategy():
     np.testing.assert_array_equal(pred, expected)
 
 
+def test_naive_forecaster_drift_strategy():
+    """Test 'drift' extrapolates the first-to-last trend line.
+
+    For a perfectly linear series the drift forecast lies exactly on the line, so
+    the h-step-ahead value is the last observation plus h times the constant slope.
+    """
+    slope = 2.0
+    y = np.arange(2, 12, 2, dtype=float)  # [2, 4, 6, 8, 10], slope 2 per step
+    last = y[-1]
+
+    for horizon in (1, 3, 5):
+        f = NaiveForecaster(strategy="drift", horizon=horizon)
+        np.testing.assert_allclose(f.forecast(y), last + horizon * slope)
+
+
+def test_naive_forecaster_drift_direct_matches_iterative():
+    """Drift gives the same next-N line via direct and iterative forecasting.
+
+    Appending an on-line prediction leaves the first-to-last slope unchanged, so
+    the recursive (iterative) forecast must reproduce the direct straight-line
+    extrapolation. Uses the default horizon=1 required by iterative forecasting.
+    """
+    slope = 3.0
+    y = np.arange(0, 15, 3, dtype=float)  # [0, 3, 6, 9, 12], slope 3 per step
+    n_ahead = 4
+    f = NaiveForecaster(strategy="drift")
+
+    direct = f.direct_forecast(y, n_ahead)
+    iterative = f.iterative_forecast(y, n_ahead)
+
+    np.testing.assert_allclose(direct, iterative)
+    expected = y[-1] + slope * np.arange(1, n_ahead + 1)
+    np.testing.assert_allclose(iterative, expected)
+
+
+def test_naive_forecaster_drift_requires_two_observations():
+    """Drift cannot estimate a trend from a single point and must raise."""
+    f = NaiveForecaster(strategy="drift")
+    with pytest.raises(ValueError, match="at least two observations"):
+        f.forecast(np.array([5.0]))
+
+
 def test_predict():
     """Test different input for private predict."""
     forecaster = NaiveForecaster(strategy="mean")


### PR DESCRIPTION
implements the "drift" simple forecasting method for naive (Hyndman FPP): extrapolate the straight line through the first and last observations, predicting y[-1] + horizon * (y[-1] - y[0]) / (n - 1). Unlike "last" and "mean" this strategy is horizon-aware; the slope is invariant under appending on-line points, so direct and iterative forecasting produce the same straight-line continuation. Drift requires at least two observations and raises otherwise.

Closes the outstanding drift item from the NaiveForecaster refactor closes #2823
