### PR TITLE
[DOC] Use a shipped dataset in the SimHash index notebook

### DIFF
--- a/examples/similarity_search/simhash_index.ipynb
+++ b/examples/similarity_search/simhash_index.ipynb
@@ -420,21 +420,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "collection shape: (5000, 1, 140)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "random projections (hash_funcs_flat_): (520, 140)\n",
-      "boolean signatures: (5000, 520) bool\n",
-      "the 26 bits forming series 0's key in table 0: [0 1 1 0 0 1 0 1 0 1 0 0 1 0 1 1 0 0 1 1 0 1 1 0 0 0]\n"
+      "collection shape: (1096, 1, 24)\n",
+      "random projections (hash_funcs_flat_): (520, 24)\n",
+      "boolean signatures: (1096, 520) bool\n",
+      "the 26 bits forming series 0's key in table 0: [0 1 0 0 1 1 1 0 1 0 0 0 1 0 1 1 1 1 1 1 1 0 0 1 0 1]\n"
      ]
     }
    ],
    "source": [
-    "from aeon.datasets import load_classification\n",
+    "from aeon.datasets import load_italy_power_demand\n",
     "from aeon.similarity_search.whole_series import SimHashIndexANN\n",
     "from aeon.similarity_search.whole_series._simhash_index_ann import (\n",
     "    _collection_to_signature,\n",
@@ -444,8 +438,9 @@
     "from aeon.utils.numba.general import z_normalise_series_2d, z_normalise_series_3d\n",
     "\n",
     "# a larger, more diverse collection than arrow_head, so that the buckets are\n",
-    "# selective enough for a query to examine clearly fewer than all the series\n",
-    "X, _ = load_classification(\"ECG5000\")\n",
+    "# selective enough for a query to examine clearly fewer than all the series.\n",
+    "# ItalyPowerDemand ships with aeon, so the notebook needs no download.\n",
+    "X, _ = load_italy_power_demand()\n",
     "print(\"collection shape:\", X.shape)  # (n_cases, n_channels, n_timepoints)\n",
     "\n",
     "index = SimHashIndexANN(n_tables=20, n_bits_per_table=26, random_state=0)\n",
@@ -467,11 +462,17 @@
    "cell_type": "markdown",
    "id": "d579218f",
    "metadata": {},
-   "source": "### From bits to bucket keys\n\nEach table maps a series to *one* bucket, but a table's key is made of $k$ separate bits. We pack these $k$ booleans into a single integer in $[0, 2^k)$ by reading them as the binary digits of that integer : bit $j$ contributes $2^j$ when it is set. The `_signatures_to_keys` helper does this in a single vectorized pass over the $k$-bit axis (accumulating the bits with shifts), which replaces the slow per-series byte conversions that used to be a bottleneck of index construction.\n\nEach of the $L$ tables is then a Python dictionary mapping a bucket key to an **integer array** of the series indices that fall in it, and the fitted attribute `tables_` is the list of these $L$ dictionaries. aeon builds each table by stably sorting that table's keys and splitting the sorted case indices at the bucket boundaries (`np.argsort` + `np.split`), rather than inserting the series one at a time : the grouping stays a single C-level operation, and keeping each bucket as an int array lets a query tally its collisions in one vectorized pass (see the next section)."
+   "source": [
+    "### From bits to bucket keys\n",
+    "\n",
+    "Each table maps a series to *one* bucket, but a table's key is made of $k$ separate bits. We pack these $k$ booleans into a single integer in $[0, 2^k)$ by reading them as the binary digits of that integer : bit $j$ contributes $2^j$ when it is set. The `_signatures_to_keys` helper does this in a single vectorized pass over the $k$-bit axis (accumulating the bits with shifts), which replaces the slow per-series byte conversions that used to be a bottleneck of index construction.\n",
+    "\n",
+    "Each of the $L$ tables is then a Python dictionary mapping a bucket key to an **integer array** of the series indices that fall in it, and the fitted attribute `tables_` is the list of these $L$ dictionaries. aeon builds each table by stably sorting that table's keys and splitting the sorted case indices at the bucket boundaries (`np.argsort` + `np.split`), rather than inserting the series one at a time : the grouping stays a single C-level operation, and keeping each bucket as an int array lets a query tally its collisions in one vectorized pass (see the next section)."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6597c0ff",
    "metadata": {
     "execution": {
@@ -481,8 +482,35 @@
      "shell.execute_reply": "2026-07-01T10:48:52.302643Z"
     }
    },
-   "outputs": [],
-   "source": "keys = _signatures_to_keys(signatures, index.n_tables, index.n_bits_per_table)\nprint(\"bucket keys:\", keys.shape)  # (n_cases, n_tables): one integer key per table\nprint(\"series 0 keys in the first 5 tables:\", keys[0, :5])\n\n# tables_ maps each bucket key to the int array of series that fall in it\nkey_of_series0_table0 = int(keys[0, 0])\nbucket = index.tables_[0][key_of_series0_table0]\nprint(f\"\\ntable 0 holds {len(index.tables_[0])} distinct buckets\")\nprint(\n    f\"series 0 shares bucket {key_of_series0_table0} (table 0) \"\n    f\"with {len(bucket)} series (including series 0 itself)\"\n)\nprint(\"first members of that bucket:\", bucket[:12])"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bucket keys: (1096, 20)\n",
+      "series 0 keys in the first 5 tables: [44028274 21973729 39330448 16656344 19283319]\n",
+      "\n",
+      "table 0 holds 209 distinct buckets\n",
+      "series 0 shares bucket 44028274 (table 0) with 5 series (including series 0 itself)\n",
+      "first members of that bucket: [  0 368 638 659 810]\n"
+     ]
+    }
+   ],
+   "source": [
+    "keys = _signatures_to_keys(signatures, index.n_tables, index.n_bits_per_table)\n",
+    "print(\"bucket keys:\", keys.shape)  # (n_cases, n_tables): one integer key per table\n",
+    "print(\"series 0 keys in the first 5 tables:\", keys[0, :5])\n",
+    "\n",
+    "# tables_ maps each bucket key to the int array of series that fall in it\n",
+    "key_of_series0_table0 = int(keys[0, 0])\n",
+    "bucket = index.tables_[0][key_of_series0_table0]\n",
+    "print(f\"\\ntable 0 holds {len(index.tables_[0])} distinct buckets\")\n",
+    "print(\n",
+    "    f\"series 0 shares bucket {key_of_series0_table0} (table 0) \"\n",
+    "    f\"with {len(bucket)} series (including series 0 itself)\"\n",
+    ")\n",
+    "print(\"first members of that bucket:\", bucket[:12])"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -520,10 +548,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "candidates examined : 1046 out of 5000 series\n",
-      "exact neighbours       : [   0 2910 2007 1255   64]\n",
-      "approximate neighbours : [   0 2910   94  893 2007]\n",
-      "proxy distances (1 / collision count): [0.05   0.1429 0.2    0.2    0.2   ]\n"
+      "candidates examined : 180 out of 1096 series\n",
+      "exact neighbours       : [  0 400 572 405 659]\n",
+      "approximate neighbours : [  0 405 400 659 178]\n",
+      "proxy distances (1 / collision count): [0.05   0.1667 0.2    0.2    0.25  ]\n"
      ]
     }
    ],


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #3811. The notebook was added in #3717.

