### PR TITLE
[BUG] MultiRocket: require 10 timepoints instead of failing after differencing

### DIFF
--- a/aeon/transformations/collection/convolution_based/_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/_multirocket.py
@@ -130,10 +130,10 @@ class MultiRocket(BaseCollectionTransformer):
             np.random.seed(self.random_state_)
 
         _, n_channels, n_timepoints = X.shape
-        if n_timepoints < 9:
+        if n_timepoints < 10:
             raise ValueError(
-                f"n_timepoints must be >= 9, but found {n_timepoints};"
-                " zero pad shorter series so that n_timepoints == 9"
+                f"n_timepoints must be >= 10, but found {n_timepoints};"
+                " zero-pad shorter series to 10 timepoints before fitting"
             )
         X = X.astype(np.float32)
         if self.normalise:

--- a/aeon/transformations/collection/convolution_based/tests/test_multirocket.py
+++ b/aeon/transformations/collection/convolution_based/tests/test_multirocket.py
@@ -1,0 +1,22 @@
+"""MultiRocket regression tests."""
+
+import numpy as np
+import pytest
+
+from aeon.transformations.collection.convolution_based import MultiRocket
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+@pytest.mark.parametrize("n_timepoints", [8, 9])
+def test_multirocket_rejects_short_series_after_differencing(n_channels, n_timepoints):
+    """Reject series too short for the differenced representation."""
+    transformer = MultiRocket(n_kernels=168)
+    with pytest.raises(ValueError, match="n_timepoints must be >= 10"):
+        transformer.fit(np.zeros((2, n_channels, n_timepoints)))
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+@pytest.mark.parametrize("n_timepoints", [10, 11])
+def test_multirocket_accepts_minimum_series(n_channels, n_timepoints):
+    """Fit the minimum valid series lengths on both the uni- and multivariate path."""
+    MultiRocket(n_kernels=168).fit(np.zeros((2, n_channels, n_timepoints)))


### PR DESCRIPTION
#### Reference Issues/PRs

References #3772. That issue reports `MRHydra`/`HydraClassifier` failing on the length-8 PenDigits dataset with `ValueError: unable to broadcast argument 1 to output array`; the traceback dies in MultiRocket's bias fitting, which is the crash this PR fixes. This is the MultiRocket half of #3772: with this change, short input is rejected up front with the true minimum (10 timepoints) and the remedy, instead of a numba broadcast error (or a guard message that names the wrong minimum).

#### What does this implement/fix? Explain your changes.

**Symptom.** `MultiRocket.fit` accepts a 9-timepoint collection and then crashes inside numba with `ValueError: unable to broadcast argument 1 to output array`. The message names no parameter, no minimum and no remedy, so a user who hits it has no way to know that the input is simply too short. Complete runnable repro, copy-paste against current `main`:

```python
import numpy as np

from aeon.transformations.collection.convolution_based import MultiRocket

rng = np.random.default_rng(42)

# 10 cases, 1 channel, 9 timepoints: passes the current n_timepoints >= 9 guard
X = rng.random((10, 1, 9))
y = np.array([0, 1] * 5)

t = MultiRocket()
t.fit(X, y)
```

On `main` this raises `ValueError: unable to broadcast argument 1 to output array` from `_fit_biases_univariate` (via `_fit_univariate` on the differenced series). With this PR it raises `ValueError: n_timepoints must be >= 10, but found 9; zero-pad shorter series to 10 timepoints before fitting`, and the same script with 10 timepoints fits and transforms cleanly.

**Root cause.** `MultiRocket._fit` validates the *raw* series length at `aeon/transformations/collection/convolution_based/_multirocket.py:133` on `main`:

```python
if n_timepoints < 9:
```

but `_fit` fits a second kernel set on the first differences of `X` (`_multirocket.py:146` and `:150`, `_X1 = np.diff(X, 1)`), which is one point shorter. The kernel fit itself needs 9 points. I confirmed that boundary directly rather than inferring it:

```
_fit_univariate n=8: ValueError: unable to broadcast argument 1 to output array
_fit_univariate n=9: OK
_fit_univariate n=10: OK
```

So a 9-point input passes validation, gets differenced to 8 points, and dies in the kernel fit. The true minimum input length is 10, not 9.

**Change.** Raise the guard to `n_timepoints < 10` and reword the message to name the real minimum and the remedy. Three lines in `_fit` (`git diff --stat` on the source file: 3 insertions, 3 deletions); nothing else in the module changes.

**Trade-off a reviewer should weigh.** This is a stricter documented input contract: a 9-timepoint collection that previously reached `fit` now raises up front. It could not complete `fit` before either — it raised a numba broadcast error at the same call — so no working configuration is taken away, but anyone catching the old `n_timepoints must be >= 9` string will see new text. The alternative design would be to zero-pad the differenced series internally so that 9-point input becomes usable; that changes what MultiRocket computes, so I did not do it here. Say the word if you would prefer that direction.

`MiniRocket` carries its own independent `n_timepoints < 9` check (`_minirocket.py:121`) and never calls `np.diff`, so it is untouched by this and its tests still assert the `>= 9` message.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

