### PR TITLE
[MNT] Mark tsfresh estimators non-deterministic for multithreading tests

### DIFF
--- a/aeon/classification/feature_based/_fresh_prince.py
+++ b/aeon/classification/feature_based/_fresh_prince.py
@@ -85,6 +85,7 @@ class FreshPRINCEClassifier(BaseClassifier):
         "capability:multithreading": True,
         "capability:train_estimate": True,
         "algorithm_type": "feature",
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 

--- a/aeon/classification/feature_based/_tsfresh.py
+++ b/aeon/classification/feature_based/_tsfresh.py
@@ -88,6 +88,7 @@ class TSFreshClassifier(BaseClassifier):
         "capability:multithreading": True,
         "capability:unequal_length": True,
         "algorithm_type": "feature",
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 

--- a/aeon/clustering/feature_based/_tsfresh.py
+++ b/aeon/clustering/feature_based/_tsfresh.py
@@ -82,6 +82,7 @@ class TSFreshClusterer(BaseClusterer):
         "capability:multithreading": True,
         "capability:unequal_length": True,
         "algorithm_type": "feature",
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 

--- a/aeon/regression/feature_based/_fresh_prince.py
+++ b/aeon/regression/feature_based/_fresh_prince.py
@@ -87,6 +87,7 @@ class FreshPRINCERegressor(BaseRegressor):
         "capability:multithreading": True,
         "capability:train_estimate": True,
         "algorithm_type": "feature",
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 

--- a/aeon/regression/feature_based/_tsfresh.py
+++ b/aeon/regression/feature_based/_tsfresh.py
@@ -69,6 +69,7 @@ class TSFreshRegressor(BaseRegressor):
         "capability:multithreading": True,
         "capability:unequal_length": True,
         "algorithm_type": "feature",
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 

--- a/aeon/testing/testing_config.py
+++ b/aeon/testing/testing_config.py
@@ -61,15 +61,6 @@ EXCLUDED_TESTS = {
     # broken by 0.63.0 numba update, see #3307 attempt to fix
     "HIVECOTEV2": ["check_classifier_against_expected_results"],
     "TemporalDictionaryEnsemble": ["check_classifier_against_expected_results"],
-    # multithreading issue, sometimes produces different results between single
-    # and multithreading
-    "FreshPRINCEClassifier": ["check_estimator_multithreading"],
-    "FreshPRINCERegressor": ["check_estimator_multithreading"],
-    "TSFreshClassifier": ["check_estimator_multithreading"],
-    "TSFreshRegressor": ["check_estimator_multithreading"],
-    "TSFreshClusterer": ["check_estimator_multithreading"],
-    "TSFreshRelevant": ["check_estimator_multithreading"],
-    "TSFresh": ["check_estimator_multithreading"],
 }
 
 # Exclude specific tests for estimators here only when numba is disabled

--- a/aeon/transformations/collection/feature_based/_tsfresh.py
+++ b/aeon/transformations/collection/feature_based/_tsfresh.py
@@ -44,6 +44,7 @@ class _TSFresh(BaseCollectionTransformer):
         "capability:multithreading": True,
         "capability:unequal_length": True,
         "fit_is_empty": True,
+        "non_deterministic": True,
         "python_dependencies": "tsfresh",
     }
 


### PR DESCRIPTION
## Summary
- Investigated intermittent `check_estimator_multithreading` failures for tsfresh-related estimators (#3326).
- Root cause: `tsfresh` parallel feature extraction (`n_jobs > 1`) can produce slightly different floating-point results vs `n_jobs=1` — this is transform-side, not downstream sklearn estimators.
- Mark all tsfresh-based estimators with `non_deterministic: True` and remove the blanket `EXCLUDED_TESTS` skips so the multithreading check still validates `n_jobs` / `_n_jobs` plumbing without asserting identical outputs.

## Investigation notes
- Reproduced the CI test path locally (`_clone_estimator` + `set_params(n_jobs=2)` + fit/predict) on `EqualLengthUnivariate-Classification-numpy3D` test data — no mismatches in 3 runs with `efficient`/`minimal` feature sets, but CI flakes are intermittent (PR #3325 previously skipped these tests for that reason).
- Downstream classifiers/regressors (FreshPRINCE, TSFreshClassifier) create a fresh `TSFresh` transformer at `fit` time with the correct `n_jobs`, so the divergence originates in `tsfresh.extract_features`, not aeon's sklearn wrappers.

## Test plan
- [x] `pytest aeon/transformations/collection/feature_based/tests/test_tsfresh.py` — pass
- [x] `pytest aeon/classification/feature_based/tests/test_tsfresh.py` — pass
- [ ] CI `test_all_estimators` with `--enablethreading True` (tsfresh soft dependency)
