### PR TITLE
[MNT] Expose YeoJohnsonTransformer through public API

### DIFF
--- a/aeon/transformations/series/__init__.py
+++ b/aeon/transformations/series/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "StatsModelsPACF",
     "BKFilter",
     "BoxCoxTransformer",
+    "YeoJohnsonTransformer",
     "ScaledLogitSeriesTransformer",
     "PCASeriesTransformer",
     "STLSeriesTransformer",
@@ -43,6 +44,7 @@ from aeon.transformations.series._pla import PLASeriesTransformer
 from aeon.transformations.series._scaled_logit import ScaledLogitSeriesTransformer
 from aeon.transformations.series._stl import STLSeriesTransformer
 from aeon.transformations.series._warping import WarpingSeriesTransformer
+from aeon.transformations.series._yeojohnson import YeoJohnsonTransformer
 from aeon.transformations.series.base import (
     BaseSeriesTransformer,
     SeriesInverseTransformerMixin,

--- a/aeon/transformations/series/tests/test_yeojohnson.py
+++ b/aeon/transformations/series/tests/test_yeojohnson.py
@@ -8,7 +8,7 @@ import pytest
 from scipy.stats import yeojohnson
 
 from aeon.datasets import load_airline
-from aeon.transformations.series._yeojohnson import YeoJohnsonTransformer
+from aeon.transformations.series import YeoJohnsonTransformer
 
 
 def test_yeojohnson_against_scipy():

--- a/docs/api_reference/transformations.md
+++ b/docs/api_reference/transformations.md
@@ -226,6 +226,7 @@ all_tags_for_estimator`` function with the argument ``"transformer"``.
     StatsModelsPACF
     BKFilter
     BoxCoxTransformer
+    YeoJohnsonTransformer
     ScaledLogitSeriesTransformer
     PCASeriesTransformer
     WarpingSeriesTransformer


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

`YeoJohnsonTransformer` lives in `aeon/transformations/series/_yeojohnson.py` and is missing from
`aeon/transformations/series/__init__.py`, so it cannot be imported from
`aeon.transformations.series` the way its neighbours can, and it does not appear in the API
reference.

It is also invisible to `all_estimators`, which walks the public modules, so none of the estimator
contract checks have ever run against it.

Adds it to `__all__` and to `docs/api_reference/transformations.md`, and extends the existing test to
import it from the package rather than from the private module.

`all_estimators(include_sklearn=False)` returns 247 before and 248 after.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Reverting `__init__.py` and keeping the test gives a collection error rather than a failure, since
the import is at module level.