#### What does this implement/fix? Explain your changes.

`examples/similarity_search/simhash_index.ipynb` loaded ECG5000 through `load_classification`, i.e. a Zenodo download at run time, which is what made the notebook CI job fail when the Zenodo metadata request timed out.

The collection is now `load_italy_power_demand()` (1096 series, shipped with aeon), so the notebook needs no network. I checked the shipped datasets against what the walkthrough wants to show (a collection large and diverse enough that a query examines clearly fewer than all series), with the notebook's index parameters (`n_tables=20, n_bits_per_table=26, random_state=0`):

| dataset | series | buckets in table 0 | series 0's bucket | candidates examined | approx vs exact top-5 |
|---|---|---|---|---|---|
| ECG5000 (before) | 5000 | – | – | 1046 / 5000 | 3 of 5 shared |
| **ItalyPowerDemand** | 1096 | 209 | 5 | 180 / 1096 | 4 of 5 shared |
| OSULeaf | 442 | 431 | 1 | 1 / 442 | only the query itself |
| ACSF1 | 200 | 78 | 64 | 114 / 200 | 3 of 5 shared |
| GunPoint | 200 | 59 | 1 | 34 / 200 | 3 of 5 shared |
| ArrowHead | 211 | 43 | 75 | 152 / 211 | 3 of 5 shared |

ItalyPowerDemand keeps the narrative of every cell intact (selective buckets, a small shared bucket for series 0, a query that examines about a sixth of the collection). Only the code of that one cell changes; the outputs of the three data-dependent cells (the load/fit cell, the bucket-keys cell and the query cell) were re-executed, and the bucket-keys cell now has outputs where it had none. The other cells, including the plots, are untouched.

`nbqa black` / `nbqa isort` (the pre-commit hooks) pass on the notebook.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

`examples/similarity_search/code_speed.ipynb` also downloads ECG5000/Wafer/FordA, but it is already on the excluded list for the PR run, so I left it alone.
