### PR TITLE
[BUG] `DiscreteFourierApproximation`: keep conjugate-symmetric terms

### DIFF
--- a/aeon/transformations/series/smoothing/_dfa.py
+++ b/aeon/transformations/series/smoothing/_dfa.py
@@ -18,7 +18,8 @@ class DiscreteFourierApproximation(BaseSeriesTransformer):
     Parameters
     ----------
     r : float, default=0.5
-        Proportion of Fourier terms to retain [0, 1]
+        Proportion of the ``n_timepoints // 2 + 1`` Fourier terms to retain [0, 1].
+        ``r=1`` reconstructs the series exactly.
     sort : bool, default=False
         Sort the Fourier terms by amplitude to keep most important terms
 
@@ -62,8 +63,11 @@ class DiscreteFourierApproximation(BaseSeriesTransformer):
         -------
         transformed version of X
         """
-        # Compute DFT
-        dft = np.fft.fft(X)
+        # Compute the DFT. X is real, so its spectrum is conjugate symmetric and
+        # rfft returns the n_timepoints // 2 + 1 non-redundant terms. Masking the
+        # two-sided fft instead drops the conjugate partner of every retained
+        # term, which halves its amplitude in the reconstruction.
+        dft = np.fft.rfft(X)
 
         # Mask array of terms to keep and number of terms to keep
         mask = np.zeros_like(dft, dtype=bool)
@@ -79,6 +83,6 @@ class DiscreteFourierApproximation(BaseSeriesTransformer):
             mask[:, 0:keep] = True
 
         # Invert DFT with masked terms
-        X_ = np.fft.ifft(dft * mask).real
+        X_ = np.fft.irfft(dft * mask, n=X.shape[1])
 
         return X_

--- a/aeon/transformations/series/smoothing/tests/test_dft.py
+++ b/aeon/transformations/series/smoothing/tests/test_dft.py
@@ -31,3 +31,39 @@ def test_dft(r, sort):
 
     np.testing.assert_almost_equal(x_1[0], x_12[0], decimal=4)
     np.testing.assert_almost_equal(x_2[0], x_12[1], decimal=4)
+
+
+@pytest.mark.parametrize("r", [0.25, 0.50, 1.00])
+@pytest.mark.parametrize("sort", [True, False])
+def test_dft_preserves_retained_amplitude(r, sort):
+    """A sinusoid inside the retained band must come back with its amplitude."""
+    n_timepoints = 64
+    k = 3  # frequency bin, well inside the retained band for every r above
+    n = np.arange(n_timepoints)
+    x = 2.0 + np.cos(2 * np.pi * k * n / n_timepoints)
+
+    dft = DiscreteFourierApproximation(r=r, sort=sort)
+    x_ = dft.fit_transform(x)[0]
+
+    np.testing.assert_allclose(x_, x, atol=1e-8)
+
+
+def test_dft_full_r_is_identity():
+    """r=1.0 retains every term, so the series must be reconstructed exactly."""
+    rng = np.random.RandomState(0)
+    for n_timepoints in (63, 64):
+        x = rng.normal(size=n_timepoints)
+        x_ = DiscreteFourierApproximation(r=1.0).fit_transform(x)[0]
+        np.testing.assert_allclose(x_, x, atol=1e-8)
+
+
+def test_dft_discards_high_frequencies():
+    """A term above the cut-off must be removed, not merely attenuated."""
+    n_timepoints = 64
+    n = np.arange(n_timepoints)
+    low = np.cos(2 * np.pi * 2 * n / n_timepoints)
+    high = np.cos(2 * np.pi * 30 * n / n_timepoints)
+
+    x_ = DiscreteFourierApproximation(r=0.25, sort=False).fit_transform(low + high)[0]
+
+    np.testing.assert_allclose(x_, low, atol=1e-8)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3710.

#### What does this implement/fix? Explain your changes.

`_transform` masked the two-sided `np.fft.fft` spectrum and kept the lowest
`keep = int(r * n_timepoints)` bins. For a real series the spectrum is conjugate
symmetric, so bins `k` and `n - k` together carry one frequency; keeping `k`
without `n - k` and then taking `.real` of the inverse returns half of that term.
A cosine lying entirely inside the retained band comes back halved rather than
unchanged:

```python
import numpy as np
from aeon.transformations.series.smoothing import DiscreteFourierApproximation

n = np.arange(64)
x = np.cos(2 * np.pi * 3 * n / 64)

out = DiscreteFourierApproximation(r=0.25).fit_transform(x)[0]
print(np.abs(out).max())            # 0.5 on main, expected 1.0
print(np.abs(out - 0.5 * x).max())  # 5.3e-16 on main: exactly half the input
```

DC is the only retained term with no partner, so the mean survives while the
variance comes out quartered. `sort=True` usually escapes it, because the
largest-`|X[k]|` bins come in conjugate pairs, so the two settings disagree by a
factor of two on the same input.

The change is to use `rfft`/`irfft`, which carry the `n_timepoints // 2 + 1`
non-redundant terms: amplitudes are preserved with no mirroring logic and `r=1`
reconstructs the series exactly. `r` becomes a proportion of those independent
terms, which does move the cut-off for a given `r`, `r=0.5` cuts at `fs/4` rather
than just below Nyquist, so the docstring now says which set `r` is a proportion
of. The measurements and the narrower alternative, mirroring the mask onto the
conjugate partners so that `r` keeps its current meaning, are in #3710; happy
to switch to that one instead.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

`test_dft.py` previously only asserted that a channel transformed alone matches
the same channel transformed inside a 2-channel array, a consistency check that
passes with or without the bug. No assertion pinned the output amplitude. Three
added: in-band amplitude preserved, for `r` in {0.25, 0.5, 1.0} and both `sort`
settings; `r=1.0` exact for odd and even lengths; and a term above the cut-off
removed rather than attenuated. On `main` that file is 3 failed, 11 passed, the
two `sort=False` amplitude cases and the high-frequency test, while the
`sort=True` cases and `r=1.0` pass, which localises the problem to the two-sided
mask.

`aeon/transformations/series/` goes from 209 passed, 1 skipped to 217 passed, 1
skipped: the eight new cases, nothing else changing colour. The 19
`check_estimator` cases for `DiscreteFourierApproximation` pass before and after.
`pre-commit` clean.

### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
