### PR TITLE
[MNT] replace REDCOMETS imblearn oversampling with aeon SMOTE/ROS

### DIFF
--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -18,7 +18,7 @@ from sklearn.utils import check_random_state
 from aeon.classification.base import BaseClassifier
 from aeon.transformations.collection import Normalizer
 from aeon.transformations.collection.dictionary_based import SAX, SFAFast
-from aeon.transformations.collection.imbalance import RandomOverSampler, SMOTE
+from aeon.transformations.collection.imbalance import SMOTE, RandomOverSampler
 from aeon.utils.validation import check_n_jobs
 
 

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -228,7 +228,10 @@ class REDCOMETS(BaseClassifier):
                     distance="euclidean",
                     n_jobs=self._n_jobs,
                 ).fit_transform(X_3d, y)
-            except (ValueError, IndexError):
+            except ValueError:
+                # aeon SMOTE raises ValueError when n_neighbors exceeds the
+                # minority class size; do not catch broader exceptions that
+                # could hide real bugs by silently falling back to ROS.
                 X_smote, y_smote = RandomOverSampler(
                     random_state=self.random_state
                 ).fit_transform(X_3d, y)

--- a/aeon/classification/dictionary_based/_redcomets.py
+++ b/aeon/classification/dictionary_based/_redcomets.py
@@ -13,14 +13,13 @@ import numpy as np
 from joblib import Parallel, delayed
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score
-from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state
 
 from aeon.classification.base import BaseClassifier
 from aeon.transformations.collection import Normalizer
 from aeon.transformations.collection.dictionary_based import SAX, SFAFast
+from aeon.transformations.collection.imbalance import RandomOverSampler, SMOTE
 from aeon.utils.validation import check_n_jobs
-from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 class REDCOMETS(BaseClassifier):
@@ -92,7 +91,6 @@ class REDCOMETS(BaseClassifier):
     """
 
     _tags = {
-        "python_dependencies": "imblearn",
         "capability:multivariate": True,
         "capability:multithreading": True,
         "algorithm_type": "dictionary",
@@ -195,15 +193,6 @@ class REDCOMETS(BaseClassifier):
             List of ``(RandomForestClassifier(), weight)`` tuples fitted on `SAX`
             transformed training data
         """
-        _check_soft_dependencies(
-            "imbalanced-learn",
-            package_import_alias={"imbalanced-learn": "imblearn"},
-            severity="error",
-            obj=self,
-        )
-
-        from imblearn.over_sampling import SMOTE, RandomOverSampler
-
         X = Normalizer().fit_transform(X).squeeze(1)
 
         if self.variant in [1, 2, 3]:
@@ -221,21 +210,29 @@ class REDCOMETS(BaseClassifier):
             y_smote = y
 
         else:
+            # Cap the minority count used for neighbour selection, matching the
+            # previous imblearn path: NearestNeighbors(n_neighbors=min_c-1)
+            # with self-exclusion leaves (min_c-2) synthesis neighbours.
             if min_neighbours > 5:
                 min_neighbours = 6
+            n_neighbors = min_neighbours - 2
+            X_3d = X[:, np.newaxis, :]
             try:
+                if n_neighbors < 1:
+                    raise ValueError(
+                        "Not enough minority samples for SMOTE neighbour search"
+                    )
                 X_smote, y_smote = SMOTE(
-                    sampling_strategy="all",
-                    k_neighbors=NearestNeighbors(
-                        n_neighbors=min_neighbours - 1, n_jobs=self._n_jobs
-                    ),
+                    n_neighbors=n_neighbors,
                     random_state=self.random_state,
-                ).fit_resample(X, y)
-
-            except ValueError:
+                    distance="euclidean",
+                    n_jobs=self._n_jobs,
+                ).fit_transform(X_3d, y)
+            except (ValueError, IndexError):
                 X_smote, y_smote = RandomOverSampler(
-                    sampling_strategy="all", random_state=self.random_state
-                ).fit_resample(X, y)
+                    random_state=self.random_state
+                ).fit_transform(X_3d, y)
+            X_smote = np.squeeze(X_smote, 1)
 
         lenses = self._get_random_lenses(X_smote, n_lenses)
         sfa_lenses = lenses[: n_lenses // 2]

--- a/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
+++ b/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
@@ -37,7 +37,7 @@ def _redcomets_resample_aeon(X2d, y, random_state=0, n_jobs=1):
             distance="euclidean",
             n_jobs=n_jobs,
         ).fit_transform(X_3d, y)
