### PR TITLE
[BUG] return empty TIC outputs for all-stump forests

### DIFF
--- a/aeon/base/_estimators/interval_based/base_interval_forest.py
+++ b/aeon/base/_estimators/interval_based/base_interval_forest.py
@@ -1305,6 +1305,9 @@ class BaseIntervalForest(ABC):
                 names.append(f"{rep}{key[2]}{dim}")
                 values.append(value)
 
+            if not names:
+                return [], []
+
             names, values = zip(*sorted(zip(names, values)))
 
             return list(names), list(values)

--- a/aeon/classification/interval_based/tests/test_interval_forests.py
+++ b/aeon/classification/interval_based/tests/test_interval_forests.py
@@ -42,7 +42,7 @@ def test_tic_curves(cls):
     params = cls._get_test_params()
     if isinstance(params, list):
         params = params[0]
-    params.update({"base_estimator": ContinuousIntervalTree()})
+    params.update({"base_estimator": ContinuousIntervalTree(), "random_state": 0})
 
     clf = cls(**params)
     clf.fit(X_train, y_train)
@@ -106,3 +106,22 @@ def test_forest_pycatch22(cls):
     ]
     assert len(deprecation_warnings) == 1
     _assert_predict_probabilities(prob, X_test, n_classes=2)
+
+
+def test_tic_curves_all_stump_forest():
+    """All-stump forests should return empty TIC outputs, not raise."""
+    import numpy as np
+
+    X = np.zeros((10, 1, 20))
+    y = np.array([0, 1] * 5)
+    clf = CanonicalIntervalForestClassifier(
+        n_estimators=2,
+        n_intervals=2,
+        att_subsample_size=2,
+        base_estimator=ContinuousIntervalTree(),
+        random_state=0,
+    )
+    clf.fit(X, y)
+    names, curves = clf.temporal_importance_curves()
+    assert names == []
+    assert curves == []

--- a/aeon/visualisation/estimator/_temporal_importance_curves.py
+++ b/aeon/visualisation/estimator/_temporal_importance_curves.py
@@ -30,6 +30,11 @@ def plot_temporal_importance_curves(
     fig : plt.Figure
     ax : plt.Axis
     """
+    if curves is None or len(curves) == 0:
+        raise ValueError("No temporal importance curves are available to plot.")
+    if curve_names is None or len(curve_names) == 0:
+        raise ValueError("No temporal importance curves are available to plot.")
+
     # find attributes to display by max information gain for any time point.
     _check_soft_dependencies("matplotlib")
 

--- a/aeon/visualisation/estimator/tests/test_tic_plotting.py
+++ b/aeon/visualisation/estimator/tests/test_tic_plotting.py
@@ -27,3 +27,15 @@ def test_plot_temporal_importance_curves():
     assert isinstance(fig, plt.Figure) and isinstance(ax, plt.Axes)
 
     plt.close()
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["matplotlib", "seaborn"], severity="none"),
+    reason="skip test if required soft dependency not available",
+)
+def test_plot_temporal_importance_curves_empty():
+    """Empty curves must raise a clear ValueError rather than NumPy noise."""
+    with pytest.raises(
+        ValueError, match="No temporal importance curves are available to plot"
+    ):
+        plot_temporal_importance_curves([], [])


### PR DESCRIPTION
## Summary
- `temporal_importance_curves` now returns `([], [])` when a fitted forest has no splits (all stumps), instead of raising `ValueError` from `zip(*[])`.
- Adds a regression test using the all-stump CIF setup from the issue.
- Pins `random_state=0` in `test_tic_curves` so the periodic TIC test is deterministic.

Fixes #3677

## Test plan
- [ ] `pytest aeon/classification/interval_based/tests/test_interval_forests.py::test_tic_curves_all_stump_forest -q`
- [ ] `pytest aeon/classification/interval_based/tests/test_interval_forests.py::test_tic_curves -q`

Made with [Cursor](https://cursor.com)