### PR TITLE
[BUG] Preserve input dtype in shift_scale_invariant zero-padding

### DIFF
--- a/aeon/distances/_shift_scale_invariant.py
+++ b/aeon/distances/_shift_scale_invariant.py
@@ -141,10 +141,10 @@ def _univariate_shift_scale_invariant_distance(
             shifted_y = y
         elif sh < 0:
             # Shift left
-            shifted_y = np.append(y[-sh:], np.zeros(-sh))
+            shifted_y = np.append(y[-sh:], np.zeros(-sh, dtype=y.dtype))
         else:
             # Shift right
-            shifted_y = np.append(np.zeros(sh), y[:-sh])
+            shifted_y = np.append(np.zeros(sh, dtype=y.dtype), y[:-sh])
 
         dist = _scale_d(x, shifted_y)
 

--- a/aeon/distances/tests/test_miscellaneous_distances.py
+++ b/aeon/distances/tests/test_miscellaneous_distances.py
@@ -35,3 +35,18 @@ def test_shift_scale_invariant_distance():
     assert univariate_shift[1].shape == (10,)
     assert isinstance(multivariate_shift[1], np.ndarray)
     assert multivariate_shift[1].shape == (3, 10)
+
+
+def test_shift_scale_invariant_distance_float32():
+    """Test that float32 input does not raise a numba TypingError (#3722).
+
+    The zero-padding in the shift branches used to default to float64, which could
+    not unify with the float32 input inside the numba-compiled distance.
+    """
+    x = make_example_2d_numpy_series(n_channels=1, n_timepoints=10, random_state=1)
+    y = make_example_2d_numpy_series(n_channels=1, n_timepoints=10, random_state=2)
+
+    dist64 = shift_scale_invariant_distance(x.astype(np.float64), y.astype(np.float64))
+    dist32 = shift_scale_invariant_distance(x.astype(np.float32), y.astype(np.float32))
+
+    assert_almost_equal(dist32, dist64, decimal=4)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3722.

#### What does this implement/fix? Explain your changes.

`shift_scale_invariant_distance` (and `KSpectralCentroid`, which uses it) raised a numba `TypingError` on `float32` input: the zero-padding in the shift branches of `_univariate_shift_scale_invariant_distance` was built with an untyped `np.zeros`, which defaults to `float64`, so `shifted_y` could not unify across the branches (`float32` from `y`, `float64` from the padded ones). Passing `dtype=y.dtype` to both zero-padding branches keeps everything at the input dtype.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Verified `shift_scale_invariant_distance` and `KSpectralCentroid` now fit/run on `float32`, matching the `float64` result.

### PR checklist

##### For all contributions
- [x] The PR title starts with [BUG].
- [x] I've added a test (`test_shift_scale_invariant_distance_float32`); verified it fails without the fix. `ruff` is green.
- [x] I'll add myself via the @all-contributors bot after merge.