### PR TITLE
[MNT] Make estimator_ and transformers_ attributes public in BaseRIST

### DIFF
--- a/aeon/base/_estimators/hybrid/base_rist.py
+++ b/aeon/base/_estimators/hybrid/base_rist.py
@@ -93,6 +93,11 @@ class BaseRIST(ABC):
         The number of channels per case in the training set.
     n_timepoints_ : int
         The length of each series in the training set.
+    estimator_ : sklearn estimator
+        The fitted base estimator.
+    transformers_ : list
+        The list of fitted transformers used in the RIST pipeline.
+
     """
 
     # TODO remove 'use_pycatch22' in v1.7.0
@@ -123,14 +128,14 @@ class BaseRIST(ABC):
 
         rng = check_random_state(self.random_state)
 
-        self._estimator = self.estimator
+        self.estimator_ = self.estimator
         if self.estimator is None:
             if is_classifier(self):
-                self._estimator = ExtraTreesClassifier(
+                self.estimator_ = ExtraTreesClassifier(
                     n_estimators=200, criterion="entropy"
                 )
             elif is_regressor(self):
-                self._estimator = ExtraTreesRegressor(n_estimators=200)
+                self.estimator_ = ExtraTreesRegressor(n_estimators=200)
         # base_estimator must be an sklearn estimator
         elif not isinstance(self.estimator, BaseEstimator):
             raise ValueError(
@@ -138,11 +143,11 @@ class BaseRIST(ABC):
                 f"Found: {self.estimator}"
             )
 
-        self._estimator = _clone_estimator(self._estimator, rng)
+        self.estimator_ = _clone_estimator(self.estimator_, rng)
 
-        m = getattr(self._estimator, "n_jobs", "missing")
+        m = getattr(self.estimator_, "n_jobs", "missing")
         if m != "missing":
-            self._estimator.n_jobs = self._n_jobs
+            self.estimator_.n_jobs = self._n_jobs
 
         if self.series_transformers == "default":
             self._series_transformers = [
@@ -168,7 +173,7 @@ class BaseRIST(ABC):
             ]
 
         Xt = np.empty((X.shape[0], 0))
-        self._transformers = []
+        self.transformers_ = []
         for st in self._series_transformers:
             if st is not None:
                 m = getattr(st, "n_jobs", "missing")
@@ -206,7 +211,7 @@ class BaseRIST(ABC):
                 n_jobs=self._n_jobs,
             )
             _set_random_states(ct, rng)
-            self._transformers.append(ct)
+            self.transformers_.append(ct)
             t = ct.fit_transform(s, y)
 
             Xt = np.hstack((Xt, t))
@@ -222,27 +227,27 @@ class BaseRIST(ABC):
                 max_shapelets=n_shapelets, n_jobs=self._n_jobs
             )
             _set_random_states(st, rng)
-            self._transformers.append(st)
+            self.transformers_.append(st)
             t = st.fit_transform(s, y)
 
             Xt = np.hstack((Xt, t))
 
         Xt = np.nan_to_num(Xt, nan=0.0, posinf=0.0, neginf=0.0)
 
-        self._estimator.fit(Xt, y)
+        self.estimator_.fit(Xt, y)
 
         return self
 
     def _predict(self, X) -> np.ndarray:
-        return self._estimator.predict(self._transform_data(X))
+        return self.estimator_.predict(self._transform_data(X))
 
     def _predict_proba(self, X) -> np.ndarray:
-        m = getattr(self._estimator, "predict_proba", None)
+        m = getattr(self.estimator_, "predict_proba", None)
         if callable(m):
-            return self._estimator.predict_proba(self._transform_data(X))
+            return self.estimator_.predict_proba(self._transform_data(X))
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            preds = self._estimator.predict(self._transform_data(X))
+            preds = self.estimator_.predict(self._transform_data(X))
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1
             return dists
@@ -255,10 +260,10 @@ class BaseRIST(ABC):
             else:
                 s = X
 
-            t = self._transformers[i * 2].transform(s)
+            t = self.transformers_[i * 2].transform(s)
             Xt = np.hstack((Xt, t))
 
-            t = self._transformers[i * 2 + 1].transform(s)
+            t = self.transformers_[i * 2 + 1].transform(s)
             Xt = np.hstack((Xt, t))
 
         Xt = np.nan_to_num(Xt, nan=0.0, posinf=0.0, neginf=0.0)

--- a/aeon/base/_estimators/hybrid/base_rist.py
+++ b/aeon/base/_estimators/hybrid/base_rist.py
@@ -97,7 +97,8 @@ class BaseRIST(ABC):
         The fitted base estimator.
     transformers_ : list
         The list of fitted transformers used in the RIST pipeline.
-
+    series_transformers_ : list
+        The list of fitted series transformers used in the RIST pipeline.
     """
 
     # TODO remove 'use_pycatch22' in v1.7.0

--- a/aeon/base/_estimators/hybrid/base_rist.py
+++ b/aeon/base/_estimators/hybrid/base_rist.py
@@ -150,7 +150,7 @@ class BaseRIST(ABC):
             self.estimator_.n_jobs = self._n_jobs
 
         if self.series_transformers == "default":
-            self._series_transformers = [
+            self.series_transformers_ = [
                 None,
                 FunctionTransformer(func=first_order_differences_3d, validate=False),
                 PeriodogramTransformer(),
@@ -159,12 +159,12 @@ class BaseRIST(ABC):
                 ),
             ]
         elif isinstance(self.series_transformers, (list, tuple)):