-    except (ValueError, IndexError):
+    except ValueError:
         X_smote, y_smote = RandomOverSampler(random_state=random_state).fit_transform(
             X_3d, y
         )

--- a/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
+++ b/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
@@ -1,0 +1,116 @@
+"""Tests for REDCOMETS oversampling without imbalanced-learn."""
+
+from collections import Counter
+
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+from sklearn.utils import check_random_state
+
+from aeon.classification.dictionary_based import REDCOMETS
+from aeon.transformations.collection import Normalizer
+from aeon.transformations.collection.imbalance import RandomOverSampler, SMOTE
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+def _normalise_2d(X2d):
+    """Apply aeon collection Normalizer to a 2D panel and return 2D."""
+    return Normalizer().fit_transform(X2d).squeeze(1)
+
+
+def _redcomets_resample_aeon(X2d, y, random_state=0, n_jobs=1):
+    """Mirror REDCOMETS oversampling with aeon transformers."""
+    X = _normalise_2d(X2d)
+    min_neighbours = min(Counter(y).values())
+    max_neighbours = max(Counter(y).values())
+    if min_neighbours == max_neighbours:
+        return X, y
+    if min_neighbours > 5:
+        min_neighbours = 6
+    n_neighbors = min_neighbours - 2
+    X_3d = X[:, np.newaxis, :]
+    try:
+        if n_neighbors < 1:
+            raise ValueError("not enough neighbours")
+        X_smote, y_smote = SMOTE(
+            n_neighbors=n_neighbors,
+            random_state=random_state,
+            distance="euclidean",
+            n_jobs=n_jobs,
+        ).fit_transform(X_3d, y)
+    except (ValueError, IndexError):
+        X_smote, y_smote = RandomOverSampler(random_state=random_state).fit_transform(
+            X_3d, y
+        )
+    return np.squeeze(X_smote, 1), y_smote
+
+
+def test_redcomets_smote_class_counts_match_imblearn():
+    """Class counts and samples after aeon SMOTE match the previous imblearn path."""
+    if not _check_soft_dependencies(
+        "imbalanced-learn",
+        package_import_alias={"imbalanced-learn": "imblearn"},
+        severity="none",
+    ):
+        return
+
+    from imblearn.over_sampling import SMOTE as ImbSMOTE
+
+    rng = check_random_state(0)
+    X2d = rng.randn(40, 30)
+    y = np.array([0] * 24 + [1] * 16)
+    Xn = _normalise_2d(X2d)
+    min_neighbours = 6
+    X_imb, y_imb = ImbSMOTE(
+        sampling_strategy="all",
+        k_neighbors=NearestNeighbors(n_neighbors=min_neighbours - 1),
+        random_state=0,
+    ).fit_resample(Xn, y)
+    X_aeon, y_aeon = _redcomets_resample_aeon(X2d, y, random_state=0)
+
+    assert Counter(map(str, y_imb)) == Counter(map(str, y_aeon))
+    assert X_imb.shape == X_aeon.shape
+
+    def sort_xy(X, y):
+        y = np.asarray(y).astype(str)
+        idx = np.lexsort((X[:, 0], y))
+        return X[idx], y[idx]
+
+    Xi, yi = sort_xy(X_imb, y_imb)
+    Xa, ya = sort_xy(X_aeon, y_aeon)
+    assert np.array_equal(yi, ya)
+    assert np.allclose(Xi, Xa)
+
+
+def test_redcomets_fits_without_imblearn_tag():
+    """REDCOMETS no longer declares an imblearn soft dependency."""
+    clf = REDCOMETS(variant=1, n_trees=2, random_state=0)
+    deps = clf.get_tag("python_dependencies", None)
+    if deps is None:
+        deps = []
+    if isinstance(deps, str):
+        deps = [deps]
+    assert "imblearn" not in deps
+    assert "imbalanced-learn" not in deps
+
+
+def test_redcomets_ros_fallback_on_tiny_minority():
+    """When SMOTE cannot run, RandomOverSampler balances class counts."""
+    rng = check_random_state(0)
+    # one class with a single sample forces SMOTE neighbour failure
+    X2 = rng.randn(10, 20)
+    y = np.array([0] * 8 + [1] * 1 + [2] * 1)
+    X_res, y_res = _redcomets_resample_aeon(X2, y, random_state=0)
+    counts = Counter(map(int, y_res))
+    assert len(set(counts.values())) == 1
+    assert counts[0] == 8
+
+
+def test_redcomets_end_to_end_fit_predict():
+    """REDCOMETS fits and predicts on a small imbalanced panel."""
+    rng = check_random_state(0)
+    X = rng.randn(30, 1, 24)
+    y = np.array([0] * 20 + [1] * 10)
+    clf = REDCOMETS(variant=1, n_trees=5, random_state=0)
+    clf.fit(X, y)
+    pred = clf.predict(X)
+    assert pred.shape == (30,)

