### PR TITLE
[BUG] DisjointCNNNetwork: stop permuting the final convolution block

### DIFF
--- a/aeon/networks/encoder/_disjoint_cnn.py
+++ b/aeon/networks/encoder/_disjoint_cnn.py
@@ -251,6 +251,8 @@ class DisjointCNNNetwork(BaseDeepLearningNetwork):
                 activation=self._activation[i],
                 kernel_initializer=self._kernel_initializer[i],
             )
+            if i < self.n_layers - 1:
+                x = tf.keras.layers.Permute((1, 3, 2))(x)
 
         max_pool_layer = tf.keras.layers.MaxPooling2D(
             pool_size=(self.pool_size, 1),
@@ -304,7 +306,5 @@ class DisjointCNNNetwork(BaseDeepLearningNetwork):
 
         spatial_conv = tf.keras.layers.BatchNormalization()(spatial_conv)
         spatial_conv = tf.keras.layers.Activation(activation=activation)(spatial_conv)
-
-        spatial_conv = tf.keras.layers.Permute((1, 3, 2))(spatial_conv)
 
         return spatial_conv

--- a/aeon/networks/encoder/tests/test_disjoint_cnn.py
+++ b/aeon/networks/encoder/tests/test_disjoint_cnn.py
@@ -20,3 +20,17 @@ def test_disjoint_cnn_netowkr_kernel_initializer():
 
     assert len(output_layer.shape) == 2
     assert len(input_layer.shape) == 3
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies(["tensorflow"], severity="none"),
+    reason="Tensorflow soft dependency unavailable.",
+)
+def test_disjoint_cnn_final_projection_receives_final_filter_count():
+    """Final block is not permuted before pooling."""
+    import tensorflow as tf
+
+    network = DisjointCNNNetwork(n_layers=2, n_filters=[4, 8], kernel_size=[3, 3])
+    inputs, outputs = network.build_network((12, 3))
+    model = tf.keras.Model(inputs, outputs)
+    assert model.layers[-1].input.shape[-1] == 8


### PR DESCRIPTION
#### Reference Issues/PRs

None. `.github/PULL_REQUEST_TEMPLATE.md` asks contributors to use linking keywords where an issue exists rather than requiring one; this was found while reading the code, not filed as an issue first.

#### What does this implement/fix? Explain your changes.

**Symptom.** Every network built by `DisjointCNNNetwork` throws away its learned representation immediately before the projection head. Global average pooling emits a **single** feature per sample regardless of how many filters the last convolution block produced. Built on `main` with `n_layers=2, n_filters=[4, 8], input_shape=(12, 3)`:

```
Activation              in (None, 12, 1, 8) -> out (None, 12, 1, 8)
Permute                 in (None, 12, 1, 8) -> out (None, 12, 8, 1)
MaxPooling2D            in (None, 12, 8, 1) -> out (None, 2, 8, 1)
GlobalAveragePooling2D  in (None, 2, 8, 1)  -> out (None, 1)
Dense                   in (None, 1)        -> out (None, 128)
```

The 128-unit projection head is fed one scalar. With the fix:

```
Activation              in (None, 12, 1, 8) -> out (None, 12, 1, 8)
MaxPooling2D            in (None, 12, 1, 8) -> out (None, 2, 1, 8)
GlobalAveragePooling2D  in (None, 2, 1, 8)  -> out (None, 8)
Dense                   in (None, 8)        -> out (None, 128)
```

**Root cause.** The axis permutation is applied inside the block helper rather than between blocks. On `main`, `_one_plus_one_d_convolution_layer` ends at `aeon/networks/encoder/_disjoint_cnn.py:308` with:

```python
spatial_conv = tf.keras.layers.Permute((1, 3, 2))(spatial_conv)
```

The permutation exists so that the *next* block's spatial convolution operates across the previous block's filters. Because it lives at the end of the helper, it also fires after the final block, where there is no next block — it just swaps the filter axis out of the feature position right before `MaxPooling2D`/`GlobalAveragePooling2D`. Pooling then reduces over the filters and leaves a last-axis size of 1.

