### PR TITLE
[MNT] Make model_ attribute public in ARIMA and ETS

### DIFF
--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -68,6 +68,8 @@ class ARIMA(BaseForecaster, IterativeForecastingMixin):
         Coefficients for autoregressive terms (length p).
     theta_ : np.ndarray
         Coefficients for moving average terms (length q).
+    model_ : np.ndarray
+        Array containing the structure of the fitted model (constant, p, q).
 
     References
     ----------

--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -102,7 +102,7 @@ class ARIMA(BaseForecaster, IterativeForecastingMixin):
         self.residuals_ = []
         self.fitted_values_ = []
         self.aic_ = 0
-        self._model = []
+        self.model_ = []
         self._parameters = []
         self.exog_ = None
         self.beta_ = None
@@ -146,17 +146,17 @@ class ARIMA(BaseForecaster, IterativeForecastingMixin):
             self.exog_n_features_ = None
 
         # Model is an array of the (c,p,q)
-        self._model = np.array(
+        self.model_ = np.array(
             (1 if self.use_constant else 0, self.p, self.q), dtype=np.int32
         )
         self._differenced_series = np.diff(series_for_arima, n=self.d)
-        s = 0.1 / (np.sum(self._model) + 1)  # Randomise
+        s = 0.1 / (np.sum(self.model_) + 1)  # Randomise
         # Nelder Mead returns the parameters in a single array
         self._parameters, self.aic_ = nelder_mead(
             0,
-            np.sum(self._model[:3]),
+            np.sum(self.model_[:3]),
             self._differenced_series,
-            self._model,
+            self.model_,
             max_iter=self.iterations,
             simplex_init=s,
         )
@@ -164,10 +164,10 @@ class ARIMA(BaseForecaster, IterativeForecastingMixin):
         self.aic_, self.residuals_, self.fitted_values_ = _arima_model(
             self._parameters,
             self._differenced_series,
-            self._model,
+            self.model_,
         )
         formatted_params = _extract_arma_params(
-            self._parameters, self._model
+            self._parameters, self.model_
         )  # Extract
         # parameters
         differenced_forecast = self.fitted_values_[-1]

--- a/aeon/forecasting/stats/_arima.py
+++ b/aeon/forecasting/stats/_arima.py
@@ -104,7 +104,6 @@ class ARIMA(BaseForecaster, IterativeForecastingMixin):
         self.residuals_ = []
         self.fitted_values_ = []
         self.aic_ = 0
-        self.model_ = []
         self._parameters = []
         self.exog_ = None
         self.beta_ = None

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -75,6 +75,9 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
         Log-likelihood of the fitted model.
     n_timepoints_ : int
         Number of time points in the training series.
+    model_ : np.ndarray
+        Array containing the structure of the fitted model (error, trend,
+        seasonality, seasonal_period).
 
     References
     ----------

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -123,7 +123,7 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
         self.aic_ = 0
         self.residuals_ = []
         self.fitted_values_ = []
-        self._model = []
+        self.model_ = []
         self.parameters_ = []
         self.alpha_ = 0
         self.beta_ = 0
@@ -169,7 +169,7 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
         self._seasonal_period = self.seasonal_period
         if self._seasonal_period < 1 or self._seasonality_type == 0:
             self._seasonal_period = 1
-        self._model = np.array(
+        self.model_ = np.array(
             [
                 self._error_type,
                 self._trend_type,
@@ -183,11 +183,11 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
             1,
             1 + 2 * (self._trend_type != 0) + (self._seasonality_type != 0),
             data,
-            self._model,
+            self.model_,
             max_iter=self.iterations,
         )
         self.alpha_, self.beta_, self.gamma_, self.phi_ = _extract_ets_params(
-            self.parameters_, self._model
+            self.parameters_, self.model_
         )
         (
             self.aic_,
@@ -200,7 +200,7 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
             self.avg_mean_sq_err_,
             self.likelihood_,
             self.k_,
-        ) = _ets_fit(self.parameters_, data, self._model)
+        ) = _ets_fit(self.parameters_, data, self.model_)
         self.forecast_ = _numba_predict(
             self._trend_type,
             self._seasonality_type,

--- a/aeon/forecasting/stats/_ets.py
+++ b/aeon/forecasting/stats/_ets.py
@@ -126,7 +126,6 @@ class ETS(BaseForecaster, IterativeForecastingMixin):
         self.aic_ = 0
         self.residuals_ = []
         self.fitted_values_ = []
-        self.model_ = []
         self.parameters_ = []
         self.alpha_ = 0
         self.beta_ = 0

--- a/aeon/forecasting/stats/tests/test_arima.py
+++ b/aeon/forecasting/stats/tests/test_arima.py
@@ -473,3 +473,18 @@ def test_auto_arima_zero_order_limits():
     f.fit(y)
     assert f.p_ == 0
     assert f.q_ == 0
+
+
+def test_arima_model_attribute_lifecycle():
+    """Test model_ set after fitting, not before and _model doesn't exist."""
+    y = np.arange(30.0)
+    forecaster = ARIMA()
+
+    assert not hasattr(forecaster, "model_")
+    assert not hasattr(forecaster, "_model")
+
+    forecaster.fit(y)
+
+    assert hasattr(forecaster, "model_")
+    assert not hasattr(forecaster, "_model")
+    assert isinstance(forecaster.model_, np.ndarray)

--- a/aeon/forecasting/stats/tests/test_ets.py
+++ b/aeon/forecasting/stats/tests/test_ets.py
@@ -434,3 +434,17 @@ def test_auto_ets_negative_data_skips_multiplicative():
     assert f.trend_type_ != 2
     assert f.seasonality_type_ != 2
     assert np.isfinite(f.forecast_)
+
+
+def test_ets_model_attribute_lifecycle():
+    """Test model_ set after fitting, not before and _model doesn't exist."""
+    y = np.arange(30.0)
+    forecaster = ETS()
+
+    assert not hasattr(forecaster, "model_")
+    assert not hasattr(forecaster, "_model")
+
+    forecaster.fit(y)
+
+    assert hasattr(forecaster, "model_")
+    assert not hasattr(forecaster, "_model")


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #2374 - Renames `_model` to `model_` across `forecasting/stats/` (`ARIMA` and `ETS`), removes early attribute initialization from `__init__`, and documents each in its class docstring.

#### What does this implement/fix? Explain your changes.

- Renames the internal `_model` to `model_` across `forecasting/stats/` (ARIMA, ETS, CES, etc.) and documents `model_` under Attributes in each class docstring.

- Removes the early initialization of `self.model_ = []` from `__init__` in `ARIMA` and `ETS` so that fitted attributes are created strictly during `fit()`.

- Adds unit tests (`test_arima_model_attribute_lifecycle` and `test_ets_model_attribute_lifecycle`) to verify that `model_` is only set after fitting and that the `_model` attribute no longer exists.

#### Does your contribution introduce a new dependency? If yes, which one?

None

#### Any other comments?

Existing test suites across `forecasting/stats/` pass cleanly with all attribute assertions updated to use `model_`:

- `forecasting/stats/tests/test_arima.py`

- `forecasting/stats/tests/test_ets.py`

- `forecasting/stats/tests/test_ces.py`

### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.