--- a/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
+++ b/aeon/classification/dictionary_based/tests/test_redcomets_oversampling.py
@@ -8,7 +8,7 @@ from sklearn.utils import check_random_state
 
 from aeon.classification.dictionary_based import REDCOMETS
 from aeon.transformations.collection import Normalizer
-from aeon.transformations.collection.imbalance import RandomOverSampler, SMOTE
+from aeon.transformations.collection.imbalance import SMOTE, RandomOverSampler
 from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 

--- a/aeon/transformations/collection/imbalance/__init__.py
+++ b/aeon/transformations/collection/imbalance/__init__.py
@@ -1,8 +1,11 @@
 """Supervised transformers to rebalance collections of time series."""
 
-__all__ = ["ADASYN", "SMOTE", "OHIT", "ESMOTE"]
+__all__ = ["ADASYN", "SMOTE", "OHIT", "ESMOTE", "RandomOverSampler"]
 
 from aeon.transformations.collection.imbalance._adasyn import ADASYN
 from aeon.transformations.collection.imbalance._esmote import ESMOTE
 from aeon.transformations.collection.imbalance._ohit import OHIT
+from aeon.transformations.collection.imbalance._random_over_sampler import (
+    RandomOverSampler,
+)
 from aeon.transformations.collection.imbalance._smote import SMOTE

--- a/aeon/transformations/collection/imbalance/_random_over_sampler.py
+++ b/aeon/transformations/collection/imbalance/_random_over_sampler.py
@@ -40,6 +40,7 @@ class RandomOverSampler(BaseCollectionTransformer):
 
     _tags = {
         "requires_y": True,
+        "capability:multivariate": True,
     }
 
     def __init__(self, random_state=None):

--- a/aeon/transformations/collection/imbalance/_random_over_sampler.py
+++ b/aeon/transformations/collection/imbalance/_random_over_sampler.py
@@ -1,0 +1,84 @@
+"""Random over-sampling for imbalanced collections of time series."""
+
+__maintainer__ = ["TonyBagnall"]
+__all__ = ["RandomOverSampler"]
+
+from collections import OrderedDict
+
+import numpy as np
+from sklearn.utils import check_random_state
+
+from aeon.transformations.collection import BaseCollectionTransformer
+
+
+class RandomOverSampler(BaseCollectionTransformer):
+    """Random over-sampling for imbalanced collections of time series.
+
+    Replicates samples from each non-majority class with replacement until every
+    class has the same number of cases as the majority class. Original samples
+    are kept; only synthetic duplicates are appended.
+
+    This mirrors ``imblearn.over_sampling.RandomOverSampler`` with
+    ``sampling_strategy="all"`` for equal-length univariate collections.
+
+    Parameters
+    ----------
+    random_state : int, RandomState instance or None, default=None
+        Controls the random number generation used when drawing replacement
+        samples.
+
+    Examples
+    --------
+    >>> from aeon.transformations.collection.imbalance import RandomOverSampler
+    >>> import numpy as np
+    >>> X = np.random.randn(10, 1, 12)
+    >>> y = np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1])
+    >>> X_res, y_res = RandomOverSampler(random_state=0).fit_transform(X, y)
+    >>> y_res.shape[0] == 14
+    True
+    """
+
+    _tags = {
+        "requires_y": True,
+    }
+
+    def __init__(self, random_state=None):
+        self.random_state = random_state
+        super().__init__()
+
+    def _fit(self, X, y=None):
+        self._random_state = check_random_state(self.random_state)
+        unique, counts = np.unique(y, return_counts=True)
+        target_stats = dict(zip(unique, counts))
+        n_sample_majority = max(target_stats.values())
+        class_majority = max(target_stats, key=target_stats.get)
+        sampling_strategy = {
+            key: n_sample_majority - value
+            for (key, value) in target_stats.items()
+            if key != class_majority
+        }
+        self.sampling_strategy_ = OrderedDict(sorted(sampling_strategy.items()))
+        return self
+
+    def _transform(self, X, y=None):
+        X_resampled = [X.copy()]
+        y_resampled = [y.copy()]
+
+        for class_sample, n_samples in self.sampling_strategy_.items():
+            if n_samples == 0:
+                continue
+            target_class_indices = np.flatnonzero(y == class_sample)
+            choose = self._random_state.choice(
+                target_class_indices, size=n_samples, replace=True
+            )
+            X_resampled.append(X[choose])
+            y_resampled.append(y[choose])
+
+        X_resampled = np.vstack(X_resampled)
+        y_resampled = np.hstack(y_resampled)
+        return X_resampled, y_resampled
+
+    @classmethod
+    def _get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        return {"random_state": 0}

