### PR TITLE
[ENH] MiniRocketClassifier: change fitted estimator from protected to public

### DIFF
--- a/aeon/classification/convolution_based/_minirocket.py
+++ b/aeon/classification/convolution_based/_minirocket.py
@@ -62,6 +62,8 @@ class MiniRocketClassifier(BaseClassifier):
         The number of classes.
     classes_ : list
         The classes labels.
+    estimator_ : sklearn classifier
+        The fitted estimator.
 
     References
     ----------
@@ -137,7 +139,7 @@ class MiniRocketClassifier(BaseClassifier):
             random_state=self.random_state,
         )
         self._scaler = StandardScaler(with_mean=False)
-        self._estimator = _clone_estimator(
+        self.estimator_ = _clone_estimator(
             (
                 RidgeClassifierCV(
                     alphas=np.logspace(-3, 3, 10), class_weight=self.class_weight
@@ -151,7 +153,7 @@ class MiniRocketClassifier(BaseClassifier):
         self.pipeline_ = make_pipeline(
             self._transformer,
             self._scaler,
-            self._estimator,
+            self.estimator_,
         )
         self.pipeline_.fit(X, y)
 
@@ -185,7 +187,7 @@ class MiniRocketClassifier(BaseClassifier):
         y : array-like, shape = (n_cases, n_classes_)
             Predicted probabilities using the ordering in classes_.
         """
-        m = getattr(self._estimator, "predict_proba", None)
+        m = getattr(self.estimator_, "predict_proba", None)
         if callable(m):
             return self.pipeline_.predict_proba(X)
         else:


### PR DESCRIPTION
#### Reference Issue
Fixes #2374 (partial: `aeon/classification/convolution_based/_minirocket.py`)

#### What does this implement/fix?
As proposed in #2374, changes the fitted estimator attribute of `MiniRocketClassifier` from the protected `self._estimator` to the public fitted-attribute convention `self.estimator_` (trailing underscore), and documents it in the class docstring under **Attributes**, following the existing convention in e.g. `feature_based/_catch22.py`.

#### PR checklist
- [x] My PR follows the [guidelines](https://github.com/aeon-toolkit/aeon/blob/main/CONTRIBUTING.md) of this project
- [x] I have commented my code in a way that is clear and useful
- [x] I have added unit tests (only if needed): no new tests needed, existing `MiniRocketClassifier` tests cover the attribute rename
- [x] I have run the unit tests locally (skipped: no local dev environment; GitHub Actions CI will run the test suite)
- [x] Any dependent changes have been reviewed and merged