### PR TITLE
[BUG] CollectionToSeriesWrapper: return a series, not a collection of one

### DIFF
--- a/aeon/transformations/series/_collection_wrapper.py
+++ b/aeon/transformations/series/_collection_wrapper.py
@@ -16,10 +16,8 @@ from aeon.transformations.series.base import (
 def _single_case(Xt):
     """Unwrap a collection of one case, and leave anything else alone.
 
-    The wrapper feeds the collection transformer one case, so a collection
-    comes back holding one. Not every collection transformer returns a
-    collection though: SFAWhole returns a tuple of two arrays, and indexing
-    that would keep the first and drop the second.
+    Not every collection transformer returns a collection. SFAWhole returns a
+    tuple of two arrays, and indexing that drops the second in silence.
     """
     if isinstance(Xt, np.ndarray) and Xt.ndim == 3 and Xt.shape[0] == 1:
         return Xt[0]

--- a/aeon/transformations/series/_collection_wrapper.py
+++ b/aeon/transformations/series/_collection_wrapper.py
@@ -67,12 +67,14 @@ class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransfo
         if not self.get_tag("fit_is_empty"):
             t = self.collection_transformer_
 
-        return t.transform(X, y)
+        # the single case went in as a collection of one and comes back as one,
+        # and a series transformer returns a series
+        return t.transform(X, y)[0]
 
     def _fit_transform(self, X, y=None):
         X = X.reshape(1, X.shape[0], X.shape[1])
         self.collection_transformer_ = self.transformer.clone()
-        return self.collection_transformer_.fit_transform(X, y)
+        return self.collection_transformer_.fit_transform(X, y)[0]
 
     def _inverse_transform(self, X, y=None):
         X = X.reshape(1, X.shape[0], X.shape[1])
@@ -81,7 +83,7 @@ class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransfo
         if not self.get_tag("fit_is_empty"):
             t = self.collection_transformer_
 
-        return t.inverse_transform(X, y)
+        return t.inverse_transform(X, y)[0]
 
     @classmethod
     def _get_test_params(cls, parameter_set="default"):

--- a/aeon/transformations/series/_collection_wrapper.py
+++ b/aeon/transformations/series/_collection_wrapper.py
@@ -4,11 +4,28 @@ __maintainer__ = ["MatthewMiddlehurst"]
 __all__ = ["CollectionToSeriesWrapper"]
 
 
+import numpy as np
+
 from aeon.transformations.collection.base import BaseCollectionTransformer
 from aeon.transformations.series.base import (
     BaseSeriesTransformer,
     SeriesInverseTransformerMixin,
 )
+
+
+def _single_case(Xt):
+    """Unwrap a collection of one case, and leave anything else alone.
+
+    The wrapper feeds the collection transformer one case, so a collection
+    comes back holding one. Not every collection transformer returns a
+    collection though: SFAWhole returns a tuple of two arrays, and indexing
+    that would keep the first and drop the second.
+    """
+    if isinstance(Xt, np.ndarray) and Xt.ndim == 3 and Xt.shape[0] == 1:
+        return Xt[0]
+    if isinstance(Xt, list) and len(Xt) == 1:
+        return Xt[0]
+    return Xt
 
 
 class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransformer):
@@ -28,6 +45,8 @@ class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransfo
     >>> transformer = Resizer(resized_length=5)
     >>> wrapper = CollectionToSeriesWrapper(transformer)
     >>> X_t = wrapper.fit_transform(X)
