### PR TITLE
[DOC] Fix BaseSeriesTransformer class docstring

### DIFF
--- a/aeon/transformations/series/base.py
+++ b/aeon/transformations/series/base.py
@@ -17,7 +17,7 @@ from aeon.utils.decorators.method_timer import method_timer
 
 
 class BaseSeriesTransformer(BaseSeriesEstimator, BaseTransformer):
-    """Transformer base class for collections."""
+    """Transformer base class for series."""
 
     # default tag values for series transformers
     _tags = {


### PR DESCRIPTION
Closes #3799

`BaseSeriesTransformer` had the `BaseCollectionTransformer` summary line
("Transformer base class for collections."), which is wrong since it transforms
single series, not collections. Changed it to "Transformer base class for series."

The identical line on `BaseCollectionTransformer` is correct and left untouched.

- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