--- a/aeon/transformations/collection/imbalance/tests/test_random_over_sampler.py
+++ b/aeon/transformations/collection/imbalance/tests/test_random_over_sampler.py
@@ -1,0 +1,64 @@
+"""Tests for RandomOverSampler."""
+
+import numpy as np
+import pytest
+from sklearn.utils import check_random_state
+
+from aeon.transformations.collection.imbalance import RandomOverSampler
+from aeon.utils.validation._dependencies import _check_soft_dependencies
+
+
+def test_random_over_sampler_balances_classes():
+    """RandomOverSampler should bring every class to the majority count."""
+    rng = check_random_state(0)
+    X = rng.randn(10, 1, 12)
+    y = np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1])
+    X_res, y_res = RandomOverSampler(random_state=0).fit_transform(X, y)
+    _, counts = np.unique(y_res, return_counts=True)
+    assert X_res.shape == (14, 1, 12)
+    assert y_res.shape == (14,)
+    assert counts.tolist() == [7, 7]
+
+
+def test_random_over_sampler_keeps_originals():
+    """Original samples should still be present after oversampling."""
+    rng = check_random_state(1)
+    X = rng.randn(8, 1, 5)
+    y = np.array([0, 0, 0, 0, 0, 1, 1, 1])
+    X_res, y_res = RandomOverSampler(random_state=1).fit_transform(X, y)
+    # first n originals kept in order for majority and minority blocks
+    assert np.allclose(X_res[:8], X)
+    assert np.array_equal(y_res[:8], y)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(
+        "imbalanced-learn",
+        package_import_alias={"imbalanced-learn": "imblearn"},
+        severity="none",
+    ),
+    reason="skip test if required soft dependency imbalanced-learn not available",
+)
+def test_random_over_sampler_matches_imblearn():
+    """Match imblearn RandomOverSampler with sampling_strategy='all'."""
+    from imblearn.over_sampling import RandomOverSampler as ImbROS
+
+    rng = check_random_state(0)
+    X2 = rng.randn(20, 15)
+    y = np.array([0] * 12 + [1] * 5 + [2] * 3)
+    X_imb, y_imb = ImbROS(sampling_strategy="all", random_state=0).fit_resample(X2, y)
+    X_aeon, y_aeon = RandomOverSampler(random_state=0).fit_transform(
+        X2[:, np.newaxis, :], y
+    )
+    X_aeon = X_aeon.squeeze(1)
+
+    def sort_xy(X, y):
+        y = np.asarray(y)
+        idx = np.lexsort((X[:, 0], y.astype(str)))
+        return X[idx], y[idx]
+
+    Xi, yi = sort_xy(X_imb, y_imb)
+    Xa, ya = sort_xy(X_aeon, y_aeon)
+    assert Xi.shape == Xa.shape
+    assert np.array_equal(yi.astype(str), ya.astype(str))
+    assert np.allclose(Xi, Xa)

