### PR TITLE
[MNT] Expose MSTLSeriesTransformer through public API

### DIFF
--- a/aeon/transformations/series/__init__.py
+++ b/aeon/transformations/series/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "MatrixProfileTransformer",
     "LogTransformer",
     "PLASeriesTransformer",
+    "MSTLSeriesTransformer",
     "StatsModelsACF",
     "StatsModelsPACF",
     "BKFilter",
@@ -36,6 +37,7 @@ from aeon.transformations.series._diff import DifferenceTransformer
 from aeon.transformations.series._dobin import Dobin
 from aeon.transformations.series._log import LogTransformer
 from aeon.transformations.series._matrix_profile import MatrixProfileTransformer
+from aeon.transformations.series._mstl import MSTLSeriesTransformer
 from aeon.transformations.series._pca import PCASeriesTransformer
 from aeon.transformations.series._pla import PLASeriesTransformer
 from aeon.transformations.series._scaled_logit import ScaledLogitSeriesTransformer

--- a/aeon/transformations/series/_mstl.py
+++ b/aeon/transformations/series/_mstl.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["MSTLSeriesTransformer"]
+
 from collections.abc import Iterable, Sequence
 from typing import Union
 

--- a/aeon/transformations/series/tests/test_mstl.py
+++ b/aeon/transformations/series/tests/test_mstl.py
@@ -3,8 +3,21 @@
 import numpy as np
 import pytest
 
-from aeon.transformations.series._mstl import MSTLSeriesTransformer
+from aeon.transformations import series
+from aeon.transformations.series import MSTLSeriesTransformer
 from aeon.transformations.series._stl import STLSeriesTransformer
+
+
+def test_mstl_is_in_public_api():
+    """MSTL is available through the series transformations public API."""
+    assert "MSTLSeriesTransformer" in series.__all__
+
+
+def test_mstl_module_declares_public_export():
+    """The implementation module declares MSTL as its public export."""
+    from aeon.transformations.series import _mstl
+
+    assert _mstl.__all__ == ["MSTLSeriesTransformer"]
 
 
 def _toy_two_season(n=504):

--- a/docs/api_reference/transformations.md
+++ b/docs/api_reference/transformations.md
@@ -220,6 +220,7 @@ all_tags_for_estimator`` function with the argument ``"transformer"``.
     MatrixProfileTransformer
     LogTransformer
     PLASeriesTransformer
+    MSTLSeriesTransformer
     StatsModelsACF
     StatsModelsPACF
     BKFilter

--- a/docs/api_reference/transformations.md
+++ b/docs/api_reference/transformations.md
@@ -220,6 +220,7 @@ all_tags_for_estimator`` function with the argument ``"transformer"``.
     MatrixProfileTransformer
     LogTransformer
     PLASeriesTransformer
+    STLSeriesTransformer
     MSTLSeriesTransformer
     StatsModelsACF
     StatsModelsPACF


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3687.

#### What does this implement/fix? Explain your changes.

Exports `MSTLSeriesTransformer` from `aeon.transformations.series` so users no longer need to import it from the private `_mstl` module.

This change:

- adds `MSTLSeriesTransformer` to the package import surface and `__all__`;
- declares the class in `_mstl.__all__` for consistency with the other series transformers;
- switches the MSTL tests to the public import and adds explicit export-contract coverage;
- adds MSTL to the transformations API autosummary.

Validation:

- `22 passed` in `aeon/transformations/series/tests/test_mstl.py`;
- estimator discovery test passes and resolves `MSTLSeriesTransformer` to the public class;
- all pre-commit hooks pass for the changed files;
- Sphinx generated both the MSTL autosummary page and the transformations HTML entry. The broader focused build later encountered an unrelated existing `nbsphinx` notebook-copy error after the target page had been written.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

The implementation itself is unchanged; this PR only exposes the existing estimator through the supported public API and documentation.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [x] I've added the estimator/function to the online [API documentation](https://www.aeon-toolkit.org/en/latest/api_reference.html).
- [ ] (OPTIONAL) I've added myself as a `__maintainer__` at the top of relevant files and want to be contacted regarding its maintenance. Unmaintained files may be removed. This is for the full file, and you should not add yourself if you are just making minor changes or do not want to help maintain its contents.

##### For developers with write access
- [ ] (OPTIONAL) I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon/blob/main/CODEOWNERS) to receive notifications regarding changes to these files.
