### PR TITLE
[ENH] Replace the esig soft dependency with RoughPy

### DIFF
--- a/aeon/classification/feature_based/_signature_classifier.py
+++ b/aeon/classification/feature_based/_signature_classifier.py
@@ -100,7 +100,7 @@ class SignatureClassifier(BaseClassifier):
     _tags = {
         "capability:multivariate": True,
         "algorithm_type": "feature",
-        "python_dependencies": "esig",
+        "python_dependencies": "roughpy",
     }
 
     def __init__(

--- a/aeon/classification/feature_based/tests/test_signature.py
+++ b/aeon/classification/feature_based/tests/test_signature.py
@@ -9,8 +9,8 @@ from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not _check_soft_dependencies("roughpy", severity="none"),
+    reason="skip test if required soft dependency roughpy not available",
 )
 def test_signature_classifier():
     """Test the SignatureClassifier."""
@@ -21,8 +21,8 @@ def test_signature_classifier():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not _check_soft_dependencies("roughpy", severity="none"),
+    reason="skip test if required soft dependency roughpy not available",
 )
 @pytest.mark.parametrize("class_weight", ["balanced", "balanced_subsample"])
 def test_signature_classifier_with_class_weight(class_weight):

--- a/aeon/transformations/collection/signature_based/_signature.py
+++ b/aeon/transformations/collection/signature_based/_signature.py
@@ -175,6 +175,8 @@ class _WindowSignatureTransform(BaseCollectionTransformer):
 
     def _transform(self, X, y=None):
         depth = self.sig_depth
+        if depth < 1:
+            raise ValueError(f"Depth must be at least 1. Depth given is: {depth}.")
         data = np.swapaxes(X, 1, 2)
 
         # Path rescaling

--- a/aeon/transformations/collection/signature_based/_signature.py
+++ b/aeon/transformations/collection/signature_based/_signature.py
@@ -462,7 +462,13 @@ def _sigdim(channels, depth):
 
 
 def _build_stream(path, depth):
-    """Build a RoughPy Lie increment stream from a ``(length, channels)`` path."""
+    """Build a RoughPy Lie increment stream from a ``(length, channels)`` path.
+
+    Adapted from the ``RoughPyBackend.prepare_stream`` method in esig 1.0.0
+    backends.py, correcting the index computation which is off by one for some
+    series lengths. https://github.com/datasig-ac-uk/esig/
+    Copyright (c) 2024 DataSig project, BSD-3
+    """
     import roughpy as rp
 
     length, channels = path.shape
@@ -475,7 +481,13 @@ def _build_stream(path, depth):
 
 
 def _stream2sig(path, depth):
-    """Compute the signature of a ``(length, channels)`` path."""
+    """Compute the signature of a ``(length, channels)`` path.
+
+    Adapted from the ``RoughPyBackend.compute_signature`` and
+    ``RoughPyBackend.empty_signature`` methods in esig 1.0.0 backends.py.
+    https://github.com/datasig-ac-uk/esig/
+    Copyright (c) 2024 DataSig project, BSD-3
+    """
     import roughpy as rp
 
     length, channels = path.shape
@@ -488,7 +500,13 @@ def _stream2sig(path, depth):
 
 
 def _stream2logsig(path, depth):
-    """Compute the log signature of a ``(length, channels)`` path."""
+    """Compute the log signature of a ``(length, channels)`` path.
+
+    Adapted from the ``RoughPyBackend.compute_log_signature`` and
+    ``RoughPyBackend.empty_log_signature`` methods in esig 1.0.0 backends.py.
+    https://github.com/datasig-ac-uk/esig/
+    Copyright (c) 2024 DataSig project, BSD-3
+    """
     import roughpy as rp
 
     length, channels = path.shape

