### PR TITLE
[BUG] Install graphviz for the notebook example runs

### DIFF
--- a/.github/workflows/periodic_tests.yml
+++ b/.github/workflows/periodic_tests.yml
@@ -57,6 +57,13 @@ jobs:
           brew install bash
           /opt/homebrew/bin/bash --version
 
+      - name: Install graphviz
+        # keras plot_model needs the graphviz "dot" binary, not just pydot;
+        # plotting_estimators.ipynb calls it through plot_network
+        run: |
+          brew install graphviz
+          dot -V
+
       - name: Setup Python 3.12
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/pr_examples.yml
+++ b/.github/workflows/pr_examples.yml
@@ -28,6 +28,13 @@ jobs:
           brew install bash
           /opt/homebrew/bin/bash --version
 
+      - name: Install graphviz
+        # keras plot_model needs the graphviz "dot" binary, not just pydot;
+        # plotting_estimators.ipynb calls it through plot_network
+        run: |
+          brew install graphviz
+          dot -V
+
       - name: Setup Python 3.12
         uses: actions/setup-python@v7
         with:

--- a/aeon/visualisation/estimator/_network_plot.py
+++ b/aeon/visualisation/estimator/_network_plot.py
@@ -64,8 +64,11 @@ def plot_network(
                 show_layer_activations=show_layer_activations,
                 dpi=dpi,
             )
-        except ImportError:
-            raise ImportError("Either graphviz or pydot should be installed.")
+        except ImportError as e:
+            raise ImportError(
+                "plot_network requires both the pydot package and a graphviz "
+                "installation providing the 'dot' binary."
+            ) from e
 
     else:
         file_name_ = "model" if file_name is None else file_name
@@ -87,5 +90,8 @@ def plot_network(
                 show_layer_activations=show_layer_activations,
                 dpi=dpi,
             )
-        except ImportError:
-            raise ImportError("Either graphviz or pydot should be installed.")
+        except ImportError as e:
+            raise ImportError(
+                "plot_network requires both the pydot package and a graphviz "
+                "installation providing the 'dot' binary."
+            ) from e


### PR DESCRIPTION
The run-notebook-examples job has failed on every PR since 27 Aug, on examples/visualisation/plotting_estimators.ipynb:

    plot_network(input_shape=(2, 12), network=mlp, show_layer_names=True)
    ImportError: You must install graphviz ... for `plot_model` to work.

plot_network calls keras plot_model, which needs the graphviz "dot" binary as well as the pydot package. macos-14 runners do not provide it and no workflow installed it, so add it next to the existing bash install in both workflows that run the notebooks.

keras only raises when "IPython.core.magics.namespace" is absent from sys.modules, printing and returning otherwise, which is why this surfaces in CI but not always locally.

Also fix the handler that masked the cause. It replaced keras's precise message with "Either graphviz or pydot should be installed", which is wrong twice over: both are required, not either, and graphviz is a system install rather than a package. It now says so and chains the original.