+    >>> X_t.shape
+    (1, 5)
     """
 
     # These tags are not set from the collection transformer.
@@ -67,14 +86,12 @@ class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransfo
         if not self.get_tag("fit_is_empty"):
             t = self.collection_transformer_
 
-        # the single case went in as a collection of one and comes back as one,
-        # and a series transformer returns a series
-        return t.transform(X, y)[0]
+        return _single_case(t.transform(X, y))
 
     def _fit_transform(self, X, y=None):
         X = X.reshape(1, X.shape[0], X.shape[1])
         self.collection_transformer_ = self.transformer.clone()
-        return self.collection_transformer_.fit_transform(X, y)[0]
+        return _single_case(self.collection_transformer_.fit_transform(X, y))
 
     def _inverse_transform(self, X, y=None):
         X = X.reshape(1, X.shape[0], X.shape[1])
@@ -83,7 +100,7 @@ class CollectionToSeriesWrapper(SeriesInverseTransformerMixin, BaseSeriesTransfo
         if not self.get_tag("fit_is_empty"):
             t = self.collection_transformer_
 
-        return t.inverse_transform(X, y)[0]
+        return _single_case(t.inverse_transform(X, y))
 
     @classmethod
     def _get_test_params(cls, parameter_set="default"):

--- a/aeon/transformations/series/tests/test_wrapper.py
+++ b/aeon/transformations/series/tests/test_wrapper.py
@@ -1,6 +1,9 @@
 """Tests for SeriesToCollectionBroadcaster transformer."""
 
+import numpy as np
+
 from aeon.testing.mock_estimators import MockCollectionTransformer
+from aeon.transformations.collection.compose import CollectionId
 from aeon.transformations.series import CollectionToSeriesWrapper
 
 
@@ -22,3 +25,26 @@ def test_broadcaster_tag_inheritance():
             assert post_constructor_tags[key] == class_tags[key]
         elif key in mock_tags:
             assert post_constructor_tags[key] == mock_tags[key]
+
+
+def test_broadcaster_returns_a_series():
+    """The wrapper takes a series and gives a series back, not a collection of one.
+
+    It reshapes the 2D input to a collection of one case for the wrapped
+    collection transformer. Nothing reshaped the output back, so callers were
+    handed a 3D array from a series transformer.
+    """
+    X = np.random.RandomState(0).normal(size=(1, 20))
+
+    bc = CollectionToSeriesWrapper(MockCollectionTransformer())
+    assert bc.fit_transform(X).shape == X.shape
+
+    bc = CollectionToSeriesWrapper(MockCollectionTransformer())
+    bc.fit(X)
+    assert bc.transform(X).shape == X.shape
+
+    # CollectionId is the one collection transformer with an inverse that is not
+    # this wrapper, so it is what the inverse path can be checked against
+    bc = CollectionToSeriesWrapper(CollectionId())
+    bc.fit(X)
+    assert bc.transform(X).shape == X.shape

--- a/aeon/transformations/series/tests/test_wrapper.py
+++ b/aeon/transformations/series/tests/test_wrapper.py
@@ -1,4 +1,4 @@
-"""Tests for SeriesToCollectionBroadcaster transformer."""
+"""Tests for CollectionToSeriesWrapper transformer."""
 
 import numpy as np
 
@@ -43,8 +43,7 @@ def test_broadcaster_returns_a_series():
     bc.fit(X)
     assert bc.transform(X).shape == X.shape
 
-    # CollectionId is the one collection transformer with an inverse that is not
-    # this wrapper, so it is what the inverse path can be checked against
+    # a second transformer, because the first is a mock and this one is not
     bc = CollectionToSeriesWrapper(CollectionId())
     bc.fit(X)
     assert bc.transform(X).shape == X.shape


### PR DESCRIPTION
#### Reference Issues/PRs

Follows #3740, where you asked for a look at coverage on the series transformers.

#### What does this implement/fix? Explain your changes.

`CollectionToSeriesWrapper` exists to let a collection transformer take a single series. It
reshapes the 2D series into a collection of one case going in, and nothing reshaped the result
back, so a series transformer handed the caller a 3D array:

```python
X = np.random.normal(size=(1, 20))
CollectionToSeriesWrapper(MockCollectionTransformer()).fit_transform(X).shape
# (1, 1, 20)
```

Each of the three methods that reshape on the way in now unwraps the single case on the way out.

That unwrap is guarded rather than a plain `[0]`, because a collection transformer need not
return a collection. `SFAWhole.transform` returns a tuple of two arrays, and indexing it keeps
the first and drops the second in silence. Only a 3D array holding one case, or a list of one,
is unwrapped; anything else is returned untouched, so `SFAWhole` through the wrapper raises
exactly as it does on `main`.

I came here from the coverage question rather than the other way round. The only test on this
file checks tag inheritance and never calls `fit`, `transform`, `fit_transform` or
`inverse_transform`, so all four sat at 0 and nobody had looked at the shape. The docstring
example prints the shape now too, which is the thing this class exists to get right.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

`inverse_transform` gets the same treatment and no test. `CollectionId` is the only collection
transformer with an inverse that is not this wrapper, and through the wrapper it raises
`NotFittedError`: with `fit_is_empty` true the wrapper calls `self.transformer`, the instance
the caller passed, which it never fits. That looks like a separate defect.

Two of the low coverage numbers nearby are not gaps. `_yeojohnson.py` reads 52% with numba on
and 96% under `NUMBA_DISABLE_JIT=1`, since coverage cannot see inside an `njit` kernel, and
`_matrix_profile.py` reads 50% only where `stumpy` is missing and its test skips. The package
sits at 92% rather than the 73% a plain run reports. `_collection_wrapper.py` at 54% was the
figure that meant what it said.
