### PR TITLE
[BUG] Fix reset() removing scikit-learn callback context attribute (#…

### DIFF
--- a/aeon/base/_base.py
+++ b/aeon/base/_base.py
@@ -87,6 +87,14 @@ class BaseAeonEstimator(BaseEstimator, ABC):
 
         _check_estimator_deps(self)
 
+    # Attributes that are not aeon hyperparameters or fitted state, but are
+    # temporarily attached to the estimator by *external* libraries (e.g.
+    # scikit-learn's callback context introduced in scikit-learn 1.9) while
+    # it is being fitted as part of a larger meta-estimator. These must
+    # survive ``reset()`` calls that happen during fitting, otherwise the
+    # external library fails when it later tries to clean up its own state.
+    _externally_owned_attrs = ("_parent_callback_ctx",)
+
     def reset(self, keep=None):
         """
         Reset the object to a clean post-init state.
@@ -99,6 +107,8 @@ class BaseAeonEstimator(BaseEstimator, ABC):
             removes any object attributes, except:
                 hyper-parameters (arguments of ``__init__``)
                 object attributes containing double-underscores, i.e., the string "__"
+                attributes temporarily owned by external libraries (e.g.
+                scikit-learn's callback context)
             runs ``__init__`` with current values of hyperparameters (result of
             ``get_params``)
 
@@ -106,6 +116,7 @@ class BaseAeonEstimator(BaseEstimator, ABC):
             object attributes containing double-underscores
             class and object methods, class attributes
             any attributes specified in the ``keep`` argument
+            attributes temporarily owned by external libraries
 
         Parameters
         ----------
@@ -131,6 +142,9 @@ class BaseAeonEstimator(BaseEstimator, ABC):
         attrs = [attr for attr in dir(self) if "__" not in attr]
         cls_attrs = [attr for attr in dir(type(self))]
         self_attrs = set(attrs).difference(cls_attrs)
+
+        # never remove attributes temporarily owned by external libraries
+        self_attrs.difference_update(self._externally_owned_attrs)
 
         # keep specific attributes if set
         if keep is not None:


### PR DESCRIPTION
### Fixes #3788

## Summary
The `BaseAeonEstimator.reset()` method removes all non-hyperparameter instance attributes during the fitting process. Starting from scikit-learn version 1.9, meta-estimators (such as `Pipeline` and `GridSearchCV`) temporarily attach a `_parent_callback_ctx` attribute to sub-estimators as part of the new callback system. However, since `reset()` deletes this attribute, scikit-learn raises an `AttributeError` when it attempts to clean it up later.

## Fix
We have added a `_externally_owned_attrs` allow-list to the `BaseAeonEstimator`, which excludes certain attributes from being removed during the `reset()` process. Currently, this allow-list contains only the `_parent_callback_ctx` attribute, but the mechanism is flexible enough to accommodate additional attributes in the future if other libraries attach similar transient states.

## Testing
- We reproduced the original crash while using scikit-learn 1.9 with `Tabularizer` in a `Pipeline` and confirmed that the fix resolves the issue.
- We verified that `reset()` still removes regular attributes and that the `keep=` option continues to function as expected.
- All tests in `aeon/base/tests/test_base.py` and `aeon/base/tests/test_compose.py` passed, achieving a score of 20/20.