The new test file `aeon/transformations/collection/convolution_based/tests/test_multirocket.py` sits next to `test_minirocket.py` in the same package as the module under test, per `docs/developer_guide/testing.md`. Both tests are parametrised over `n_channels` in `[1, 2]` because `_fit` branches on `n_channels == 1` into `_fit_univariate`; the bug is present on both paths (shown above).

### Testing

Environment: Python 3.12.12, local `.venv`, numba/NumPy from `pyproject.toml`.

**Revert proof — new tests fail against unpatched source, pass with the fix.**

Fix in place:

```
$ .venv/bin/python -m pytest aeon/transformations/collection/convolution_based/tests/test_multirocket.py -p no:randomly -q
8 passed in 6.83s
```

Source restored to the base commit, new test file left in place (`git checkout <base> -- aeon/transformations/collection/convolution_based/_multirocket.py`):

```
E       AssertionError: Regex pattern did not match.
E         Expected regex: 'n_timepoints must be >= 10'
E         Actual message: 'unable to broadcast argument 1 to output array\nFile ".../_multirocket.py", line 1, '

=========================== short test summary info ============================
FAILED .../tests/test_multirocket.py::test_multirocket_rejects_short_series_after_differencing[8-1]
FAILED .../tests/test_multirocket.py::test_multirocket_rejects_short_series_after_differencing[8-2]
FAILED .../tests/test_multirocket.py::test_multirocket_rejects_short_series_after_differencing[9-1]
FAILED .../tests/test_multirocket.py::test_multirocket_rejects_short_series_after_differencing[9-2]
4 failed, 4 passed in 4.01s
```

All four rejection cases fail without the fix — the 8-point cases because the old message says `>= 9`, the 9-point cases because nothing is raised until numba fails. The four acceptance cases (10 and 11 timepoints) pass either way, which is the point: the change does not move the working boundary.

**Surrounding suite:**

```
$ .venv/bin/python -m pytest aeon/transformations/collection/convolution_based/tests/ -p no:randomly -q
63 passed, 5 skipped in 56.79s
```

**General estimator checks:**

```
MultiRocket Counter({'PASSED': 20}) 20 checks
MultiRocketClassifier Counter({'PASSED': 22}) 22 checks
```

`aeon/testing/testing_data.py` only ever sets `n_timepoints` to 10 or 20 (`grep -o "n_timepoints=[0-9]*" | sort | uniq -c` → 24 × `=10`, 116 × `=20`), so the raised boundary cannot affect general testing.

**Wrapping estimator at the new boundary** — `MultiRocketClassifier` propagates the new message rather than the numba error:

```
MultiRocketClassifier n_timepoints=9: ValueError: n_timepoints must be >= 10, but found 9; zero-pad shorter series to 10 timepoints before fitting
MultiRocketClassifier n_timepoints=10: fit OK
```

**`MultiRocketHydraClassifier` and `HydraClassifier` at the boundary** (macOS arm64, Python 3.12.12, torch 2.14.0, default parameters, 10 synthetic cases, `fit` then `predict`):

| n_timepoints | MRHydra on `main` | MRHydra with this PR | Hydra, both |
|---|---|---|---|
| 8 | `n_timepoints must be >= 9` | `n_timepoints must be >= 10` | ok |
| 9 | broadcast error from #3772 | `n_timepoints must be >= 10` | ok |
| 10 | ok | ok | ok |
| 11 | ok | ok | ok |
| 12 | ok | ok | ok |

Identical for 1 and 2 channels. The working minimum for `MultiRocketHydraClassifier` is 10 both before and after this change; only the error raised at 8 and 9 timepoints changes.

**Lint** (on the two touched files):

```
$ .venv/bin/ruff check <touched files>
All checks passed!
$ .venv/bin/ruff format --check <touched files>
2 files already formatted
$ git diff --check <base>
(no output)
```

### What was not verified

- **The real PenDigits download was not used.** The boundary table in *Testing* uses synthetic series around PenDigits' shape (2 channels, 8 timepoints). `HydraClassifier` fit and predicted at 8 timepoints there, so the Hydra side of #3772 did not reproduce and this PR does not touch Hydra.
- **Full `pre-commit` was not run.** `pre-commit`, `black`, `isort`, `pyupgrade` and `codespell` are not installed here. Only `ruff check` and `ruff format --check` ran, on the touched files. `black`/`isort` conflicts are unlikely given `ruff format` reports the files already formatted, but I did not prove it.
- **No benchmark run.** MultiRocket's transform output for valid lengths is unchanged by construction (only a validation threshold and a message moved), and I did not re-run any accuracy or timing benchmark.
- **No CI run.** Nothing here was executed on aeon's CI matrix; this is one macOS/Python 3.12 environment.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors — not done; I would rather leave this to the `@all-contributors` bot after the PR is merged, if you want it at all.
- [x] The PR title starts with `[BUG]`.

##### For new estimators and functions
Not applicable — no new estimator or public function is added; the change is a validation threshold and a test file.

##### For developers with write access
Not applicable — I do not have write access.

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.


