### PR TITLE
[BUG] Use removesuffix(".py") when collecting changed files for numba cache invalidation

### DIFF
--- a/aeon/testing/_cicd_numba_caching.py
+++ b/aeon/testing/_cicd_numba_caching.py
@@ -38,7 +38,7 @@ if os.environ.get("CACHING_CICD_RUNNING") == "1":  # pragma: no cover
 
         for temp in files:
             if temp.endswith(".py"):
-                clean_files.append((temp.split("/")[-1]).strip(".py"))
+                clean_files.append(temp.split("/")[-1].removesuffix(".py"))
 
         return clean_files
 


### PR DESCRIPTION
#### Reference Issues/PRs

None — found while auditing `str.strip` calls that are passed a suffix rather than a character set.

#### What does this implement/fix? Explain your changes.

`aeon/testing/_cicd_numba_caching.py` collects the files changed in a PR so the CI run can invalidate their numba caches:

```python
for temp in files:
    if temp.endswith(".py"):
        clean_files.append((temp.split("/")[-1]).strip(".py"))
```

`str.strip` takes a **character set**, not a suffix, so `.strip(".py")` also eats leading and trailing `.`, `p` and `y` characters from the basename. **44 of the 955 `.py` files** in the repository come out mangled, including a number of numba-heavy modules:

| changed file | `CHANGED_FILES` entry | cache key from `custom_load_index` |
|---|---|---|
| `aeon/anomaly_detection/series/distance_based/_stomp.py` | `_stom` | `_stomp` |
| `aeon/segmentation/_clasp.py` | `_clas` | `_clasp` |
| `aeon/distances/elastic/_erp.py` | `_er` | `_erp` |
| `aeon/classification/feature_based/_summary.py` | `_summar` | `_summary` |
| `aeon/pipeline.py` | `ipeline` | `pipeline` |

The other side of the comparison, in `custom_load_index`, derives the name with

```python
cache_filename = self._index_path.split("/")[-1].split("-")[0].split(".")[0]
```

which keeps the basename intact. So `cache_filename in CHANGED_FILES` never matches for any file whose basename starts with `p`/`y` or ends with `p`/`y`, and the stale numba cache for that module survives a change to its source — exactly the situation this module exists to prevent. (Also affected: `_stray.py`, `_mlp.py`, `_seasonality.py`, `_identity.py`, `_tvp.py`, `dummy.py`, `discovery.py`, and their test modules.)

`removesuffix(".py")` strips exactly the extension, which is what the `temp.endswith(".py")` guard above already established is present.

#### Verification

`get_invalid_numba_files` was extracted from the module with `ast.get_source_segment` and run with a stubbed `subprocess` returning a fixed `git diff --name-only` list; the `cache_filename = ...` expression was extracted from `custom_load_index` the same way and evaluated on the matching numba index filename, so both sides of the comparison come from the real source:

| changed source file | `CHANGED_FILES` entry | cache key | invalidated before | after |
|---|---|---|---|---|
| `.../_stomp.py` | `_stom` | `_stomp` | **False** | True |
| `aeon/segmentation/_clasp.py` | `_clas` | `_clasp` | **False** | True |
| `aeon/distances/elastic/_erp.py` | `_er` | `_erp` | **False** | True |
| `.../_summary.py` | `_summar` | `_summary` | **False** | True |
| `aeon/pipeline.py` | `ipeline` | `pipeline` | **False** | True |
| `aeon/distances/elastic/_dtw.py` (control) | `_dtw` | `_dtw` | True | True |
| `.../_rocket.py` (control) | `_rocket` | `_rocket` | True | True |

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

The module only runs when `CACHING_CICD_RUNNING=1`, so this is CI-only and cannot affect user-facing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