--- a/aeon/transformations/collection/imbalance/tests/test_random_over_sampler.py
+++ b/aeon/transformations/collection/imbalance/tests/test_random_over_sampler.py
@@ -31,6 +31,20 @@ def test_random_over_sampler_keeps_originals():
     assert np.array_equal(y_res[:8], y)
 
 
+def test_random_over_sampler_multivariate():
+    """RandomOverSampler should accept multi-channel series and copy whole cases."""
+    rng = check_random_state(2)
+    X = rng.randn(9, 3, 16)
+    y = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1])
+    X_res, y_res = RandomOverSampler(random_state=2).fit_transform(X, y)
+    _, counts = np.unique(y_res, return_counts=True)
+    assert X_res.shape == (12, 3, 16)
+    assert counts.tolist() == [6, 6]
+    # originals preserved at the front; all channels kept
+    assert np.allclose(X_res[:9], X)
+    assert np.array_equal(y_res[:9], y)
+
+
 @pytest.mark.skipif(
     not _check_soft_dependencies(
         "imbalanced-learn",


### PR DESCRIPTION
## Fix

Fixes #3654

### Problem

`imbalanced-learn` was only needed at runtime by `REDCOMETS` (SMOTE + RandomOverSampler). aeon already has a ported collection `SMOTE`, so the soft dependency is unnecessary for this path.

### Solution

1. Add `RandomOverSampler` to `aeon.transformations.collection.imbalance` (matches imblearn `sampling_strategy="all"`, with multivariate support).
2. Replace REDCOMETS oversampling with aeon `SMOTE` / `RandomOverSampler`.
3. Neighbour mapping preserves the previous imblearn behaviour:
   - `m = min(min_class_count, 6)`
   - `NearestNeighbors(n_neighbors=m-1)` + self-exclusion ⇒ synthesis neighbours `m-2`
   - `SMOTE(n_neighbors=m-2, distance="euclidean", random_state=...)`
4. Remove REDCOMETS `python_dependencies: imblearn` tag.
5. Catch only `ValueError` around aeon SMOTE (boundary / neighbour failures); do not swallow broader exceptions.

`imbalanced-learn` remains an optional soft dependency for SMOTE/ADASYN **parity tests** only; removing it from `pyproject.toml` can be a follow-up once those tests use hard-coded fixtures.

### Equivalence evidence (correctness only)

Resampling + REDCOMETS `variant=1`, `n_trees=25`, `random_state=0` on UCR train/test:

| dataset | resample mode | bit-exact | acc old | acc new | Δacc |
|---------|---------------|-----------|---------|---------|------|
| ItalyPowerDemand | smote | yes | 0.9417 | 0.9417 | 0 |
| GunPoint | smote | yes | 0.9667 | 0.9667 | 0 |
| Wine | smote | yes | 0.5556 | 0.5556 | 0 |
| ECG200 | smote | yes | 0.8600 | 0.8600 | 0 |
| ArrowHead | none (balanced) | yes | 0.6800 | 0.6800 | 0 |
| Beef | none | yes | 0.7333 | 0.7333 | 0 |
| Coffee | none | yes | 1.0000 | 1.0000 | 0 |
| OliveOil | smote | no | 0.9000 | 0.9000 | 0 |
| Lightning7 | smote | no | 0.7260 | 0.7260 | 0 |
| Trace | smote | no | 0.9500 | 0.9500 | 0 |

Notes:
- Binary / larger-minority cases are often bit-identical after neighbour mapping.
- Multiclass / small-minority cases (OliveOil, Lightning7, Trace) are not always bit-identical (as expected), but **test accuracy was identical** on this suite.
- An expanded 56-dataset follow-up and a multi-seed re-check of the few accuracy deltas are in the PR comments (correctness only; no speed claims).

### Changes

- `imbalance/_random_over_sampler.py` (new, multivariate-capable)
- `imbalance/__init__.py` export
- `_redcomets.py` oversampling path
- tests for ROS (incl. multivariate) + REDCOMETS oversampling / no-imblearn tag

### Testing

- unit: ROS balances classes, matches imblearn ROS when available, multivariate whole-case copy
- unit: REDCOMETS SMOTE path matches imblearn on a synthetic binary case
- unit: ROS fallback on tiny minority
- unit: REDCOMETS end-to-end fit/predict without imblearn
- UCR accuracy equivalence table above

Happy to extend the UCR suite further if useful.