### PR TITLE
[ENH] Check series anomaly detectors discriminate on the labelled fix…

### DIFF
--- a/aeon/testing/estimator_checking/_yield_series_anomaly_detection_checks.py
+++ b/aeon/testing/estimator_checking/_yield_series_anomaly_detection_checks.py
@@ -3,10 +3,17 @@
 from functools import partial
 
 import numpy as np
+from sklearn.metrics import roc_auc_score
 
 from aeon.base._base import _clone_estimator
 from aeon.base._base_series import VALID_SERIES_INNER_TYPES
 from aeon.testing.testing_data import FULL_TEST_DATA_DICT
+
+# Smallest gap from the constant score baseline that a detector must reach on the
+# labelled testing fixture. The fixture is short and holds a single labelled
+# anomaly, so this floor is deliberately low. It is here to catch a detector which
+# does not discriminate at all, not to grade how good a detector is.
+MIN_DISCRIMINATION_MARGIN = 0.05
 
 
 def _yield_series_anomaly_detection_checks(
@@ -21,6 +28,19 @@ def _yield_series_anomaly_detection_checks(
 
     # test class instances
     for i, estimator in enumerate(estimator_instances):
+        # binary output is a label rather than a ranking, so there is no score to
+        # rank the time points by. estimator is None when a soft dependency is
+        # missing and the instance could not be created
+        if (
+            estimator is not None
+            and estimator.get_tag("anomaly_output_type") == "anomaly_scores"
+        ):
+            yield partial(
+                check_series_anomaly_detector_discriminates,
+                estimator=estimator,
+                datatype=datatypes[i][0],
+            )
+
         # test all data types
         for datatype in datatypes[i]:
             yield partial(
@@ -71,3 +91,48 @@ def check_series_anomaly_detector_output(estimator, datatype):
         ), "y_pred must contain only 0s, 1s, True, or False"
     else:
         raise ValueError(f"Unknown anomaly output type: {out_type}")
+
+
+def check_series_anomaly_detector_discriminates(estimator, datatype):
+    """Test the series anomaly detector separates the labelled anomalies.
+
+    The current output check only looks at the shape and dtype of the scores. A
+    detector which returns the same score at every time point, or scores unrelated
+    to the input, passes it. This check adds the missing part, that the scores
+    actually separate the labelled anomalies from the normal time points.
+
+    A constant anomaly score is not wrong in general. On a constant input series a
+    constant score is the right answer. This check never sees such a series. It only
+    runs on the labelled testing fixture, which does contain anomalies, so a
+    constant score on that fixture is a real failure.
+
+    The measure is the area under the ROC curve, which is rank based, so no
+    threshold or scale is assumed. Detectors which score anomalies low rather than
+    high are accepted, only the distance from the baseline is used.
+    """
+    estimator = _clone_estimator(estimator, random_state=0)
+
+    estimator.fit(
+        FULL_TEST_DATA_DICT[datatype]["train"][0],
+        FULL_TEST_DATA_DICT[datatype]["train"][1],
+    )
+    y_pred = estimator.predict(FULL_TEST_DATA_DICT[datatype]["test"][0])
+    y_true = np.asarray(FULL_TEST_DATA_DICT[datatype]["test"][1]).astype(bool)
+
+    # the fixture needs both anomalous and normal time points for the area under
+    # the curve to be defined
+    if not y_true.any() or y_true.all():
+        return
+
+    auc = roc_auc_score(y_true, y_pred)
+    # a detector returning one score everywhere lands exactly on chance level, so
+    # this reads the baseline off the fixture instead of hard coding it
+    baseline = roc_auc_score(y_true, np.zeros(len(y_true)))
+
+    assert abs(auc - baseline) >= MIN_DISCRIMINATION_MARGIN, (
+        f"Anomaly scores do not separate the labelled anomalies in the testing "
+        f"fixture. Area under the ROC curve is {auc:.3f} against a constant score "
+        f"baseline of {baseline:.3f}, a difference of at least "
+        f"{MIN_DISCRIMINATION_MARGIN} is required. A single repeated score, or "
+        f"scores unrelated to the input, will produce this."
+    )

--- a/aeon/testing/estimator_checking/tests/test_yield_series_anomaly_detection_checks.py
+++ b/aeon/testing/estimator_checking/tests/test_yield_series_anomaly_detection_checks.py
@@ -1,0 +1,47 @@
+"""Tests for the series anomaly detection estimator checks."""
+
+__maintainer__ = []
+
+import numpy as np
+import pytest
+
+from aeon.anomaly_detection.series.base import BaseSeriesAnomalyDetector
+from aeon.testing.estimator_checking._yield_series_anomaly_detection_checks import (
+    check_series_anomaly_detector_discriminates,
+    check_series_anomaly_detector_output,
+)
+
+DATATYPE = "UnivariateSeries-Anomaly-np.ndarray"
+
+
+class _ConstantScoreDetector(BaseSeriesAnomalyDetector):
+    """Detector which returns the same anomaly score at every time point."""
+
+    _tags = {
+        "capability:univariate": True,
+        "capability:multivariate": True,
+        "anomaly_output_type": "anomaly_scores",
+        "learning_type:unsupervised": True,
+    }
+
+    def __init__(self):
+        super().__init__(axis=1)
+
+    def _predict(self, X):
+        return np.full(X.shape[self.axis], 0.7)
+
+
+def test_constant_scores_fail_discrimination_check():
+    """Test a constant anomaly score is rejected on the labelled fixture.
+
+    A constant score is only wrong because the fixture used here holds labelled
+    anomalies. On a constant input series a constant score would be correct, and this
+    check never runs on such a series.
+    """
+    detector = _ConstantScoreDetector()
+
+    # the existing output check only looks at shape and dtype, so it accepts this
+    check_series_anomaly_detector_output(detector, DATATYPE)
+
+    with pytest.raises(AssertionError, match="do not separate the labelled anomalies"):
+        check_series_anomaly_detector_discriminates(detector, DATATYPE)

--- a/aeon/testing/mock_estimators/_mock_anomaly_detectors.py
+++ b/aeon/testing/mock_estimators/_mock_anomaly_detectors.py
@@ -28,7 +28,13 @@ class MockAnomalyDetector(BaseSeriesAnomalyDetector):
         super().__init__(axis=1)
 
     def _predict(self, X):
-        return np.zeros(X.shape[self.axis])
+        # A minimal anomaly score which still depends on the input, the distance of
+        # each time point from the mean of its channel, averaged over channels. The
+        # previous constant score meant this mock did not discriminate at all, so it
+        # could not stand in for a detector in the general estimator checks.
+        # Missing time points score zero, this mock is capable of missing values.
+        deviation = np.abs(X - np.nanmean(X, axis=self.axis, keepdims=True))
+        return np.nan_to_num(deviation).mean(axis=1 - self.axis)
 
 
 class MockAnomalyDetectorRequiresFit(MockAnomalyDetector):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/aeon-toolkit/aeon/issues/3771

Related, not addressed here: https://github.com/aeon-toolkit/aeon/issues/2801

#### What does this implement/fix? Explain your changes.

`check_series_anomaly_detector_output` only checks the shape and dtype of the returned scores. A detector that returns a constant score passes it. So does one that returns scores unrelated to the input. Nothing in the general checks asks whether the detector discriminates.

This adds `check_series_anomaly_detector_discriminates`. It fits and predicts on the labelled fixture the suite already uses, then measures the area under the ROC curve of the scores against that fixture's labels. It requires a gap of at least 0.05 from a constant-score baseline computed on the same labels, which is chance level by construction.

On @TonyBagnall's question in the issue about whether a constant score is always wrong. It is not. On a constant input series a constant score is the right answer. This check never sees such a series. It only runs on the labelled fixture, which does contain anomalies, so a constant score on that fixture is a real failure. The docstring says this so the next reader does not have to find the issue thread.

Design notes:

- Rank based, so no threshold and no assumption about the scale of the scores.
- The gap is two-sided. `OneClassSVM` and `IsolationForest` both score anomalies low rather than high on this fixture, area under the curve 0.000 with `random_state=0`. They discriminate perfectly, the sign is inverted. That may be worth a separate look, but a one-sided check would fail them here for the wrong reason.
- The baseline is read off the fixture rather than hard coded at 0.5, so it survives changes to the fixture's anomaly rate.
- Only yielded for `anomaly_output_type == "anomaly_scores"`. Binary output is a label, not a ranking, and an all-zero label vector is a legitimate prediction.
- Runs on one datatype per instance, so it adds one fit and predict per detector.
- `random_state=0` is pinned, following the existing convention in the clustering, classification and multithreading check files. Without it `IsolationForest` and `ExtendedIsolationForest` fall under the floor in roughly 2 runs in 100.

#### Does your contribution introduce a new dependency? If yes, which one?

No. `roc_auc_score` comes from scikit-learn, already a core dependency.

#### Any other comments?

Three things need review.

**`MockAnomalyDetector` had to change.** It returned `np.zeros(...)` with `anomaly_output_type: "anomaly_scores"`, so it was exactly the degenerate detector this check rejects, and it is run through `parametrize_with_checks` in `test_check_estimator.py`. It now returns the distance of each time point from its channel mean. Still trivial, but it depends on the input. No test asserted its values, only shape and dtype. If you would rather the mock stay a no-op, the alternative is an `EXCLUDED_TESTS` entry, but the developer guide calls those temporary so I did not go that way.

**The floor is low on purpose, and it will not catch random scores.** The labelled fixture is 20 time points with exactly one anomaly, so the area under the curve only takes values `k/19`. A floor high enough to reliably catch random scores would fail real detectors. Measured over 1000 seeds a random-score detector is caught 11% of the time. A constant score is caught every time. The worst margin among current detectors is STOMP at 0.132 against the 0.05 floor. Raising the floor would need a longer fixture with more labelled anomalies, which touches shared data and belongs in its own PR.

**Not extended to collection anomaly detectors.** They use per-case classification labels, which is different semantics. Happy to follow up if you want it.

On #2801, I looked at whether it fits here and it does not. I compared `fit_predict(X)` against `fit(X).predict(X)` for the ten series detectors that override `_fit_predict`. Five differ: CBLOF, ExtendedIsolationForest, IsolationForest, LOF and PyODAdapter. The pyod adapter path returns `decision_scores_`, the in-sample training scores, while `predict` calls `decision_function`, and LOF also flips `novelty` between them. So the test as described in that issue would fail half the detectors today, and whether that is a bug or intended is a design decision I did not want to make inside this PR. I will write it up on #2801.