--- a/aeon/transformations/collection/signature_based/_signature.py
+++ b/aeon/transformations/collection/signature_based/_signature.py
@@ -51,7 +51,7 @@ class SignatureTransformer(BaseCollectionTransformer):
     _tags = {
         "output_data_type": "Tabular",
         "capability:multivariate": True,
-        "python_dependencies": "esig",
+        "python_dependencies": "roughpy",
     }
 
     def __init__(
@@ -147,7 +147,7 @@ class _WindowSignatureTransform(BaseCollectionTransformer):
         "fit_is_empty": True,
         "output_data_type": "Tabular",
         "capability:multivariate": True,
-        "python_dependencies": "esig",
+        "python_dependencies": "roughpy",
     }
 
     def __init__(
@@ -174,25 +174,6 @@ class _WindowSignatureTransform(BaseCollectionTransformer):
         )
 
     def _transform(self, X, y=None):
-        import esig
-
-        # monkey patch due to bug in esig which causes some data shapes to crash.
-        # Remove if it is fixed upstream I guess.
-        def prepare_stream(self, stream_data, depth):
-            import numpy as np
-            import roughpy as rp
-
-            no_samples, width = stream_data.shape
-            increments = np.diff(stream_data, axis=0)
-            indices = np.arange(no_samples - 1) / (no_samples - 1)
-            context = rp.get_context(width, depth, rp.DPReal)
-            stream = rp.LieIncrementStream.from_increments(
-                increments, indices=indices, ctx=context
-            )
-            return stream
-
-        esig.backends.RoughPyBackend.prepare_stream = prepare_stream
-
         depth = self.sig_depth
         data = np.swapaxes(X, 1, 2)
 
@@ -204,12 +185,12 @@ class _WindowSignatureTransform(BaseCollectionTransformer):
         if self.sig_tfm == "signature":
 
             def transform(x):
-                return esig.stream2sig(x, depth)[1:].reshape(-1, 1)
+                return _stream2sig(x, depth)[1:].reshape(-1, 1)
 
         else:
 
             def transform(x):
-                return esig.stream2logsig(x, depth).reshape(1, -1)
+                return _stream2logsig(x, depth).reshape(1, -1)
 
         length = data.shape[1]
 
@@ -446,15 +427,7 @@ def _rescale_path(path, depth):
 
 def _rescale_signature(signature, channels, depth):
     """Rescales the output signature by multiplying the depth-d term by d!."""
-    import esig
-
-    # Needed for weird esig fails
-    if depth == 1:
-        sigdim = channels
-    elif channels == 1:
-        sigdim = depth
-    else:
-        sigdim = esig.sigdim(channels, depth) - 1
+    sigdim = _sigdim(channels, depth) - 1
     # Verify shape
     if sigdim != signature.shape[-1]:
         raise ValueError(
@@ -479,3 +452,48 @@ def _rescale_signature(signature, channels, depth):
         terms.append(signature[..., start:end] * val)
 
     return np.concatenate(terms, axis=-1)
+
+
+def _sigdim(channels, depth):
+    """Return the number of terms in a signature truncated at ``depth``."""
+    if channels == 1:
+        return depth + 1
+    return (channels ** (depth + 1) - 1) // (channels - 1)
+
+
+def _build_stream(path, depth):
+    """Build a RoughPy Lie increment stream from a ``(length, channels)`` path."""
+    import roughpy as rp
+
+    length, channels = path.shape
+    context = rp.get_context(channels, depth, rp.DPReal)
+    return rp.LieIncrementStream.from_increments(
+        np.diff(path, axis=0),
+        indices=np.arange(length - 1) / (length - 1),
+        ctx=context,
+    )
+
+
+def _stream2sig(path, depth):
+    """Compute the signature of a ``(length, channels)`` path."""
+    import roughpy as rp
+
+    length, channels = path.shape
+    if length == 1:
+        signature = np.zeros(_sigdim(channels, depth))
+        signature[0] = 1.0
+        return signature
+    stream = _build_stream(path, depth)
+    return np.array(stream.signature(rp.RealInterval(0.0, 1.0)), copy=True)
+
+
+def _stream2logsig(path, depth):
+    """Compute the log signature of a ``(length, channels)`` path."""
+    import roughpy as rp
+
+    length, channels = path.shape
+    if length == 1:
+        context = rp.get_context(channels, depth, rp.DPReal)
+        return np.zeros(context.lie_size(depth))
+    stream = _build_stream(path, depth)
+    return np.array(stream.log_signature(rp.RealInterval(0.0, 1.0)), copy=True)

--- a/aeon/transformations/collection/signature_based/tests/test_signature.py
+++ b/aeon/transformations/collection/signature_based/tests/test_signature.py
@@ -8,13 +8,15 @@ from aeon.utils.validation._dependencies import _check_soft_dependencies
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not _check_soft_dependencies("roughpy", severity="none"),
+    reason="skip test if required soft dependency roughpy not available",
 )
 def test_generalised_signature_method():
     """Check that dimension and dim of output are correct."""
     # Build an array X, note that this is [n_sample, n_channels, length] shape.