**Change.** Move the `Permute((1, 3, 2))` out of the helper and into the `build_network` loop, guarded by `if i < self.n_layers - 1` (`_disjoint_cnn.py:254-255` on this branch). Inter-block behaviour is unchanged — the same permutation happens in the same place between blocks. Only the trailing one is gone. Two lines added to the loop, two removed from the helper; the class signature and public API are untouched.

**Trade-off a reviewer should weigh — this is a real behaviour change, not a refactor.** Networks built after this change have a different graph, so **existing DisjointCNN checkpoints will not load**. Anyone with saved weights has to retrain. That is the price of the fix; there is no way to restore the final-filter representation while keeping the old output shape. I have not re-benchmarked accuracy against the published DisjointCNN numbers (see *What was not verified*), so if aeon's stored results for this architecture were produced with the permuted graph, they were produced against the defect.

`_one_plus_one_d_convolution_layer` is private and is referenced nowhere outside `_disjoint_cnn.py` (checked with grep across `aeon/`), so moving the permute out of it cannot affect another network.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

The new test asserts a graph property (`model.layers[-1].input.shape[-1] == 8`) rather than a numeric output, because the defect is structural. The expected `8` is hard-coded from the test's own `n_filters=[4, 8]` argument rather than read back off the model, so it is not tautological. It reuses the TensorFlow soft-dependency skip already used by the other test in the file.

### Testing

Environment: Python 3.12.12, local `.venv`, TensorFlow 2.21.0 installed — so the new test executed rather than skipping.

**Revert proof — new test fails against unpatched source, passes with the fix.**

Fix in place:

```
$ .venv/bin/python -m pytest aeon/networks/encoder/tests/test_disjoint_cnn.py -p no:randomly -q
2 passed in 0.47s
```

Source restored to the base commit, new test left in place (`git checkout <base> -- aeon/networks/encoder/_disjoint_cnn.py`):

```
>       assert model.layers[-1].input.shape[-1] == 8
E       assert 1 == 8
FAILED aeon/networks/encoder/tests/test_disjoint_cnn.py::test_disjoint_cnn_final_projection_receives_final_filter_count
1 failed, 1 passed in 2.39s
```

`assert 1 == 8` is the defect stated numerically: 1 feature reaching the projection head where `n_filters[-1] == 8` belongs.

**Surrounding suites:**

```
$ .venv/bin/python -m pytest aeon/networks/encoder/tests/ aeon/classification/deep_learning/tests/test_deep_classifier_base.py -p no:randomly -q
168 passed, 2 xfailed, 2 warnings in 16.90s
```

**General estimator checks on both estimators that use this network:**

```
DisjointCNNClassifier Counter({'PASSED': 33}) 33 checks
DisjointCNNRegressor  Counter({'PASSED': 33}) 33 checks
```

**No stored expected results are invalidated:** `grep -rn "DisjointCNN" aeon/testing/expected_results/` returns nothing, so there is no results table to update.

**Lint** (on the two touched files):

```
$ .venv/bin/ruff check <touched files>
All checks passed!
$ .venv/bin/ruff format --check <touched files>
2 files already formatted
$ git diff --check <base>
(no output)
```

### What was not verified

- **No accuracy benchmark, no training run on real data.** The evidence here is a graph-shape assertion plus `check_estimator`, which fits tiny synthetic data and asserts API conformance — it does not measure whether the corrected network learns better. I did not reproduce the published DisjointCNN results before or after, and I cannot tell you the accuracy delta.
- **Weight compatibility was not tested, only reasoned about.** I did not attempt to load an old checkpoint into the new graph; I am asserting incompatibility from the shape change, not from an observed load failure.
- **One TensorFlow version only.** TensorFlow 2.21.0, macOS, CPU. No GPU, no older TF, and nothing was run on aeon's CI matrix.
- **Full `pre-commit` was not run.** `pre-commit`, `black`, `isort`, `pyupgrade` and `codespell` are not installed in this environment. Only `ruff check` and `ruff format --check` ran, on the touched files.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors — not done; I would rather leave this to the `@all-contributors` bot after the PR is merged, if you want it at all.
- [x] The PR title starts with `[BUG]`.

##### For new estimators and functions
Not applicable — no new estimator or public function is added.

##### For developers with write access
Not applicable — I do not have write access.

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.
