### PR TITLE
Fix merlin standard deviation check being inverted

### DIFF
--- a/aeon/anomaly_detection/series/distance_based/_merlin.py
+++ b/aeon/anomaly_detection/series/distance_based/_merlin.py
@@ -85,13 +85,14 @@ class MERLIN(BaseSeriesAnomalyDetector):
             )
 
         for i in range(X.shape[0] - self.min_length + 1):
-            if std(X[i : i + self.min_length]) > AEON_NUMBA_STD_THRESHOLD:
+            if std(X[i : i + self.min_length]) <= AEON_NUMBA_STD_THRESHOLD:
                 warnings.warn(
                     "There is region close to constant that will cause the results "
                     "to be unstable. It is suggested to delete the constant region "
                     "or try again with a longer min_length.",
                     stacklevel=2,
                 )
+                break
 
         lengths = np.linspace(
             self.min_length,

--- a/aeon/anomaly_detection/series/distance_based/tests/test_merlin.py
+++ b/aeon/anomaly_detection/series/distance_based/tests/test_merlin.py
@@ -3,6 +3,7 @@
 __maintainer__ = ["MatthewMiddlehurst"]
 
 import numpy as np
+import pytest
 
 from aeon.anomaly_detection.series.distance_based import MERLIN
 
@@ -70,3 +71,45 @@ def test_merlin():
     assert pred.shape == (50,)
     assert pred.dtype == bool
     assert (pred[15:22] == [False, True, True, True, True, True, False]).all()
+
+
+def test_merlin_constant_region_warning():
+    """Test MERLIN warns on constant regions."""
+    ad = MERLIN(min_length=5, max_length=10)
+    # Series with a flat region
+    X = np.array(
+        [
+            1,
+            2,
+            3,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+        ]
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match="There is region close to constant that will cause the results "
+        "to be unstable.",
+    ):
+        ad.predict(X)


### PR DESCRIPTION
In `aeon/anomaly_detection/series/distance_based/_merlin.py`, the condition `std(X[i : i + self.min_length]) > AEON_NUMBA_STD_THRESHOLD` was incorrectly warning when the sequence *wasn't* flat. This commit inverses the check so it correctly warns when a sequence *is* flat. Additionally, added a test case `test_merlin_constant_region_warning` to explicitly verify this fix. Fixes #3759