### PR TITLE
[BUG] shift_scale_invariant_distance: allocate shift padding with the input dtype

### DIFF
--- a/aeon/clustering/tests/test_k_sc.py
+++ b/aeon/clustering/tests/test_k_sc.py
@@ -57,6 +57,27 @@ def test_k_spectral_centroid_multivariate():
     assert np.array_equal(preds, expected_labels)
 
 
+def test_k_spectral_centroid_float32_fit_and_predict():
+    """The public float32 clusterer path remains compatible with shift-scale code."""
+    data = make_example_3d_numpy(8, 1, 12, return_y=False, random_state=42).astype(
+        np.float32
+    )
+    clusterer = KSpectralCentroid(
+        n_clusters=2,
+        init="first",
+        n_init=1,
+        max_iter=3,
+        random_state=42,
+    )
+
+    labels = clusterer.fit_predict(data)
+    predictions = clusterer.predict(data)
+
+    assert labels.shape == (data.shape[0],)
+    assert predictions.shape == (data.shape[0],)
+    assert np.array_equal(labels, predictions)
+
+
 def test_k_spectral_centroid_with_max_shift():
     """Test KSpectralCentroid with different max_shift."""
     data, y_train = load_gunpoint(split="train")

--- a/aeon/distances/_shift_scale_invariant.py
+++ b/aeon/distances/_shift_scale_invariant.py
@@ -141,10 +141,10 @@ def _univariate_shift_scale_invariant_distance(
             shifted_y = y
         elif sh < 0:
             # Shift left
-            shifted_y = np.append(y[-sh:], np.zeros(-sh))
+            shifted_y = np.append(y[-sh:], np.zeros(-sh, dtype=y.dtype))
         else:
             # Shift right
-            shifted_y = np.append(np.zeros(sh), y[:-sh])
+            shifted_y = np.append(np.zeros(sh, dtype=y.dtype), y[:-sh])
 
         dist = _scale_d(x, shifted_y)
 

--- a/aeon/distances/tests/test_miscellaneous_distances.py
+++ b/aeon/distances/tests/test_miscellaneous_distances.py
@@ -1,6 +1,7 @@
 """Test the miscellaneous distance functions."""
 
 import numpy as np
+import pytest
 from numpy.ma.testutils import assert_almost_equal
 
 from aeon.distances import (
@@ -35,3 +36,14 @@ def test_shift_scale_invariant_distance():
     assert univariate_shift[1].shape == (10,)
     assert isinstance(multivariate_shift[1], np.ndarray)
     assert multivariate_shift[1].shape == (3, 10)
+
+
+def test_shift_scale_invariant_distance_preserves_float_dtype_padding():
+    """Float32 and float64 shifts remain aligned."""
+    x32 = np.array([1, 2, 3], dtype=np.float32)
+    y32 = np.array([2, 3, 0], dtype=np.float32)
+    assert shift_scale_invariant_distance(x32, y32, max_shift=1) == pytest.approx(
+        shift_scale_invariant_distance(
+            x32.astype(np.float64), y32.astype(np.float64), max_shift=1
+        )
+    )


### PR DESCRIPTION
#### Reference Issues/PRs

None. `.github/PULL_REQUEST_TEMPLATE.md` asks contributors to use linking keywords where an issue exists rather than requiring one; this was found while reading the code, not filed as an issue first.

#### What does this implement/fix? Explain your changes.

**Symptom.** `shift_scale_invariant_distance` cannot be called with `float32` input, and neither can anything built on it — `KSpectralCentroid.fit` on a float32 collection fails the same way. It is not a wrong answer, it is a hard numba compile error. On `main`:

```
$ .venv/bin/python -c "shift_scale_invariant_distance(x_f32, y_f32, max_shift=1)"
TypingError: Cannot unify array(float32, 1d, C) and array(float64, 1d, C) for 'best_shifted_y.2',
defined at .../aeon/distances/_shift_scale_invariant.py (155)

float64 -> 0.2672612419124244
```

float32 is the natural dtype for large time-series collections, so this makes the whole shift-scale-invariant family unusable on exactly the data most likely to need it.

**Root cause.** `_univariate_shift_scale_invariant_distance` allocates the shift padding without a dtype, at `aeon/distances/_shift_scale_invariant.py:144` and `:147` on `main`:

```python
shifted_y = np.append(y[-sh:], np.zeros(-sh))     # line 144
shifted_y = np.append(np.zeros(sh), y[:-sh])      # line 147
```

`np.zeros` defaults to `float64`. Inside a numba-compiled function, `np.append` of a float32 slice and a float64 array does not silently upcast the way NumPy would — numba fails to unify the branch types where `best_shifted_y` is assigned (`_shift_scale_invariant.py:153`), and the whole function refuses to compile. The reported line 155 is the `return`, where the unification is forced.

**Change.** Allocate the padding as `np.zeros(n, dtype=y.dtype)` in both shift branches, so the concatenation stays within one dtype. Two lines.

**Trade-off a reviewer should weigh.** For float64 input this is a no-op — `y.dtype` *is* `float64`, so the same array is allocated. I checked that rather than assuming: two float64 values are bit-identical before and after the change (below). The only observable difference is that float32 input now computes in float32 and so differs from the float64 result by rounding, which is why the new test uses `pytest.approx` rather than exact equality:

```
float32 -> 0.26726123690605164
float64 -> 0.2672612419124244
exactly equal? False
relative difference 1.873213162137731e-08
```

That is within `pytest.approx`'s default relative tolerance of 1e-6. The alternative — upcasting float32 input to float64 — would keep one canonical answer but silently double the memory of the hot loop, so I did not do it.

Integer input still raises a numba `TypingError` and `float16` still raises `NotImplementedError`. Both do so on the base commit too (I ran them on both), so they are pre-existing limitations, not regressions introduced here. This PR does not attempt to fix them.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Two tests, deliberately at two levels: one on the distance function itself, and one on `KSpectralCentroid` so the compiled clusterer path is covered end to end through the public API rather than only at the numba-function boundary.

### Testing

Environment: Python 3.12.12, local `.venv`.

**Revert proof — new tests fail against unpatched source, pass with the fix.**

Fix in place:

```
$ .venv/bin/python -m pytest aeon/distances/tests/test_miscellaneous_distances.py aeon/clustering/tests/test_k_sc.py -p no:randomly -q -rs
SKIPPED [2] aeon/clustering/tests/test_k_sc.py:117: Only run on multithread testing
7 passed, 2 skipped, 1 warning in 9.94s
```

(The 2 skips are pre-existing multithread-only tests, unrelated to this change.)

Source restored to the base commit, new tests left in place (`git checkout <base> -- aeon/distances/_shift_scale_invariant.py`):

```
FAILED aeon/distances/tests/test_miscellaneous_distances.py::test_shift_scale_invariant_distance_preserves_float_dtype_padding
FAILED aeon/clustering/tests/test_k_sc.py::test_k_spectral_centroid_float32_fit_and_predict
2 failed, 5 passed, 2 skipped, 1 warning in 6.65s
```

Both new tests fail without the fix, at both levels.

**float64 output is bit-identical before and after.** Same inputs (`np.random.RandomState(0)`), run once with the patched file and once with the base file restored:

```
                        patched                base
float64 pairwise sum    17.721422444055367     17.721422444055367
float64 scalar          0.8928282837109359     0.8928282837109359
```

**Surrounding suites:**

```
$ .venv/bin/python -m pytest aeon/distances/tests/ -p no:randomly -q
493 passed, 46 skipped, 1 warning in 4.48s

$ .venv/bin/python -m pytest aeon/clustering/tests/ -p no:randomly -q
306 passed, 91 skipped, 1 warning in 29.21s
```

**General estimator checks:**

```
KSpectralCentroid Counter({'PASSED': 21}) 21 checks
```

**Lint** (on the three touched files):

```
$ .venv/bin/ruff check <touched files>
All checks passed!
$ .venv/bin/ruff format --check <touched files>
3 files already formatted
$ git diff --check <base>
(no output)
```

### What was not verified

- **float32 numerical quality was not assessed, only compilability and agreement at one small case.** The new distance test uses a 3-point series. I did not check accumulation error on long series, where float32 drift could matter more than the 1.9e-08 seen here.
- **No dedicated float32 case for the multivariate pairwise entry point.** The clusterer test covers a univariate float32 collection end to end; I did not add a float32 multivariate pairwise test.
- **float16 and integer input remain broken** — see above. Confirmed pre-existing on the base commit, but not fixed and not covered by a test.
- **No clustering-quality comparison.** The `KSpectralCentroid` test asserts that `fit_predict` and `predict` agree and return the right shapes; it does not assert that float32 clustering matches float64 clustering, and I did not measure that.
- **Full `pre-commit` was not run.** `pre-commit`, `black`, `isort`, `pyupgrade` and `codespell` are not installed in this environment. Only `ruff check` and `ruff format --check` ran, on the touched files. Nothing was run on aeon's CI matrix.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors — not done; I would rather leave this to the `@all-contributors` bot after the PR is merged, if you want it at all.
- [x] The PR title starts with `[BUG]`.

##### For new estimators and functions
Not applicable — no new estimator or public function is added.

##### For developers with write access
Not applicable — I do not have write access.

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.
