### PR TITLE
[MNT] Make estimator and transformer attributes public in interval-based classifiers

### DIFF
--- a/aeon/classification/interval_based/_interval_pipelines.py
+++ b/aeon/classification/interval_based/_interval_pipelines.py
@@ -75,6 +75,10 @@ class RandomIntervalClassifier(BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : ndarray of shape (n_classes)
         Holds the label for each class.
+    estimator_ : BaseEstimator
+        The fitted estimator for the classifier.
+    transformer_ : RandomIntervals
+        The fitted transformer for the classifier.
 
     See Also
     --------
@@ -146,7 +150,7 @@ class RandomIntervalClassifier(BaseClassifier):
         self.n_cases_, self.n_channels_, self.n_timepoints_ = X.shape
         self._n_jobs = check_n_jobs(self.n_jobs)
 
-        self._transformer = RandomIntervals(
+        self.transformer_ = RandomIntervals(
             n_intervals=self.n_intervals,
             min_interval_length=self.min_interval_length,
             max_interval_length=self.max_interval_length,
@@ -157,7 +161,7 @@ class RandomIntervalClassifier(BaseClassifier):
             parallel_backend=self.parallel_backend,
         )
 
-        self._estimator = _clone_estimator(
+        self.estimator_ = _clone_estimator(
             (
                 RandomForestClassifier(n_estimators=200)
                 if self.estimator is None
@@ -166,11 +170,11 @@ class RandomIntervalClassifier(BaseClassifier):
             self.random_state,
         )
 
-        if hasattr(self._estimator, "n_jobs"):
-            self._estimator.n_jobs = self._n_jobs
+        if hasattr(self.estimator_, "n_jobs"):
+            self.estimator_.n_jobs = self._n_jobs
 
-        X_t = self._transformer.fit_transform(X, y)
-        self._estimator.fit(X_t, y)
+        X_t = self.transformer_.fit_transform(X, y)
+        self.estimator_.fit(X_t, y)
 
         return self
 
@@ -187,7 +191,7 @@ class RandomIntervalClassifier(BaseClassifier):
         y : array-like, shape = [n_cases]
             Predicted class labels.
         """
-        return self._estimator.predict(self._transformer.transform(X))
+        return self.estimator_.predict(self.transformer_.transform(X))
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predicts labels probabilities for sequences in X.
@@ -202,12 +206,12 @@ class RandomIntervalClassifier(BaseClassifier):
         y : array-like, shape = [n_cases, n_classes_]
             Predicted probabilities using the ordering in classes_.
         """
-        m = getattr(self._estimator, "predict_proba", None)
+        m = getattr(self.estimator_, "predict_proba", None)
         if callable(m):
-            return self._estimator.predict_proba(self._transformer.transform(X))
+            return self.estimator_.predict_proba(self.transformer_.transform(X))
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            preds = self._estimator.predict(self._transformer.transform(X))
+            preds = self.estimator_.predict(self.transformer_.transform(X))
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1
             return dists
@@ -311,6 +315,10 @@ class SupervisedIntervalClassifier(BaseClassifier):
         Number of classes. Extracted from the data.
     classes_ : ndarray of shape (n_classes)
         Holds the label for each class.
+    estimator_ : BaseEstimator
+        The fitted estimator for the classifier.
+    transformer_ : SupervisedIntervals
+        The fitted transformer for the classifier.
 
     See Also
     --------
@@ -384,7 +392,7 @@ class SupervisedIntervalClassifier(BaseClassifier):
         self.n_cases_, self.n_channels_, self.n_timepoints_ = X.shape
         self._n_jobs = check_n_jobs(self.n_jobs)
 
-        self._transformer = SupervisedIntervals(
+        self.transformer_ = SupervisedIntervals(
             n_intervals=self.n_intervals,
             min_interval_length=self.min_interval_length,
             features=self.features,
@@ -396,7 +404,7 @@ class SupervisedIntervalClassifier(BaseClassifier):
             parallel_backend=self.parallel_backend,
         )
 
-        self._estimator = _clone_estimator(
+        self.estimator_ = _clone_estimator(
             (
                 RandomForestClassifier(n_estimators=200)
                 if self.estimator is None
@@ -405,11 +413,11 @@ class SupervisedIntervalClassifier(BaseClassifier):
             self.random_state,
         )
 
-        if hasattr(self._estimator, "n_jobs"):
-            self._estimator.n_jobs = self._n_jobs
+        if hasattr(self.estimator_, "n_jobs"):
+            self.estimator_.n_jobs = self._n_jobs
 
-        X_t = self._transformer.fit_transform(X, y)
-        self._estimator.fit(X_t, y)
+        X_t = self.transformer_.fit_transform(X, y)
+        self.estimator_.fit(X_t, y)
 
         return self
 
@@ -426,7 +434,7 @@ class SupervisedIntervalClassifier(BaseClassifier):
         y : array-like, shape = [n_cases]
             Predicted class labels.
         """
-        return self._estimator.predict(self._transformer.transform(X))
+        return self.estimator_.predict(self.transformer_.transform(X))
 
     def _predict_proba(self, X) -> np.ndarray:
         """Predicts labels probabilities for sequences in X.
@@ -441,12 +449,12 @@ class SupervisedIntervalClassifier(BaseClassifier):
         y : array-like, shape = [n_cases, n_classes_]
             Predicted probabilities using the ordering in classes_.
         """
-        m = getattr(self._estimator, "predict_proba", None)
+        m = getattr(self.estimator_, "predict_proba", None)
         if callable(m):
-            return self._estimator.predict_proba(self._transformer.transform(X))
+            return self.estimator_.predict_proba(self.transformer_.transform(X))
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            preds = self._estimator.predict(self._transformer.transform(X))
+            preds = self.estimator_.predict(self.transformer_.transform(X))
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1
             return dists

--- a/aeon/classification/interval_based/_quant.py
+++ b/aeon/classification/interval_based/_quant.py
@@ -54,6 +54,13 @@ class QUANTClassifier(BaseClassifier):
         If `None`, the random number generator is the `RandomState` instance used
         by `np.random`.
 
+    Attributes
+    ----------
+    estimator_ : BaseEstimator
+        The fitted estimator for the classifier.
+    transformer_ : QUANTTransformer
+        The fitted transformer for the classifier.
+
     See Also
     --------
     QUANTTransformer
@@ -116,12 +123,12 @@ class QUANTClassifier(BaseClassifier):
         self :
             Reference to self.
         """
-        self._transformer = QUANTTransformer(
+        self.transformer_ = QUANTTransformer(
             interval_depth=self.interval_depth,
             quantile_divisor=self.quantile_divisor,
         )
 
-        self._estimator = _clone_estimator(
+        self.estimator_ = _clone_estimator(
             (
                 ExtraTreesClassifier(
                     n_estimators=200,
@@ -136,8 +143,8 @@ class QUANTClassifier(BaseClassifier):
             self.random_state,
         )
 
-        X_t = self._transformer.fit_transform(X, y)
-        self._estimator.fit(X_t, y)
+        X_t = self.transformer_.fit_transform(X, y)
+        self.estimator_.fit(X_t, y)
 
         return self
 
@@ -154,7 +161,7 @@ class QUANTClassifier(BaseClassifier):
         y : array-like of shape (n_cases)
             Predicted class labels.
         """
-        return self._estimator.predict(self._transformer.transform(X))
+        return self.estimator_.predict(self.transformer_.transform(X))
 
     def _predict_proba(self, X):
         """Predicts labels probabilities for sequences in X.
@@ -169,12 +176,12 @@ class QUANTClassifier(BaseClassifier):
         y : array-like of shape (n_cases, n_classes_)
             Predicted probabilities using the ordering in classes_.
         """
-        m = getattr(self._estimator, "predict_proba", None)
+        m = getattr(self.estimator_, "predict_proba", None)
         if callable(m):
-            return self._estimator.predict_proba(self._transformer.transform(X))
+            return self.estimator_.predict_proba(self.transformer_.transform(X))
         else:
             dists = np.zeros((X.shape[0], self.n_classes_))
-            preds = self._estimator.predict(self._transformer.transform(X))
+            preds = self.estimator_.predict(self.transformer_.transform(X))
             for i in range(0, X.shape[0]):
                 dists[i, self._class_dictionary[preds[i]]] = 1
             return dists

--- a/aeon/classification/interval_based/_rstsf.py
+++ b/aeon/classification/interval_based/_rstsf.py
@@ -47,6 +47,13 @@ class RSTSF(BaseClassifier):
         The number of jobs to run in parallel for both `fit` and `predict` functions.
         `-1` means using all processors.
 
+    Attributes
+    ----------
+    transformers_ : list
+        The fitted transformers for the classifier.
+    series_transformers_ : list
+        The fitted series transformers for the classifier.
+
     See Also
     --------
     SupervisedIntervals
@@ -99,16 +106,16 @@ class RSTSF(BaseClassifier):
 
         lags = int(12 * (X.shape[2] / 100.0) ** 0.25)
 
-        self._series_transformers = [
+        self.series_transformers_ = [
             FunctionTransformer(func=first_order_differences_3d, validate=False),
             PeriodogramTransformer(),
             ARCoefficientTransformer(order=lags, replace_nan=True),
         ]
 
-        transforms = [X] + [t.fit_transform(X) for t in self._series_transformers]
+        transforms = [X] + [t.fit_transform(X) for t in self.series_transformers_]
 
         Xt = np.empty((X.shape[0], 0))
-        self._transformers = []
+        self.transformers_ = []
         transform_data_lengths = []
         for t in transforms:
             si = SupervisedIntervals(
@@ -120,7 +127,7 @@ class RSTSF(BaseClassifier):
             )
             features = si.fit_transform(t, y)
             Xt = np.hstack((Xt, features))
-            self._transformers.append(si)
+            self.transformers_.append(si)
             transform_data_lengths.append(features.shape[1])
 
         self.clf_ = ExtraTreesClassifier(
@@ -144,7 +151,7 @@ class RSTSF(BaseClassifier):
 
         count = 0
         for r in range(len(transforms)):
-            self._transformers[r].set_features_to_transform(
+            self.transformers_[r].set_features_to_transform(
                 features_to_transform[count : count + transform_data_lengths[r]],
                 raise_error=False,
             )
@@ -161,11 +168,11 @@ class RSTSF(BaseClassifier):
         return self.clf_.predict_proba(Xt)
 
     def _predict_transform(self, X):
-        transforms = [X] + [t.transform(X) for t in self._series_transformers]
+        transforms = [X] + [t.transform(X) for t in self.series_transformers_]
 
         Xt = np.empty((X.shape[0], 0))
         for i, t in enumerate(transforms):
-            si = self._transformers[i]
+            si = self.transformers_[i]
             Xt = np.hstack((Xt, si.transform(t)))
 
         return Xt

--- a/aeon/classification/interval_based/tests/test_interval_pipelines.py
+++ b/aeon/classification/interval_based/tests/test_interval_pipelines.py
@@ -9,6 +9,7 @@ from aeon.classification.interval_based import (
 )
 from aeon.testing.testing_data import EQUAL_LENGTH_UNIVARIATE_CLASSIFICATION
 from aeon.testing.utils.estimator_checks import _assert_predict_probabilities
+from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,10 @@ def test_interval_pipeline_classifiers(cls):
     _assert_predict_probabilities(prob, X_test, n_classes=2)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_interval_classifier_estimator_attribute_lifecycle():
     """Test estimator and transformer attributes are created only on fit."""
     from aeon.classification.interval_based import (
@@ -65,6 +70,10 @@ def test_interval_classifier_estimator_attribute_lifecycle():
         assert not hasattr(clf, "_transformer")
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 def test_rstsf_transformers_attribute_lifecycle():
     """Test transformers and series_transformers attributes are created only on fit."""
     from aeon.classification.interval_based import RSTSF

--- a/aeon/classification/interval_based/tests/test_interval_pipelines.py
+++ b/aeon/classification/interval_based/tests/test_interval_pipelines.py
@@ -28,3 +28,64 @@ def test_interval_pipeline_classifiers(cls):
     clf.fit(X_train, y_train)
     prob = clf.predict_proba(X_test)
     _assert_predict_probabilities(prob, X_test, n_classes=2)
+
+
+def test_interval_classifier_estimator_attribute_lifecycle():
+    """Test estimator and transformer attributes are created only on fit."""
+    from aeon.classification.interval_based import (
+        QUANTClassifier,
+        RandomIntervalClassifier,
+        SupervisedIntervalClassifier,
+    )
+    from aeon.testing.data_generation import make_example_3d_numpy
+
+    X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=20)
+
+    for cls in [
+        QUANTClassifier,
+        RandomIntervalClassifier,
+        SupervisedIntervalClassifier,
+    ]:
+        params = cls._get_test_params()
+        if isinstance(params, list):
+            params = params[0]
+
+        clf = cls(**params)
+
+        assert not hasattr(clf, "estimator_")
+        assert not hasattr(clf, "_estimator")
+        assert not hasattr(clf, "transformer_")
+        assert not hasattr(clf, "_transformer")
+
+        clf.fit(X, y)
+
+        assert hasattr(clf, "estimator_")
+        assert not hasattr(clf, "_estimator")
+        assert hasattr(clf, "transformer_")
+        assert not hasattr(clf, "_transformer")
+
+
+def test_rstsf_transformers_attribute_lifecycle():
+    """Test transformers and series_transformers attributes are created only on fit."""
+    from aeon.classification.interval_based import RSTSF
+    from aeon.testing.data_generation import make_example_3d_numpy
+
+    X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=20)
+
+    params = RSTSF._get_test_params()
+    if isinstance(params, list):
+        params = params[0]
+
+    clf = RSTSF(**params)
+
+    assert not hasattr(clf, "transformers_")
+    assert not hasattr(clf, "_transformers")
+    assert not hasattr(clf, "series_transformers_")
+    assert not hasattr(clf, "_series_transformers")
+
+    clf.fit(X, y)
+
+    assert hasattr(clf, "transformers_")
+    assert not hasattr(clf, "_transformers")
+    assert hasattr(clf, "series_transformers_")
+    assert not hasattr(clf, "_series_transformers")


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #2374.

#### What does this implement/fix? Explain your changes.

* **`QUANTClassifier`, `RandomIntervalClassifier`, `SupervisedIntervalClassifier`:** Renames `_estimator` and `_transformer` to `estimator_` and `transformer_`.
* **`RSTSF`:** Renames `_transformers` and `_series_transformers` to `transformers_` and `series_transformers_`.
* **Initialization:** Removes `__init__` declarations for all the above attributes to ensure they are created strictly during `fit()`.
* **Documentation:** Adds the renamed attributes to their respective class docstrings.
* **Tests:** Adds `test_interval_classifier_estimator_attribute_lifecycle` and `test_rstsf_transformers_attribute_lifecycle` to `test_interval_pipelines.py` to verify attributes are only present after fitting.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### Any other comments?

Note: Alongside the attributes listed in #2374, `_series_transformers` and `_transformer` were also renamed to address previous reviewer feedback.

### PR checklist

##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.