-            self._series_transformers = [
+            self.series_transformers_ = [
                 None if st is None else _clone_estimator(st, random_state=rng)
                 for st in self.series_transformers
             ]
         else:
-            self._series_transformers = [
+            self.series_transformers_ = [
                 (
                     None
                     if self.series_transformers is None
@@ -174,7 +174,7 @@ class BaseRIST(ABC):
 
         Xt = np.empty((X.shape[0], 0))
         self.transformers_ = []
-        for st in self._series_transformers:
+        for st in self.series_transformers_:
             if st is not None:
                 m = getattr(st, "n_jobs", "missing")
                 if m != "missing":
@@ -254,7 +254,7 @@ class BaseRIST(ABC):
 
     def _transform_data(self, X):
         Xt = np.empty((X.shape[0], 0))
-        for i, st in enumerate(self._series_transformers):
+        for i, st in enumerate(self.series_transformers_):
             if st is not None:
                 s = st.transform(X)
             else:

--- a/aeon/base/_estimators/hybrid/tests/test_base_rist.py
+++ b/aeon/base/_estimators/hybrid/tests/test_base_rist.py
@@ -93,11 +93,11 @@ def test_rist_series_transform_input():
     )
     rist.fit(X, y)
 
-    assert len(rist._series_transformers) == 4
-    assert rist._series_transformers[0] is None
-    assert isinstance(rist._series_transformers[1], FunctionTransformer)
-    assert isinstance(rist._series_transformers[2], PeriodogramTransformer)
-    assert isinstance(rist._series_transformers[3], ARCoefficientTransformer)
+    assert len(rist.series_transformers_) == 4
+    assert rist.series_transformers_[0] is None
+    assert isinstance(rist.series_transformers_[1], FunctionTransformer)
+    assert isinstance(rist.series_transformers_[2], PeriodogramTransformer)
+    assert isinstance(rist.series_transformers_[3], ARCoefficientTransformer)
 
     rist = RISTClassifier(
         series_transformers=[
@@ -110,9 +110,9 @@ def test_rist_series_transform_input():
     )
     rist.fit(X, y)
 
-    assert len(rist._series_transformers) == 2
-    assert rist._series_transformers[0] is None
-    assert isinstance(rist._series_transformers[1], FunctionTransformer)
+    assert len(rist.series_transformers_) == 2
+    assert rist.series_transformers_[0] is None
+    assert isinstance(rist.series_transformers_[1], FunctionTransformer)
 
     rist = RISTClassifier(
         series_transformers=None,
@@ -122,7 +122,7 @@ def test_rist_series_transform_input():
     )
     rist.fit(X, y)
 
-    assert rist._series_transformers == [None]
+    assert rist.series_transformers_ == [None]
 
 
 @pytest.mark.skipif(

--- a/aeon/base/_estimators/hybrid/tests/test_base_rist.py
+++ b/aeon/base/_estimators/hybrid/tests/test_base_rist.py
@@ -55,11 +55,11 @@ def test_rist_estimator_input():
 
     rist = RISTClassifier(n_intervals=3, n_shapelets=3, series_transformers=None)
     rist.fit(X, y)
-    assert isinstance(rist._estimator, ExtraTreesClassifier)
+    assert isinstance(rist.estimator_, ExtraTreesClassifier)
 
     rist = RISTRegressor(n_intervals=3, n_shapelets=3, series_transformers=None)
     rist.fit(X, y)
-    assert isinstance(rist._estimator, ExtraTreesRegressor)
+    assert isinstance(rist.estimator_, ExtraTreesRegressor)
 
     with pytest.raises(
         ValueError, match="base_estimator must be a scikit-learn BaseEstimator"

--- a/aeon/classification/hybrid/_rist.py
+++ b/aeon/classification/hybrid/_rist.py
@@ -80,6 +80,12 @@ class RISTClassifier(BaseRIST, BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : ndarray of shape (n_classes_)
         Holds the label for each class.
+    estimator_ : sklearn estimator
+        The fitted base estimator.
+    transformers_ : list
+        The list of fitted transformenrs used in the RIST pipeline.
+    series_transformers_ : list
+        The list of fitted series transformers used in the RIST pipeline.
 
     See Also
     --------

--- a/aeon/regression/hybrid/_rist.py
+++ b/aeon/regression/hybrid/_rist.py
@@ -71,6 +71,12 @@ class RISTRegressor(BaseRIST, BaseRegressor):
         The number of channels per case in the training set.
     n_timepoints_ : int
         The length of each series in the training set.
+    estimator_ : sklearn estimator
+        The fitted base estimator.
+    transformers_ : list
+        The list of fitted transformenrs used in the RIST pipeline.
+    series_transformers_ : list
+        The list of fitted series transformers used in the RIST pipeline.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #2374 - renames `_estimator` and `_transformers` to `estimator_` and `transformers_` in `BaseRIST` and documents them in the class docstring.

#### What does this implement/fix? Explain your changes.

Renames the internal `_estimator` and `_transformers` attributes to `estimator_` and `transformers_` on `BaseRIST`, following the trailing underscore convention.

Adds the new `estimator_` and `transformers_` attributes to class docstring's Attribute section.

#### Does your contribution introduce a new dependency? If yes, which one?

None

#### Any other comments?

Existing test suite passes unchanges, as `test_all_estimators.py` verifies the state updates for the concrete class inheriting from this abstract base class.

### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.