### PR TITLE
[BUG] Preserve final DisjointCNN filter features

### DIFF
--- a/aeon/networks/encoder/_disjoint_cnn.py
+++ b/aeon/networks/encoder/_disjoint_cnn.py
@@ -251,6 +251,8 @@ class DisjointCNNNetwork(BaseDeepLearningNetwork):
                 activation=self._activation[i],
                 kernel_initializer=self._kernel_initializer[i],
             )
+            if i < self.n_layers - 1:
+                x = tf.keras.layers.Permute((1, 3, 2))(x)
 
         max_pool_layer = tf.keras.layers.MaxPooling2D(
             pool_size=(self.pool_size, 1),
@@ -304,7 +306,5 @@ class DisjointCNNNetwork(BaseDeepLearningNetwork):
 
         spatial_conv = tf.keras.layers.BatchNormalization()(spatial_conv)
         spatial_conv = tf.keras.layers.Activation(activation=activation)(spatial_conv)
-
-        spatial_conv = tf.keras.layers.Permute((1, 3, 2))(spatial_conv)
 
         return spatial_conv

--- a/aeon/networks/encoder/tests/test_disjoint_cnn.py
+++ b/aeon/networks/encoder/tests/test_disjoint_cnn.py
@@ -12,11 +12,15 @@ from aeon.utils.validation._dependencies import _check_soft_dependencies
 )
 def test_disjoint_cnn_netowkr_kernel_initializer():
     """Test DisjointCNN for different kernel_initializer per layer."""
+    import tensorflow as tf
+
     input_layer, output_layer = DisjointCNNNetwork(
         n_layers=2,
+        n_filters=[4, 8],
         kernel_initializer=["he_uniform", "glorot_uniform"],
         kernel_size=[2, 2],
     ).build_network(input_shape=((10, 2)))
 
     assert len(output_layer.shape) == 2
     assert len(input_layer.shape) == 3
+    assert tf.keras.Model(input_layer, output_layer).layers[-1].input.shape[-1] == 8


### PR DESCRIPTION
Title: [BUG] Preserve final DisjointCNN filter features

## Summary

- Apply the DisjointCNN axis permutation only between convolution blocks, matching the reference architecture.
- Preserve all final convolution filters through global average pooling instead of collapsing the projection input to one feature.
- Add a focused network-shape regression assertion.

Fixes #3775

## Test evidence

- Python compilation passed for the changed implementation and test.
- A focused source assertion verified that `Permute` is applied only when another block follows.
- `git diff --check` passed.
- The TensorFlow-backed pytest test was not run locally because this environment lacks pytest and TensorFlow; CI should run the added assertion.

## Risks or notes for maintainers

- The network is shared by the classifier and regressor, so both now retain the final filter dimension as intended.
- No dependency is introduced.
- A full ERing accuracy benchmark was not run locally; the regression test covers the tensor-shape root cause isolated in the issue.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
