### PR TITLE
[BUG] Return empty result instead of raising in temporal_importance_curves for all-stump forests (#3677)

### DIFF
--- a/aeon/base/_estimators/interval_based/base_interval_forest.py
+++ b/aeon/base/_estimators/interval_based/base_interval_forest.py
@@ -1305,6 +1305,9 @@ class BaseIntervalForest(ABC):
                 names.append(f"{rep}{key[2]}{dim}")
                 values.append(value)
 
+            if len(names) == 0:
+                return [], []
+
             names, values = zip(*sorted(zip(names, values)))
 
             return list(names), list(values)

--- a/aeon/base/_estimators/interval_based/tests/test_base_interval_forest.py
+++ b/aeon/base/_estimators/interval_based/tests/test_base_interval_forest.py
@@ -286,6 +286,29 @@ def test_temporal_importance_curves(base_estimator):
     assert all(np.all(c >= 0) for c in curves)
 
 
+def test_temporal_importance_curves_all_stumps():
+    """Test temporal_importance_curves returns empty results for all-stump forests.
+
+    Regression test for #3677, where a forest made up entirely of
+    ContinuousIntervalTree stumps (no splits) caused temporal_importance_curves to
+    raise a ValueError instead of returning an empty result.
+    """
+    X, y = make_example_3d_numpy(n_cases=10, n_timepoints=12, random_state=0)
+
+    est = IntervalForestClassifier(
+        base_estimator=ContinuousIntervalTree(max_depth=0),
+        n_estimators=3,
+        n_intervals=2,
+        random_state=0,
+    )
+    est.fit(X, y)
+
+    names, curves = est.temporal_importance_curves()
+
+    assert names == []
+    assert curves == []
+
+
 def test_interval_forest_invalid_base_estimator():
     """Test BaseIntervalForest raises ValueError for invalid base_estimator."""
     X, y = make_example_3d_numpy()


### PR DESCRIPTION
`zip(*sorted(zip(names, values)))` blows up with `not enough values to unpack (expected 2, got 0)` when every fitted `ContinuousIntervalTree` in the forest is a stump — splits/gains/curves all come back empty. Matches the exact repro in #3677 (periodic `test_tic_curves` CI failure). Short-circuits to `[], []` before the zip when there's nothing to sort, per the fix suggested in the issue.

Also adds a regression test (`test_temporal_importance_curves_all_stumps` in `aeon/base/_estimators/interval_based/tests/test_base_interval_forest.py`) that fits an `IntervalForestClassifier` with `ContinuousIntervalTree(max_depth=0)` (forcing every tree to be a stump) and asserts `temporal_importance_curves()` returns `([], [])` instead of raising.

Fixes #3677.