### PR TITLE
[DOC] Replace "indexes" with "indices" in docstrings for numpy consistency

### DIFF
--- a/aeon/benchmarking/metrics/segmentation.py
+++ b/aeon/benchmarking/metrics/segmentation.py
@@ -23,9 +23,9 @@ def count_error(
     Parameters
     ----------
     true_change_points: array_like
-        Integer indexes (positions) of true change points
+        Integer indices (positions) of true change points
     pred_change_points: array_like
-        Integer indexes (positions) of predicted change points
+        Integer indices (positions) of predicted change points
 
     Returns
     -------
@@ -52,9 +52,9 @@ def hausdorff_error(
     Parameters
     ----------
     true_change_points: array_like
-        Integer indexes (positions) of true change points
+        Integer indices (positions) of true change points
     pred_change_points: array_like
-        Integer indexes (positions) of predicted change points
+        Integer indices (positions) of predicted change points
     symmetric: bool
         If ``True`` symmetric Hausdorff distance will be used
     seed: int, default=0
@@ -85,9 +85,9 @@ def prediction_ratio(
     Parameters
     ----------
     true_change_points: array_like
-        Integer indexes (positions) of true change points
+        Integer indices (positions) of true change points
     pred_change_points: array_like
-        Integer indexes (positions) of predicted change points
+        Integer indices (positions) of predicted change points
 
     Returns
     -------

--- a/aeon/classification/shapelet_based/_rdst.py
+++ b/aeon/classification/shapelet_based/_rdst.py
@@ -51,7 +51,7 @@ class RDSTClassifier(BaseClassifier):
         will be used.
     alpha_similarity : float, default=0.5
         The strength of the alpha similarity pruning. The higher the value, the fewer
-        common indexes with previously sampled shapelets are allowed when sampling a
+        common indices with previously sampled shapelets are allowed when sampling a
         new candidate with the same dilation parameter. It can cause the number of
         sampled shapelets to be lower than max_shapelets if the whole search space has
         been covered. The default is 0.5, and the maximum is 1. Values above it have

--- a/aeon/distances/elastic/_erp.py
+++ b/aeon/distances/elastic/_erp.py
@@ -27,7 +27,7 @@ def erp_distance(
     r"""Compute the ERP distance between two time series.
 
     Edit Distance with Real Penalty, ERP, first proposed in [1]_, attempts to align
-    time series by better considering how indexes are carried forward through the
+    time series by better considering how indices are carried forward through the
     cost matrix. Usually in the dtw cost matrix, if an alignment cannot be found the
     previous value is carried forward in  the move off the diagonal. ERP instead
     proposes the idea of gaps or sequences of points that have no matches. These

--- a/aeon/distances/elastic/_lcss.py
+++ b/aeon/distances/elastic/_lcss.py
@@ -55,7 +55,7 @@ def lcss_distance(
 
     LCSS attempts to find the longest common sequence between two time series and
     returns a value that is the percentage that longest common sequence assumes.
-    Originally present in [1]_, LCSS is computed by matching indexes that are
+    Originally present in [1]_, LCSS is computed by matching indices that are
     similar up until a defined threshold (epsilon).
 
     The value returned will be between 0.0 and 1.0, where 0.0 means the two time series

--- a/aeon/regression/shapelet_based/_rdst.py
+++ b/aeon/regression/shapelet_based/_rdst.py
@@ -50,7 +50,7 @@ class RDSTRegressor(BaseRegressor):
         will be used.
     alpha_similarity : float, default=0.5
         The strength of the alpha similarity pruning. The higher the value, the lower
-        the allowed number of common indexes with previously sampled shapelets
+        the allowed number of common indices with previously sampled shapelets
         when sampling a new candidate with the same dilation parameter.
         It can cause the number of sampled shapelets to be lower than max_shapelets if
         the whole search space has been covered. The default is 0.5, and the maximum is

--- a/aeon/segmentation/_ggs.py
+++ b/aeon/segmentation/_ggs.py
@@ -91,7 +91,7 @@ class _GGS:
     Attributes
     ----------
     change_points_: array_like, default=[]
-        Locations of change points as integer indexes. By convention change points
+        Locations of change points as integer indices. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
     _intermediate_change_points: List[List[int]], default=[]
         Intermediate values of change points for each value of k = 1...k_max
@@ -166,7 +166,7 @@ class _GGS:
             2D `array_like` representing time series with sequence index along
             the first dimension and value series as columns.
         change_points: list of ints
-            Locations of change points as integer indexes. By convention change points
+            Locations of change points as integer indices. By convention change points
             include the identity segmentation, i.e. first and last index + 1 values.
 
         Returns
@@ -259,7 +259,7 @@ class _GGS:
             2D `array_like` representing time series with sequence index along
             the first dimension and value series as columns.
         change_points: list of ints
-            Locations of change points as integer indexes. By convention change points
+            Locations of change points as integer indices. By convention change points
             include the identity segmentation, i.e. first and last index + 1 values.
         new_index: list of ints
             New change points
@@ -267,7 +267,7 @@ class _GGS:
         Returns
         -------
         change_points: list of ints
-            Locations of change points as integer indexes. By convention change points
+            Locations of change points as integer indices. By convention change points
             include the identity segmentation, i.e. first and last index + 1 values.
         """
         rng = check_random_state(self.random_state)
@@ -412,7 +412,7 @@ class GreedyGaussianSegmenter(BaseSegmenter):
     Attributes
     ----------
     change_points_: array_like, default=[]
-        Locations of change points as integer indexes. By convention change points
+        Locations of change points as integer indices. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
     _intermediate_change_points: List[List[int]], default=[]
         Intermediate values of change points for each value of k = 1...k_max

--- a/aeon/segmentation/_igts.py
+++ b/aeon/segmentation/_igts.py
@@ -67,7 +67,7 @@ def generate_segments(X: npt.ArrayLike, change_points: list[int]) -> npt.ArrayLi
         and value series in columns.
 
     change_points: list of int
-        Locations of change points as integer indexes. By convention change points
+        Locations of change points as integer indices. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
 
     Yields
@@ -89,7 +89,7 @@ def generate_segments_pandas(X: npt.ArrayLike, change_points: list) -> npt.Array
         and value series in columns.
 
     change_points: list of int
-        Locations of change points as integer indexes. By convention change points
+        Locations of change points as integer indices. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
 
     Yields
@@ -157,7 +157,7 @@ class _IGTS:
     intermediate_results_: list = field(init=False, default_factory=list)
 
     def identity(self, X: npt.ArrayLike) -> list[int]:
-        """Return identity segmentation, i.e. terminal indexes of the data."""
+        """Return identity segmentation, i.e. terminal indices of the data."""
         return sorted([0, X.shape[0]])
 
     def get_candidates(self, n_samples: int, change_points: list[int]) -> list[int]:
@@ -193,7 +193,7 @@ class _IGTS:
             and value series in columns.
 
         change_points: list of ints
-            Locations of change points as integer indexes. By convention change points
+            Locations of change points as integer indices. By convention change points
             include the identity segmentation, i.e. first and last index + 1 values.
 
         Returns
@@ -223,7 +223,7 @@ class _IGTS:
         Returns
         -------
         change_points: list of ints
-            Locations of change points as integer indexes. By convention change points
+            Locations of change points as integer indices. By convention change points
             include the identity segmentation, i.e. first and last index + 1 values.
         """
         n_samples, n_series = X.shape
@@ -296,7 +296,7 @@ class InformationGainSegmenter(BaseSegmenter):
     Attributes
     ----------
     change_points_: list of int
-        Locations of change points as integer indexes. By convention change points
+        Locations of change points as integer indices. By convention change points
         include the identity segmentation, i.e. first and last index + 1 values.
 
     intermediate_results_: list of ``ChangePointResult``

--- a/aeon/segmentation/base.py
+++ b/aeon/segmentation/base.py
@@ -145,7 +145,7 @@ class BaseSegmenter(BaseSeriesEstimator):
         Returns
         -------
         List
-            Either a list of indexes of X indicating where each segment begins or a
+            Either a list of indices of X indicating where each segment begins or a
             list of integers of ``len(X)`` indicating which segment each time point
             belongs to.
         """

--- a/aeon/transformations/collection/channel_selection/base.py
+++ b/aeon/transformations/collection/channel_selection/base.py
@@ -1,7 +1,7 @@
 """Base channel selection transformer.
 
 Extends BaseCollectionTransformer and implements _transform to return
-selected indexes.
+selected indices.
 """
 
 __maintainer__ = ["TonyBagnall"]

--- a/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py
@@ -78,7 +78,7 @@ class RandomDilatedShapeletTransform(BaseCollectionTransformer):
         will be used.
     alpha_similarity : float, default=0.5
         The strength of the alpha similarity pruning. The higher the value, the fewer
-        common indexes with previously sampled shapelets are allowed when sampling a
+        common indices with previously sampled shapelets are allowed when sampling a
         new candidate with the same dilation parameter. It can cause the number of
         sampled shapelets to be lower than max_shapelets if the whole search space
         has been covered. The default is 0.5, and the maximum is 1. Values above it
@@ -683,7 +683,7 @@ def random_dilated_shapelet_extraction(
         Occurrence feature.
     alpha_similarity : float
         The strength of the alpha similarity pruning. The higher the value, the lower
-        the allowed number of common indexes with previously sampled shapelets
+        the allowed number of common indices with previously sampled shapelets
         when sampling a new candidate with the same dilation parameter.
         It can cause the number of sampled shapelets to be lower than max_shapelets if
         the whole search space has been covered. The default is 0.5.

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -607,7 +607,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
             [s[_CHANNEL] for s in self.shapelets], dtype=np.int32
         )
         # A shapelet's values and its sorted indices share the same length, so
-        # one offsets array indexes both flat buffers.
+        # one offsets array indices into both flat buffers.
         self._transform_offsets = np.zeros(len(self.shapelets) + 1, dtype=np.int64)
         self._transform_offsets[1:] = np.cumsum(self._transform_lengths)
         if len(self.shapelets) == 0:

--- a/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
+++ b/aeon/transformations/collection/shapelet_based/_shapelet_transform.py
@@ -607,7 +607,7 @@ class RandomShapeletTransform(BaseCollectionTransformer):
             [s[_CHANNEL] for s in self.shapelets], dtype=np.int32
         )
         # A shapelet's values and its sorted indices share the same length, so
-        # one offsets array indices into both flat buffers.
+        # one offsets array is used to index into both flat buffers.
         self._transform_offsets = np.zeros(len(self.shapelets) + 1, dtype=np.int64)
         self._transform_offsets[1:] = np.cumsum(self._transform_lengths)
         if len(self.shapelets) == 0:

--- a/aeon/transformations/collection/signature_based/_signature.py
+++ b/aeon/transformations/collection/signature_based/_signature.py
@@ -268,7 +268,7 @@ def _window_getter(
     -------
     list:
         A list of lists where the inner lists are lists of tuples that
-        denote the start and end indexes of each window.
+        denote the start and end indices of each window.
     """
     # Setup all available windows here
     length_step = {"length": window_length, "step": window_step}

--- a/aeon/utils/numba/general.py
+++ b/aeon/utils/numba/general.py
@@ -531,7 +531,7 @@ def sliding_mean_std_one_series(
     std = np.zeros((n_channels, n_subs))
 
     for i_mod_dil in prange(dilation):
-        # Array mainting indexes of a dilated subsequence
+        # Array maintaining indices of a dilated subsequence
         _idx_sub = np.zeros(length, dtype=np.intp)
         for i_length in prange(length):
             _idx_sub[i_length] = (i_length * dilation) + i_mod_dil


### PR DESCRIPTION
Closes #3735 

Following up on #3491 and #3530, this PR replaces remaining occurrences of 
"indexes" with "indices" in docstrings and comments across the codebase, 
for consistency with numpy terminology.

Only docstrings and comments are changed — no variable names, no logic touched.

**Files changed:**
- `aeon/segmentation/_igts.py`
- `aeon/segmentation/_ggs.py`
- `aeon/segmentation/base.py`
- `aeon/benchmarking/metrics/segmentation.py`
- `aeon/classification/shapelet_based/_rdst.py`
- `aeon/regression/shapelet_based/_rdst.py`
- `aeon/transformations/collection/shapelet_based/_dilated_shapelet_transform.py`
- `aeon/transformations/collection/shapelet_based/_shapelet_transform.py`
- `aeon/utils/numba/general.py`