### PR TITLE
[BUG] Fix numpy 2 incompatibilities in ClaSP, TRILITE and NBeats

### DIFF
--- a/aeon/forecasting/deep_learning/_nbeats.py
+++ b/aeon/forecasting/deep_learning/_nbeats.py
@@ -323,7 +323,7 @@ class NBeatsForecaster(BaseDeepForecaster, SeriesToSeriesForecastingMixin):
             y=y, prediction_horizon=self.horizon, exog=exog
         )
         if len(prediction) == 1:
-            prediction = float(prediction)
+            prediction = float(prediction[0])
         return prediction
 
     def _series_to_series_forecast(self, y, prediction_horizon, exog=None):

--- a/aeon/transformations/collection/self_supervised/_trilite.py
+++ b/aeon/transformations/collection/self_supervised/_trilite.py
@@ -487,7 +487,7 @@ class TRILITE(BaseCollectionTransformer):
             all_indices_without_ref = np.delete(arr=all_indices, obj=i_ref)
 
             # choose a random sample used for the negative generation
-            index_neg = int(np.random.choice(all_indices_without_ref, size=1))
+            index_neg = np.random.choice(all_indices_without_ref, size=1).item()
 
             _ref = ref[i_ref].copy()
 
@@ -497,19 +497,19 @@ class TRILITE(BaseCollectionTransformer):
             )
 
             # choose samples used for the mixing up
-            index_ts1_pos = int(
-                np.random.choice(all_indices_without_ref_and_not_ref, size=1)
-            )
-            index_ts2_pos = int(
-                np.random.choice(all_indices_without_ref_and_not_ref, size=1)
-            )
+            index_ts1_pos = np.random.choice(
+                all_indices_without_ref_and_not_ref, size=1
+            ).item()
+            index_ts2_pos = np.random.choice(
+                all_indices_without_ref_and_not_ref, size=1
+            ).item()
 
-            index_ts1_neg = int(
-                np.random.choice(all_indices_without_ref_and_not_ref, size=1)
-            )
-            index_ts2_neg = int(
-                np.random.choice(all_indices_without_ref_and_not_ref, size=1)
-            )
+            index_ts1_neg = np.random.choice(
+                all_indices_without_ref_and_not_ref, size=1
+            ).item()
+            index_ts2_neg = np.random.choice(
+                all_indices_without_ref_and_not_ref, size=1
+            ).item()
 
             _not_ref = ref[index_neg].copy()
 
@@ -570,7 +570,9 @@ class TRILITE(BaseCollectionTransformer):
     def _apply_masking(self, pos, neg, n_channels, length_TS, mask_length):
         """Apply masking phase on pos and neg."""
         # select a random start for the mask
-        start_mask = int(np.random.randint(low=0, high=length_TS - mask_length, size=1))
+        start_mask = np.random.randint(
+            low=0, high=length_TS - mask_length, size=1
+        ).item()
         stop_mask = start_mask + mask_length
 
         # define noise on replacement on the left side of the mask

--- a/aeon/transformations/series/_clasp.py
+++ b/aeon/transformations/series/_clasp.py
@@ -313,7 +313,7 @@ def _roc_auc_score(y_score, y_true):
         else:
             return np.nan
 
-    area = direction * np.trapz(tpr, fpr)
+    area = direction * np.trapezoid(tpr, fpr)
     return area
 
 


### PR DESCRIPTION
fixes #3793 

np.trapz was removed in numpy 2 (renamed np.trapezoid), and converting a size-1 array with ndim > 0 to a Python scalar now raises TypeError.

Keeps size=1 on the RNG calls and uses .item() so the draws are unchanged and results stay bit-identical.

