### PR TITLE
[BUG] samplers: ask for the labels transform needs instead of failing on them

### DIFF
--- a/aeon/transformations/collection/imbalance/_adasyn.py
+++ b/aeon/transformations/collection/imbalance/_adasyn.py
@@ -83,6 +83,11 @@ class ADASYN(SMOTE):
         )
 
     def _transform(self, X, y=None):
+        if y is None:
+            raise ValueError(
+                f"{self.__class__.__name__} resamples X and y together, so transform "
+                "needs the labels: pass y, or call fit_transform."
+            )
         X = np.squeeze(X, axis=1)
         X_resampled = [X.copy()]
         y_resampled = [y.copy()]

--- a/aeon/transformations/collection/imbalance/_esmote.py
+++ b/aeon/transformations/collection/imbalance/_esmote.py
@@ -106,6 +106,11 @@ class ESMOTE(BaseCollectionTransformer):
         return self
 
     def _transform(self, X, y=None):
+        if y is None:
+            raise ValueError(
+                f"{self.__class__.__name__} resamples X and y together, so transform "
+                "needs the labels: pass y, or call fit_transform."
+            )
         X_resampled = [X.copy()]
         y_resampled = [y.copy()]
 

--- a/aeon/transformations/collection/imbalance/_ohit.py
+++ b/aeon/transformations/collection/imbalance/_ohit.py
@@ -108,6 +108,11 @@ class OHIT(BaseCollectionTransformer):
         return self
 
     def _transform(self, X, y=None):
+        if y is None:
+            raise ValueError(
+                f"{self.__class__.__name__} resamples X and y together, so transform "
+                "needs the labels: pass y, or call fit_transform."
+            )
         X = np.squeeze(X, axis=1)
         X_resampled = [X.copy()]
         y_resampled = [y.copy()]

--- a/aeon/transformations/collection/imbalance/_random_over_sampler.py
+++ b/aeon/transformations/collection/imbalance/_random_over_sampler.py
@@ -62,6 +62,11 @@ class RandomOverSampler(BaseCollectionTransformer):
         return self
 
     def _transform(self, X, y=None):
+        if y is None:
+            raise ValueError(
+                f"{self.__class__.__name__} resamples X and y together, so transform "
+                "needs the labels: pass y, or call fit_transform."
+            )
         X_resampled = [X.copy()]
         y_resampled = [y.copy()]
 

--- a/aeon/transformations/collection/imbalance/_smote.py
+++ b/aeon/transformations/collection/imbalance/_smote.py
@@ -125,6 +125,11 @@ class SMOTE(BaseCollectionTransformer):
         return self
 
     def _transform(self, X, y=None):
+        if y is None:
+            raise ValueError(
+                f"{self.__class__.__name__} resamples X and y together, so transform "
+                "needs the labels: pass y, or call fit_transform."
+            )
         # remove the channel axis to be compatible with sklearn
         X = np.squeeze(X, axis=1)
         X_resampled = [X.copy()]

--- a/aeon/transformations/collection/imbalance/tests/test_transform_needs_y.py
+++ b/aeon/transformations/collection/imbalance/tests/test_transform_needs_y.py
@@ -1,0 +1,40 @@
+"""Every sampler asks for the labels rather than failing on them."""
+
+import numpy as np
+import pytest
+
+from aeon.testing.data_generation import make_example_3d_numpy
+from aeon.transformations.collection.imbalance import (
+    ADASYN,
+    ESMOTE,
+    OHIT,
+    SMOTE,
+    RandomOverSampler,
+)
+
+SAMPLERS = [ADASYN, ESMOTE, OHIT, SMOTE, RandomOverSampler]
+
+
+@pytest.mark.parametrize("sampler", SAMPLERS)
+def test_transform_without_y_is_refused(sampler):
+    """A sampler resamples X and y together, so transform cannot run on X alone.
+
+    The base signature makes y optional and every sampler read it straight into
+    `y.copy()`, so the call raised AttributeError on None rather than naming the
+    argument it wanted.
+    """
+    X, y = make_example_3d_numpy(n_cases=20, n_channels=1, n_labels=2, random_state=0)
+    fitted = sampler().fit(X, y)
+    with pytest.raises(ValueError, match="resamples X and y together"):
+        fitted.transform(X)
+
+
+@pytest.mark.parametrize("sampler", SAMPLERS)
+def test_transform_with_y_still_resamples(sampler):
+    """The guard leaves the supported call alone."""
+    X, _ = make_example_3d_numpy(n_cases=20, n_channels=1, random_state=0)
+    y = np.array([0] * 14 + [1] * 6)
+    fitted = sampler().fit(X, y)
+    Xt, yt = fitted.transform(X, y)
+    assert len(Xt) == len(yt)
+    assert len(yt) >= len(y)


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

`SMOTE().fit(X, y).transform(X)` dies inside the sampler on `AttributeError: 'NoneType' object has no attribute 'shape'`, rather than saying the labels are required. ADASYN, ESMOTE, OHIT and RandomOverSampler do the same.

The five resample `X` and `y` together, so `transform` cannot work without `y`. The `requires_y` tag marks what `fit` needs and nothing on the class marks what `transform` needs, so there was no other way for a caller to find out.

Each `_transform` now raises `ValueError` naming the estimator and both ways out:

```
SMOTE resamples X and y together, so transform needs the labels:
pass y, or call fit_transform.
```

The guard sits in the five samplers rather than in `BaseCollectionTransformer`, where a first attempt broke five legitimate estimators that transform without labels.

`aeon/transformations/collection/imbalance` runs 19 passed, 3 skipped. The new test file adds 10 cases: the five refusals, the five estimators still resampling when `y` is passed.
