### PR TITLE
[BUG] Fix inverted MERLIN near-constant std check

### DIFF
--- a/aeon/anomaly_detection/series/distance_based/_merlin.py
+++ b/aeon/anomaly_detection/series/distance_based/_merlin.py
@@ -85,13 +85,14 @@ class MERLIN(BaseSeriesAnomalyDetector):
             )
 
         for i in range(X.shape[0] - self.min_length + 1):
-            if std(X[i : i + self.min_length]) > AEON_NUMBA_STD_THRESHOLD:
+            if std(X[i : i + self.min_length]) <= AEON_NUMBA_STD_THRESHOLD:
                 warnings.warn(
                     "There is region close to constant that will cause the results "
                     "to be unstable. It is suggested to delete the constant region "
                     "or try again with a longer min_length.",
                     stacklevel=2,
                 )
+                break
 
         lengths = np.linspace(
             self.min_length,

--- a/aeon/anomaly_detection/series/distance_based/tests/test_merlin.py
+++ b/aeon/anomaly_detection/series/distance_based/tests/test_merlin.py
@@ -3,6 +3,7 @@
 __maintainer__ = ["MatthewMiddlehurst"]
 
 import numpy as np
+import pytest
 
 from aeon.anomaly_detection.series.distance_based import MERLIN
 
@@ -70,3 +71,19 @@ def test_merlin():
     assert pred.shape == (50,)
     assert pred.dtype == bool
     assert (pred[15:22] == [False, True, True, True, True, True, False]).all()
+
+
+def test_merlin_constant_region_warning():
+    """Test MERLIN warns once on near-constant regions."""
+    ad = MERLIN(min_length=5, max_length=10)
+    # Flat window of length min_length so std is below the threshold.
+    X = np.concatenate(
+        [np.arange(1, 6, dtype=float), np.full(6, 5.0), np.arange(6, 21, dtype=float)]
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match="There is region close to constant that will cause the results "
+        "to be unstable.",
+    ):
+        ad.predict(X)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3759.

#### What does this implement/fix? Explain your changes.

MERLIN warned when subsequence `std` was *above* `AEON_NUMBA_STD_THRESHOLD`, i.e. the opposite of a near-constant region. Invert the comparison to `<=` so the warning fires on flat/near-constant windows, and `break` after the first warning so it is not repeated for every window.

Add `test_merlin_constant_region_warning` covering the constant-region path.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Suggested fix from the issue: invert the test and stop after one warning.

### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you **after** the PR has been merged.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.