-    import esig
+    from aeon.transformations.collection.signature_based._signature import (
+        _sigdim,
+    )
 
     n_channels = 3
     depth = 4
@@ -22,14 +24,11 @@ def test_generalised_signature_method():
 
     # Check the global dimension comes out correctly
     method = SignatureTransformer(depth=depth, window_name="global")
-    assert method.fit_transform(X).shape[1] == esig.sigdim(n_channels + 1, depth) - 1
+    assert method.fit_transform(X).shape[1] == _sigdim(n_channels + 1, depth) - 1
 
     # Check dyadic dim
     method = SignatureTransformer(depth=depth, window_name="dyadic", window_depth=3)
-    assert (
-        method.fit_transform(X).shape[1]
-        == (esig.sigdim(n_channels + 1, depth) - 1) * 15
-    )
+    assert method.fit_transform(X).shape[1] == (_sigdim(n_channels + 1, depth) - 1) * 15
 
     # Ensure an example
     X = np.array([[0, 1], [2, 3], [1, 1]]).reshape(-1, 2, 3)
@@ -41,8 +40,8 @@ def test_generalised_signature_method():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("esig", severity="none"),
-    reason="skip test if required soft dependency esig not available",
+    not _check_soft_dependencies("roughpy", severity="none"),
+    reason="skip test if required soft dependency roughpy not available",
 )
 def test_window_error():
     """Test that wrong window parameters raise error."""

--- a/aeon/transformations/collection/signature_based/tests/test_signature.py
+++ b/aeon/transformations/collection/signature_based/tests/test_signature.py
@@ -63,3 +63,17 @@ def test_window_error():
     )
     with pytest.raises(ValueError):
         method.fit_transform(X)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("roughpy", severity="none"),
+    reason="skip test if required soft dependency roughpy not available",
+)
+def test_depth_error():
+    """Test that a non-positive signature depth raises an error."""
+    X = np.random.randn(5, 2, 10)
+
+    for depth in (0, -1):
+        method = SignatureTransformer(depth=depth, window_name="global")
+        with pytest.raises(ValueError, match="Depth must be at least 1"):
+            method.fit_transform(X)

--- a/examples/classification/feature_based.ipynb
+++ b/examples/classification/feature_based.ipynb
@@ -293,7 +293,7 @@
     "and obtain information about the parameterisation of the time series. A hierarchical\n",
     "dyadic window is run over the series, with the signature transform being applied to\n",
     "each window. The output for each window is then concatenated into a feature vector.\n",
-    "Signatures requires the installation of the soft dependency esig."
+    "Signatures requires the installation of the soft dependency roughpy."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,13 @@ dependencies = [
 # soft dependencies
 [project.optional-dependencies]
 all_extras = [
-    "esig>=1.0.0; platform_system != 'Darwin' and python_version < '3.14'",
     "huggingface-hub>=0.20.0",
     "imbalanced-learn",
     "matplotlib>=3.3.2",
     "pycatch22>=0.4.5",
     "pyod>=1.1.3",
     "pydot>=2.0.0",
+    "roughpy>=0.2.0; platform_system != 'Linux' or platform_machine == 'x86_64'",
     "ruptures>=1.1.9",
     "seaborn>=0.11.0",
     "sparse",


### PR DESCRIPTION
This PR swaps `esig` for `roughpy`. `esig` is no longer maintained, is mostly a wrapper for `roughpy`, and has caused issues in the past for installs. This allows us to keep the algorithms which use it, and hopefully is a bit less troublesome. 

Includes some `esig` functions which are required as a bridge, and fixes the previous monkey patch for an unfixed bug.

AI found some issues with ARM Linux installs, so excluded that for now.