### PR TITLE
[BUG] Fix `MUSE` with `scikit-learn` 1.8 and drop deprecated parameters

### DIFF
--- a/aeon/classification/dictionary_based/_muse.py
+++ b/aeon/classification/dictionary_based/_muse.py
@@ -264,15 +264,14 @@ class MUSE(BaseClassifier):
             self.clf = RidgeClassifierCV(
                 alphas=np.logspace(-3, 3, 10), class_weight=self.class_weight
             )
+            all_words = all_words.astype(np.float32, copy=False)
         else:
             self.clf = LogisticRegression(
                 max_iter=5000,
                 solver="liblinear",
                 dual=True,
                 class_weight=self.class_weight,
-                penalty="l2",
                 random_state=self.random_state,
-                n_jobs=self.n_jobs,
             )
             if self.n_classes_ > 2:
                 self.clf = OneVsRestClassifier(self.clf, n_jobs=self.n_jobs)

--- a/aeon/classification/dictionary_based/_weasel.py
+++ b/aeon/classification/dictionary_based/_weasel.py
@@ -251,9 +251,7 @@ class WEASEL(BaseClassifier):
                 solver="liblinear",
                 dual=True,
                 class_weight=self.class_weight,
-                penalty="l2",
                 random_state=self.random_state,
-                n_jobs=self.n_jobs,
             )
             if self.n_classes_ > 2:
                 self.clf = OneVsRestClassifier(self.clf, n_jobs=self.n_jobs)

--- a/aeon/classification/dictionary_based/tests/test_muse.py
+++ b/aeon/classification/dictionary_based/tests/test_muse.py
@@ -1,8 +1,10 @@
 """Test MUSE multivariate classifier."""
 
+import numpy as np
 import pytest
 
 from aeon.classification.dictionary_based import MUSE
+from aeon.datasets import load_basic_motions
 from aeon.testing.data_generation import make_example_3d_numpy
 
 
@@ -14,3 +16,18 @@ def test_muse():
     assert X2.shape[2] == X.shape[2] and X2.shape[1] == X.shape[1] * 2
     with pytest.raises(ValueError, match="Error in MUSE, min_window"):
         muse.fit(X, y)
+
+
+def test_muse_score():
+    """Test of MUSE train estimate on basic motions data."""
+    # load basic motions data
+    X_train, y_train = load_basic_motions(split="train")
+    X_test, y_test = load_basic_motions(split="test")
+
+    # train muse
+    muse = MUSE(random_state=0)
+    muse.fit(X_train, y_train)
+    score = muse.score(X_test, y_test)
+
+    assert isinstance(score, float)
+    np.testing.assert_almost_equal(score, 1.0, decimal=4)


### PR DESCRIPTION
Fixes muse which was missed in #3250 which pushed a fix for WEASEL.

Removes deprecated parameters. This is functionally the same as live, as the current options do not change defaults or any internal operations.