### PR TITLE
[BUG] Stabilize HIVE-COTE lifecycle test

### DIFF
--- a/aeon/classification/hybrid/tests/test_hc.py
+++ b/aeon/classification/hybrid/tests/test_hc.py
@@ -137,7 +137,13 @@ def test_hivecote_estimator_attribute_lifecycle():
     from aeon.classification.hybrid import HIVECOTEV1, HIVECOTEV2
     from aeon.testing.data_generation import make_example_3d_numpy
 
-    X, y = make_example_3d_numpy(n_cases=10, n_channels=1, n_timepoints=20)
+    X, y = make_example_3d_numpy(
+        n_cases=10,
+        n_channels=1,
+        n_timepoints=20,
+        min_cases_per_label=3,
+        random_state=0,
+    )
 
     for hc_class in [HIVECOTEV1, HIVECOTEV2]:
         params = hc_class._get_test_params()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3761.

#### What does this implement/fix? Explain your changes.

The HIVE-COTE attribute lifecycle test only checks whether `fitted_estimators_` is created during `fit`, but its generated classification labels were random and could leave a class with too few cases for the full ensemble fit.

This fixes the unrelated flakiness by seeding the generated data and guaranteeing at least three cases per label. Production estimator behavior is unchanged.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Validation:

- `pytest aeon/classification/hybrid/tests/test_hc.py -q` (8 passed)
- `pre-commit run --files aeon/classification/hybrid/tests/test_hc.py` (passed)
- `git diff --check` (passed)

The full repository test suite was not run; the complete affected HIVE-COTE test module passed.

### PR checklist

##### For all contributions

- [ ] I've added myself to the list of contributors. This can be done after the PR is merged.
- [x] The PR title starts with an accepted topic tag.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
